### PR TITLE
Fix panic in is_potential_tag_start due to UTF-8 slicing

### DIFF
--- a/src/ui/streaming.rs
+++ b/src/ui/streaming.rs
@@ -475,10 +475,12 @@ impl StreamProcessor {
 
         // Check if the text could be the start of any tag
         for prefix in &TAG_PREFIXES {
-            // Loop through all possible partial matches
-            for i in 1..=prefix.len().min(text.len()) {
-                // Check if the end of text matches the beginning of a tag prefix
-                if &text[text.len() - i..] == &prefix[..i] {
+            let text_chars: Vec<char> = text.chars().collect(); // Convert text to Vec<char>
+            let prefix_chars: Vec<char> = prefix.chars().collect(); // Convert prefix to Vec<char>
+                                                                    // Loop through all possible partial matches
+            for i in 1..=prefix_chars.len().min(text_chars.len()) {
+                // Check if the last `i` characters of text match the first `i` characters of prefix
+                if text_chars[text_chars.len() - i..] == prefix_chars[..i] {
                     return true;
                 }
             }


### PR DESCRIPTION
### Description
Fixes a panic in `is_potential_tag_start` caused by slicing at invalid UTF-8 boundaries (e.g., multi-byte chars like '─').
![CleanShot 2025-04-04 at 14 27 59@2x](https://github.com/user-attachments/assets/5d1f33ab-dd2a-4e5d-b61d-006ac813d352)

### Changes
- Switched from byte-based slicing to `.chars()`-based comparison for UTF-8 safety.

### Related Issues
- Resolves crash at `src/ui/streaming.rs:481` (byte index 30 not a char boundary).

