### PR TITLE
Clarify --task flag requirements in CLI

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -50,8 +50,8 @@ struct Args {
     #[arg(long, default_value = ".")]
     path: Option<PathBuf>,
 
-    /// Task to perform on the codebase (required unless --continue or --ui is used)
-    #[arg(short, long, required_unless_present_any = ["continue_task", "ui"])]
+    /// Task to perform on the codebase (required for agent mode only)
+    #[arg(short, long)]
     task: Option<String>,
 
     /// Start with GUI interface
@@ -250,8 +250,9 @@ async fn main() -> Result<()> {
                 );
             }
 
+            // In agent mode, --task is required unless using --continue or --ui
             if !continue_task && task.is_none() && !use_gui {
-                anyhow::bail!("Either --task, --continue, or --ui must be specified");
+                anyhow::bail!("In agent mode, either --task, --continue, or --ui must be specified");
             }
 
             // Check if GUI mode is requested


### PR DESCRIPTION
When running the server subcommand, it incorrectly requires the --task argument, which should only be required for the agent mode (default mode). Additionally, the --verbose flag defined for the server subcommand appears to be ignored. (I'm not familiar with Rust, so I'm not sure if this is the correct fix. :)

```rust
$ cargo run -- server
   Compiling code-assistant v0.1.2 
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 6.41s
     Running `target/debug/code-assistant server`
error: the following required arguments were not provided:
  --task <TASK>

Usage: code-assistant --task <TASK>

For more information, try '--help'.
```