### PR TITLE
Normalize files

### DIFF
--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -380,7 +380,7 @@ impl CodeExplorer for MockExplorer {
             .ok_or_else(|| anyhow::anyhow!("File not found: {}", path.display()))?
             .clone();
 
-        let updated_content = crate::utils::apply_replacements(&content, replacements)?;
+        let updated_content = crate::utils::apply_replacements_normalized(&content, replacements)?;
 
         // Update the stored content
         files.insert(path.to_path_buf(), updated_content.clone());

--- a/src/types.rs
+++ b/src/types.rs
@@ -45,6 +45,34 @@ impl Default for FileEncoding {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum LineEnding {
+    LF,   // Unix: \n
+    CRLF, // Windows: \r\n
+    CR,   // Legacy Mac: \r
+}
+
+impl Default for LineEnding {
+    fn default() -> Self {
+        Self::LF
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileFormat {
+    pub encoding: FileEncoding,
+    pub line_ending: LineEnding,
+}
+
+impl Default for FileFormat {
+    fn default() -> Self {
+        Self {
+            encoding: FileEncoding::UTF8,
+            line_ending: LineEnding::LF,
+        }
+    }
+}
+
 /// Represents the agent's working memory during execution
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]
 pub struct WorkingMemory {
@@ -215,9 +243,7 @@ pub enum Tool {
     },
     /// Read content of one or multiple files into working memory
     /// Supports line range syntax in paths like 'file.txt:10-20' to read lines 10-20
-    ReadFiles { 
-        paths: Vec<PathBuf> 
-    },
+    ReadFiles { paths: Vec<PathBuf> },
     /// Write content to a file
     WriteFile {
         path: PathBuf,
@@ -424,7 +450,12 @@ pub trait CodeExplorer: Send + Sync {
     /// Reads the content of a file
     fn read_file(&self, path: &PathBuf) -> Result<String>;
     /// Reads the content of a file between specific line numbers
-    fn read_file_range(&self, path: &PathBuf, start_line: Option<usize>, end_line: Option<usize>) -> Result<String>;
+    fn read_file_range(
+        &self,
+        path: &PathBuf,
+        start_line: Option<usize>,
+        end_line: Option<usize>,
+    ) -> Result<String>;
     /// Write the content of a file
     fn write_file(&self, path: &PathBuf, content: &String, append: bool) -> Result<()>;
     fn delete_file(&self, path: &PathBuf) -> Result<()>;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -5,4 +5,4 @@ pub mod encoding;
 
 #[allow(unused_imports)]
 pub use command::{CommandExecutor, CommandOutput, DefaultCommandExecutor};
-pub use file_updater::{apply_replacements, FileUpdaterError};
+pub use file_updater::{apply_replacements_normalized, FileUpdaterError};


### PR DESCRIPTION
- Store the line ending per resource
- Read files with consistent line endings and trailing whitespace removed
- Make search/replace block parsing robust against an additional separator at the end of the replace block