### PR TITLE
Smarter tool limit enforcement

### DIFF
--- a/crates/code_assistant/src/agent/runner.rs
+++ b/crates/code_assistant/src/agent/runner.rs
@@ -448,10 +448,20 @@ impl Agent {
                 let error_text = Self::format_error_for_user(&e);
 
                 let error_msg = match self.tool_syntax {
-                    ToolSyntax::Xml => {
-                        // For XML mode, create structured tool-result message like regular tool results
+                    ToolSyntax::Native => {
+                        // For native mode, keep text message since parsing errors occur before
+                        // we have any LLM-provided tool IDs to reference
+                        Message {
+                            role: MessageRole::User,
+                            content: MessageContent::Text(error_text),
+                            request_id: None,
+                            usage: None,
+                        }
+                    }
+                    _ => {
+                        // For custom tool-syntax modes, create structured tool-result message like regular tool results
                         // Generate normal tool ID for consistency with UI expectations
-                        let tool_id = format!("tool-{}-0", request_counter);
+                        let tool_id = format!("tool-{}-1", request_counter);
 
                         // Create and store a ToolExecution for the parse error
                         let tool_execution =
@@ -465,25 +475,6 @@ impl Agent {
                                 content: error_text,
                                 is_error: Some(true),
                             }]),
-                            request_id: None,
-                            usage: None,
-                        }
-                    }
-                    ToolSyntax::Native => {
-                        // For native mode, keep text message since parsing errors occur before
-                        // we have any LLM-provided tool IDs to reference
-                        Message {
-                            role: MessageRole::User,
-                            content: MessageContent::Text(error_text),
-                            request_id: None,
-                            usage: None,
-                        }
-                    }
-                    ToolSyntax::Caret => {
-                        // For caret mode, use text message like native mode
-                        Message {
-                            role: MessageRole::User,
-                            content: MessageContent::Text(error_text),
                             request_id: None,
                             usage: None,
                         }

--- a/crates/code_assistant/src/main.rs
+++ b/crates/code_assistant/src/main.rs
@@ -91,8 +91,8 @@ struct Args {
     #[arg(long, default_value = "8192")]
     num_ctx: Option<usize>,
 
-    /// Tool invocation syntax ('native' = tools via API, 'xml' = custom system message)
-    #[arg(long, default_value = "xml")]
+    /// Tool invocation syntax ('native' = tools via API, 'xml' and 'caret' = custom system message)
+    #[arg(long, default_value = "native")]
     tool_syntax: Option<ToolSyntax>,
 
     /// Record API responses to a file (only supported for Anthropic provider currently)
@@ -601,7 +601,7 @@ async fn run_agent(args: Args) -> Result<()> {
     let base_url = args.base_url.clone();
     let aicore_config = args.aicore_config.clone();
     let num_ctx = args.num_ctx.unwrap_or(8192);
-    let tool_syntax = args.tool_syntax.unwrap_or(ToolSyntax::Xml);
+    let tool_syntax = args.tool_syntax.unwrap_or(ToolSyntax::Native);
     let use_gui = args.ui;
 
     // Setup logging based on verbose flag

--- a/crates/code_assistant/src/tools/mod.rs
+++ b/crates/code_assistant/src/tools/mod.rs
@@ -8,6 +8,9 @@ pub mod parser_registry;
 // System message generation
 pub mod system_message;
 
+// Tool use filtering system
+pub mod tool_use_filter;
+
 // New trait-based tools implementation
 pub mod core;
 pub mod impls;
@@ -15,7 +18,11 @@ pub mod impls;
 #[cfg(test)]
 mod tests;
 
-pub use parse::{parse_caret_tool_invocations, parse_xml_tool_invocations};
+pub use parse::{
+    parse_caret_tool_invocations, parse_caret_tool_invocations_with_filter,
+    parse_caret_tool_invocations_with_truncation, parse_xml_tool_invocations,
+    parse_xml_tool_invocations_with_filter, parse_xml_tool_invocations_with_truncation,
+};
 pub use parser_registry::ParserRegistry;
 pub use system_message::generate_system_message;
 pub use types::{AnnotatedToolDefinition, ParseError, ToolRequest};

--- a/crates/code_assistant/src/tools/mod.rs
+++ b/crates/code_assistant/src/tools/mod.rs
@@ -18,11 +18,7 @@ pub mod impls;
 #[cfg(test)]
 mod tests;
 
-pub use parse::{
-    parse_caret_tool_invocations, parse_caret_tool_invocations_with_filter,
-    parse_caret_tool_invocations_with_truncation, parse_xml_tool_invocations,
-    parse_xml_tool_invocations_with_filter, parse_xml_tool_invocations_with_truncation,
-};
+pub use parse::{parse_caret_tool_invocations, parse_xml_tool_invocations};
 pub use parser_registry::ParserRegistry;
 pub use system_message::generate_system_message;
 pub use types::{AnnotatedToolDefinition, ParseError, ToolRequest};

--- a/crates/code_assistant/src/tools/parse.rs
+++ b/crates/code_assistant/src/tools/parse.rs
@@ -109,16 +109,8 @@ pub fn parse_caret_tool_invocations(
     text: &str,
     request_id: u64,
     _start_tool_count: usize,
-) -> Result<Vec<ToolRequest>> {
-    parse_caret_tool_invocations_with_filter(text, request_id, _start_tool_count, None)
-}
-
-pub fn parse_caret_tool_invocations_with_filter(
-    text: &str,
-    request_id: u64,
-    _start_tool_count: usize,
     filter: Option<&dyn ToolUseFilter>,
-) -> Result<Vec<ToolRequest>> {
+) -> Result<(Vec<ToolRequest>, String)> {
     let mut tool_requests = Vec::new();
     let tool_regex = regex::Regex::new(r"(?m)^\^\^\^([a-zA-Z0-9_]+)$").unwrap();
     let multiline_start_regex = regex::Regex::new(r"(?m)^([a-zA-Z0-9_]+)\s+---\s*$").unwrap();
@@ -126,6 +118,7 @@ pub fn parse_caret_tool_invocations_with_filter(
     let tool_end_regex = regex::Regex::new(r"(?m)^\^\^\^$").unwrap();
 
     let mut remaining_text = text;
+    let mut truncation_pos = text.len(); // Default to end of text
 
     while let Some(tool_match) = tool_regex.find(remaining_text) {
         // Extract tool name
@@ -134,6 +127,17 @@ pub fn parse_caret_tool_invocations_with_filter(
             .and_then(|caps| caps.get(1))
             .map(|m| m.as_str())
             .ok_or_else(|| ToolError::ParseError("Failed to extract tool name".to_string()))?;
+
+        // Check filter before processing this tool
+        let tool_index = tool_requests.len() + 1;
+        if let Some(filter) = filter {
+            if !filter.allow_tool_at_position(tool_name, tool_index) {
+                // Tool not allowed, truncate before this tool
+                let absolute_tool_start = text.len() - remaining_text.len() + tool_match.start();
+                truncation_pos = absolute_tool_start;
+                break;
+            }
+        }
 
         // Check if the tool exists in the registry
         if ToolRegistry::global().get(tool_name).is_none() {
@@ -144,15 +148,15 @@ pub fn parse_caret_tool_invocations_with_filter(
         let tool_start = tool_match.end();
         let remaining_after_tool = &remaining_text[tool_start..];
 
-        let tool_content = if let Some(end_match) = tool_end_regex.find(remaining_after_tool) {
-            let content = &remaining_after_tool[..end_match.start()];
-            remaining_text = &remaining_after_tool[end_match.end()..];
-            content
-        } else {
-            // No end found, treat rest as tool content
-            remaining_text = "";
-            remaining_after_tool
-        };
+        let (tool_content, tool_end_pos) =
+            if let Some(end_match) = tool_end_regex.find(remaining_after_tool) {
+                let content = &remaining_after_tool[..end_match.start()];
+                let end_pos = tool_start + end_match.end();
+                (content, Some(end_pos))
+            } else {
+                // No end found, treat rest as tool content
+                (remaining_after_tool, None)
+            };
 
         // Parse parameters from tool content (returns raw HashMap)
         let raw_params = parse_caret_tool_parameters_raw(
@@ -177,17 +181,7 @@ pub fn parse_caret_tool_invocations_with_filter(
             convert_raw_params_to_json_fallback(&raw_params)
         };
 
-        // Check filter before adding this tool
-        let tool_index = tool_requests.len() + 1;
-        if let Some(filter) = filter {
-            if !filter.allow_tool_at_position(tool_name, tool_index) {
-                // Tool not allowed at this position, stop parsing here
-                break;
-            }
-        }
-
         // Generate a unique tool ID: tool-<request_id>-<tool_index_in_request>
-        // First tool in the request gets index 1, second gets index 2, etc.
         let tool_id = format!("tool-{}-{}", request_id, tool_index);
 
         // Create a ToolRequest
@@ -199,297 +193,28 @@ pub fn parse_caret_tool_invocations_with_filter(
 
         tool_requests.push(tool_request);
 
-        // Check if we should allow content after this tool
-        if let Some(filter) = filter {
-            if !filter.allow_content_after_tool(tool_name, tool_index) {
-                // No content allowed after this tool, stop parsing here
-                break;
-            }
-        }
-    }
+        // Update remaining text for next iteration
+        if let Some(end_pos) = tool_end_pos {
+            remaining_text = &remaining_text[end_pos..];
 
-    Ok(tool_requests)
-}
-
-pub fn parse_xml_tool_invocations(
-    text: &str,
-    request_id: u64,
-    _start_tool_count: usize,
-) -> Result<Vec<ToolRequest>> {
-    parse_xml_tool_invocations_with_filter(text, request_id, _start_tool_count, None)
-}
-
-pub fn parse_xml_tool_invocations_with_filter(
-    text: &str,
-    request_id: u64,
-    _start_tool_count: usize,
-    filter: Option<&dyn ToolUseFilter>,
-) -> Result<Vec<ToolRequest>> {
-    let mut tool_requests = Vec::new();
-    let mut state = ParseState::SearchingForTool;
-    let mut current_pos = 0;
-
-    while current_pos < text.len() {
-        // Find next '<' character
-        if let Some(tag_start) = text[current_pos..].find('<') {
-            let abs_tag_start = current_pos + tag_start;
-
-            // Extract tag content until '>'
-            if let Some(tag_end) = text[abs_tag_start..].find('>') {
-                let abs_tag_end = abs_tag_start + tag_end;
-                let tag_content = &text[abs_tag_start + 1..abs_tag_end]; // Skip '<' and '>'
-
-                debug!("Found tag: <{}>", tag_content);
-
-                // Check if this is a tool tag
-                if let Some(tool_name) = tag_content.strip_prefix(TOOL_TAG_PREFIX) {
-                    match &state {
-                        ParseState::SearchingForTool => {
-                            // Check filter before starting this tool
-                            let tool_index = tool_requests.len() + 1;
-                            if let Some(filter) = filter {
-                                if !filter.allow_tool_at_position(tool_name, tool_index) {
-                                    // Tool not allowed at this position, stop parsing here
-                                    break;
-                                }
-                            }
-
-                            // Start of a new tool invocation
-                            state = ParseState::InTool {
-                                tool_name: tool_name.to_string(),
-                                start_pos: abs_tag_start,
-                            };
-                            current_pos = abs_tag_end + 1;
-                            continue;
-                        }
-                        ParseState::InTool {
-                            tool_name: current_tool,
-                            ..
-                        }
-                        | ParseState::InParam {
-                            tool_name: current_tool,
-                            ..
-                        } => {
-                            // Found another tool start while already in a tool - this is an error
-                            return Err(ToolError::ParseError(format!(
-                                "Malformed tool invocation: found nested tool invocation. Started '{}' but found start of '{}' before closing the first one",
-                                current_tool, tool_name
-                            )).into());
-                        }
-                    }
+            // Check if we should allow content after this tool
+            if let Some(filter) = filter {
+                if !filter.allow_content_after_tool(tool_name, tool_index) {
+                    // No content allowed after this tool, truncate here
+                    let absolute_end_pos = text.len() - remaining_text.len();
+                    truncation_pos = absolute_end_pos;
+                    break;
                 }
-                // Check if this is a tool closing tag
-                else if let Some(tool_name) =
-                    tag_content.strip_prefix(&format!("/{}", TOOL_TAG_PREFIX))
-                {
-                    match &state {
-                        ParseState::SearchingForTool => {
-                            // Found closing tag without opening tag
-                            return Err(ToolError::ParseError(format!(
-                                "Malformed tool invocation: found closing tag '</tool:{}>' without corresponding opening tag",
-                                tool_name
-                            )).into());
-                        }
-                        ParseState::InTool {
-                            tool_name: current_tool,
-                            start_pos,
-                        } => {
-                            if tool_name != current_tool {
-                                // Mismatched closing tag
-                                return Err(ToolError::ParseError(format!(
-                                    "Malformed tool invocation: mismatching tool names in start and end tag. Expected '</tool:{}>' but found '</tool:{}>'",
-                                    current_tool, tool_name
-                                )).into());
-                            }
-
-                            // Extract the complete tool XML
-                            let tool_content = &text[*start_pos..abs_tag_end + 1];
-                            debug!("Found complete tool content:\n{}", tool_content);
-
-                            // Parse the tool XML to get tool name and parameters
-                            let (parsed_tool_name, tool_params) = parse_tool_xml(tool_content)?;
-
-                            // Check if the tool exists in the registry
-                            if ToolRegistry::global().get(&parsed_tool_name).is_none() {
-                                return Err(ToolError::UnknownTool(parsed_tool_name).into());
-                            }
-
-                            // Check filter before adding this tool
-                            let tool_index = tool_requests.len() + 1;
-                            if let Some(filter) = filter {
-                                if !filter.allow_tool_at_position(&parsed_tool_name, tool_index) {
-                                    // Tool not allowed at this position, stop parsing here
-                                    // Reset state and break out of parsing
-                                    state = ParseState::SearchingForTool;
-                                    break;
-                                }
-                            }
-
-                            // Generate a unique tool ID: tool-<request_id>-<tool_index_in_request>
-                            // First tool in the request gets index 1, second gets index 2, etc.
-                            let tool_id = format!("tool-{}-{}", request_id, tool_index);
-
-                            // Create a ToolRequest
-                            let tool_request = ToolRequest {
-                                id: tool_id,
-                                name: parsed_tool_name.clone(),
-                                input: tool_params,
-                            };
-
-                            tool_requests.push(tool_request);
-
-                            // Check if we should allow content after this tool
-                            if let Some(filter) = filter {
-                                if !filter.allow_content_after_tool(&parsed_tool_name, tool_index) {
-                                    // No content allowed after this tool, stop parsing here
-                                    state = ParseState::SearchingForTool;
-                                    break;
-                                }
-                            }
-
-                            // Reset state
-                            state = ParseState::SearchingForTool;
-                            current_pos = abs_tag_end + 1;
-                            continue;
-                        }
-                        ParseState::InParam {
-                            param_name: current_param,
-                            ..
-                        } => {
-                            // We're still inside a parameter when trying to close the tool - this is an error
-                            return Err(ToolError::ParseError(format!(
-                                "Malformed tool invocation: unclosed parameter '{}' in tool '{}' - missing closing tag '</param:{}>'",
-                                current_param, tool_name, current_param
-                            )).into());
-                        }
-                    }
-                }
-                // Check if this is a parameter tag
-                else if let Some(param_name) = tag_content.strip_prefix(PARAM_TAG_PREFIX) {
-                    match &state {
-                        ParseState::SearchingForTool => {
-                            // Parameter tag outside of tool - ignore it
-                            current_pos = abs_tag_end + 1;
-                            continue;
-                        }
-                        ParseState::InTool {
-                            tool_name,
-                            start_pos,
-                        } => {
-                            // Start of parameter
-                            state = ParseState::InParam {
-                                tool_name: tool_name.clone(),
-                                param_name: param_name.to_string(),
-                                start_pos: *start_pos,
-                            };
-                            current_pos = abs_tag_end + 1;
-                            continue;
-                        }
-                        ParseState::InParam {
-                            tool_name,
-                            param_name: current_param,
-                            ..
-                        } => {
-                            // Found another parameter start while already in a parameter - this is an error
-                            return Err(ToolError::ParseError(format!(
-                                "Malformed tool invocation: found nested parameter. Started parameter '{}' in tool '{}' but found start of parameter '{}' before closing the first one",
-                                current_param, tool_name, param_name
-                            )).into());
-                        }
-                    }
-                }
-                // Check if this is a parameter closing tag
-                else if let Some(param_name) =
-                    tag_content.strip_prefix(&format!("/{}", PARAM_TAG_PREFIX))
-                {
-                    match &state {
-                        ParseState::SearchingForTool | ParseState::InTool { .. } => {
-                            // Parameter closing tag outside of parameter - ignore it
-                            current_pos = abs_tag_end + 1;
-                            continue;
-                        }
-                        ParseState::InParam {
-                            tool_name,
-                            param_name: current_param,
-                            start_pos,
-                            ..
-                        } => {
-                            if param_name != current_param {
-                                // Mismatched parameter closing tag
-                                return Err(ToolError::ParseError(format!(
-                                    "Malformed tool invocation: mismatching parameter names in start and end tag. Expected '</param:{}>' but found '</param:{}>' in tool '{}'",
-                                    current_param, param_name, tool_name
-                                )).into());
-                            }
-
-                            // End of parameter - go back to InTool state
-                            state = ParseState::InTool {
-                                tool_name: tool_name.clone(),
-                                start_pos: *start_pos,
-                            };
-                            current_pos = abs_tag_end + 1;
-                            continue;
-                        }
-                    }
-                }
-                // Any other tag - check if we're inside a tool (but not inside a parameter)
-                else {
-                    match &state {
-                        ParseState::InTool { tool_name, .. } => {
-                            // Found non-tool/non-param tag inside a tool (but outside parameters) - this is an error
-                            return Err(ToolError::ParseError(format!(
-                                "Malformed tool invocation: found unexpected tag '<{}>' inside tool '{}'. Only parameter tags are allowed inside tool blocks",
-                                tag_content, tool_name
-                            )).into());
-                        }
-                        ParseState::InParam { .. } => {
-                            // Inside a parameter - tags are allowed as part of parameter content
-                            current_pos = abs_tag_end + 1;
-                            continue;
-                        }
-                        ParseState::SearchingForTool => {
-                            // Outside of tools - ignore other tags
-                            current_pos = abs_tag_end + 1;
-                            continue;
-                        }
-                    }
-                }
-            } else {
-                // Found '<' but no matching '>' - skip this character
-                current_pos = abs_tag_start + 1;
-                continue;
             }
         } else {
-            // No more '<' characters
+            // No tool end found, stop processing
             break;
         }
     }
 
-    // Check if we ended in an incomplete state
-    match state {
-        ParseState::SearchingForTool => {
-            // This is fine
-        }
-        ParseState::InTool { tool_name, .. } => {
-            return Err(ToolError::ParseError(format!(
-                "Malformed tool invocation: unclosed tool '{}' - missing closing tag '</tool:{}>'",
-                tool_name, tool_name
-            ))
-            .into());
-        }
-        ParseState::InParam {
-            tool_name,
-            param_name,
-            ..
-        } => {
-            return Err(ToolError::ParseError(format!(
-                "Malformed tool invocation: unclosed parameter '{}' in tool '{}' - missing closing tag '</param:{}>'",
-                param_name, tool_name, param_name
-            )).into());
-        }
-    }
-
-    Ok(tool_requests)
+    // Return the parsed tools and truncated text
+    let truncated_text = &text[..truncation_pos];
+    Ok((tool_requests, truncated_text.to_string()))
 }
 
 fn parse_caret_tool_parameters_raw(
@@ -977,126 +702,10 @@ pub fn convert_xml_params_to_json(
     Ok(result)
 }
 
-/// Parse caret tool invocations with truncation support
-/// Returns both the parsed tool requests and the truncated text
-pub fn parse_caret_tool_invocations_with_truncation(
+pub fn parse_xml_tool_invocations(
     text: &str,
     request_id: u64,
-    start_tool_count: usize,
-    filter: Option<&dyn ToolUseFilter>,
-) -> Result<(Vec<ToolRequest>, String)> {
-    let mut tool_requests = Vec::new();
-    let tool_regex = regex::Regex::new(r"(?m)^\^\^\^([a-zA-Z0-9_]+)$").unwrap();
-    let multiline_start_regex = regex::Regex::new(r"(?m)^([a-zA-Z0-9_]+)\s+---\s*$").unwrap();
-    let multiline_end_regex = regex::Regex::new(r"(?m)^---\s+([a-zA-Z0-9_]+)\s*$").unwrap();
-    let tool_end_regex = regex::Regex::new(r"(?m)^\^\^\^$").unwrap();
-
-    let mut remaining_text = text;
-    let mut truncation_pos = text.len(); // Default to end of text
-
-    while let Some(tool_match) = tool_regex.find(remaining_text) {
-        // Extract tool name
-        let tool_name = tool_regex
-            .captures(&remaining_text[tool_match.start()..])
-            .and_then(|caps| caps.get(1))
-            .map(|m| m.as_str())
-            .ok_or_else(|| ToolError::ParseError("Failed to extract tool name".to_string()))?;
-
-        // Check filter before processing this tool
-        let tool_index = tool_requests.len() + 1;
-        if let Some(filter) = filter {
-            if !filter.allow_tool_at_position(tool_name, tool_index) {
-                // Tool not allowed, truncate before this tool
-                let absolute_tool_start = text.len() - remaining_text.len() + tool_match.start();
-                truncation_pos = absolute_tool_start;
-                break;
-            }
-        }
-
-        // Check if the tool exists in the registry
-        if ToolRegistry::global().get(tool_name).is_none() {
-            return Err(ToolError::UnknownTool(tool_name.to_string()).into());
-        }
-
-        // Find the end of this tool block
-        let tool_start = tool_match.end();
-        let remaining_after_tool = &remaining_text[tool_start..];
-
-        let (tool_content, tool_end_pos) = if let Some(end_match) = tool_end_regex.find(remaining_after_tool) {
-            let content = &remaining_after_tool[..end_match.start()];
-            let end_pos = tool_start + end_match.end();
-            (content, Some(end_pos))
-        } else {
-            // No end found, treat rest as tool content
-            (remaining_after_tool, None)
-        };
-
-        // Parse parameters from tool content (returns raw HashMap)
-        let raw_params = parse_caret_tool_parameters_raw(
-            tool_content,
-            &multiline_start_regex,
-            &multiline_end_regex,
-        )?;
-
-        // Convert parameters to JSON using schema-based approach if tool exists, otherwise use fallback
-        let tool_params = if ToolRegistry::global().get(tool_name).is_some() {
-            // Use schema-based conversion for registered tools
-            convert_xml_params_to_json(tool_name, &raw_params, &ToolRegistry::global()).map_err(
-                |e| {
-                    ToolError::ParseError(format!(
-                        "Error converting caret parameters to JSON: {}",
-                        e
-                    ))
-                },
-            )?
-        } else {
-            // Fallback to legacy conversion for unregistered tools (mainly for tests)
-            convert_raw_params_to_json_fallback(&raw_params)
-        };
-
-        // Generate a unique tool ID: tool-<request_id>-<tool_index_in_request>
-        let tool_id = format!("tool-{}-{}", request_id, tool_index);
-
-        // Create a ToolRequest
-        let tool_request = ToolRequest {
-            id: tool_id,
-            name: tool_name.to_string(),
-            input: tool_params,
-        };
-
-        tool_requests.push(tool_request);
-
-        // Update remaining text for next iteration
-        if let Some(end_pos) = tool_end_pos {
-            remaining_text = &remaining_text[end_pos..];
-
-            // Check if we should allow content after this tool
-            if let Some(filter) = filter {
-                if !filter.allow_content_after_tool(tool_name, tool_index) {
-                    // No content allowed after this tool, truncate here
-                    let absolute_end_pos = text.len() - remaining_text.len();
-                    truncation_pos = absolute_end_pos;
-                    break;
-                }
-            }
-        } else {
-            // No tool end found, process remaining text
-            remaining_text = "";
-            break;
-        }
-    }
-
-    // Return the parsed tools and truncated text
-    let truncated_text = &text[..truncation_pos];
-    Ok((tool_requests, truncated_text.to_string()))
-}
-
-/// Parse XML tool invocations with truncation support
-/// Returns both the parsed tool requests and the truncated text
-pub fn parse_xml_tool_invocations_with_truncation(
-    text: &str,
-    request_id: u64,
-    start_tool_count: usize,
+    _start_tool_count: usize,
     filter: Option<&dyn ToolUseFilter>,
 ) -> Result<(Vec<ToolRequest>, String)> {
     let mut tool_requests = Vec::new();
@@ -1260,8 +869,7 @@ pub fn parse_xml_tool_invocations_with_truncation(
                             )).into());
                         }
                     }
-                }
-                else if let Some(param_name) =
+                } else if let Some(param_name) =
                     tag_content.strip_prefix(&format!("/{}", PARAM_TAG_PREFIX))
                 {
                     match &state {
@@ -1290,8 +898,7 @@ pub fn parse_xml_tool_invocations_with_truncation(
                             continue;
                         }
                     }
-                }
-                else {
+                } else {
                     match &state {
                         ParseState::InTool { tool_name, .. } => {
                             return Err(ToolError::ParseError(format!(
@@ -1807,7 +1414,7 @@ mod tests {
     async fn test_parse_caret_tool_invocations_simple() {
         let text = concat!("^^^list_projects\n", "^^^");
 
-        let result = parse_caret_tool_invocations(text, 123, 0).unwrap();
+        let (result, _) = parse_caret_tool_invocations(text, 123, 0, None).unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].name, "list_projects");
     }
@@ -1825,7 +1432,7 @@ mod tests {
             "^^^"
         );
 
-        let result = parse_caret_tool_invocations(text, 123, 0).unwrap();
+        let (result, _) = parse_caret_tool_invocations(text, 123, 0, None).unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].name, "write_file");
         assert_eq!(result[0].input["project"], "test");
@@ -1853,7 +1460,7 @@ mod tests {
             "^^^"
         );
 
-        let result = parse_caret_tool_invocations(text, 123, 0).unwrap();
+        let (result, _) = parse_caret_tool_invocations(text, 123, 0, None).unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].name, "read_files");
         assert_eq!(result[0].input["project"], "test");
@@ -1880,7 +1487,7 @@ mod tests {
             "^^^"
         );
 
-        let result = parse_caret_tool_invocations(text, 123, 0).unwrap();
+        let (result, _) = parse_caret_tool_invocations(text, 123, 0, None).unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].name, "replace_in_file");
         assert_eq!(result[0].input["project"], "test");
@@ -1892,7 +1499,7 @@ mod tests {
     async fn test_parse_caret_tool_invocations_with_text_before() {
         let text = concat!("I'll help you with that.\n\n", "^^^list_projects\n", "^^^");
 
-        let result = parse_caret_tool_invocations(text, 123, 0).unwrap();
+        let (result, _) = parse_caret_tool_invocations(text, 123, 0, None).unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].name, "list_projects");
     }
@@ -1901,7 +1508,7 @@ mod tests {
     async fn test_parse_caret_tool_invocations_no_tools() {
         let text = "This is just plain text with no tools.";
 
-        let result = parse_caret_tool_invocations(text, 123, 0).unwrap();
+        let (result, _) = parse_caret_tool_invocations(text, 123, 0, None).unwrap();
         assert_eq!(result.len(), 0);
     }
 
@@ -1909,7 +1516,7 @@ mod tests {
     async fn test_parse_caret_tool_invocations_unknown_tool() {
         let text = concat!("^^^unknown_tool\n", "param: value\n", "^^^");
 
-        let result = parse_caret_tool_invocations(text, 123, 0);
+        let result = parse_caret_tool_invocations(text, 123, 0, None);
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
@@ -1948,7 +1555,7 @@ mod tests {
             "^^^"
         );
 
-        let result = parse_caret_tool_invocations(text_single, 123, 0).unwrap();
+        let (result, _) = parse_caret_tool_invocations(text_single, 123, 0, None).unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].name, "write_file");
         assert_eq!(result[0].input["project"], "test");
@@ -1968,7 +1575,7 @@ mod tests {
             "^^^"
         );
 
-        let result = parse_caret_tool_invocations(text_array, 123, 0).unwrap();
+        let (result, _) = parse_caret_tool_invocations(text_array, 123, 0, None).unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].name, "read_files");
         assert_eq!(result[0].input["project"], "test");
@@ -1992,7 +1599,7 @@ mod tests {
             "^^^"
         );
 
-        let result = parse_caret_tool_invocations(text_empty, 123, 0).unwrap();
+        let (result, _) = parse_caret_tool_invocations(text_empty, 123, 0, None).unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].name, "read_files");
 
@@ -2013,7 +1620,7 @@ mod tests {
             "^^^"
         );
 
-        let result = parse_caret_tool_invocations(text_mixed, 123, 0).unwrap();
+        let (result, _) = parse_caret_tool_invocations(text_mixed, 123, 0, None).unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].name, "read_files");
 
@@ -2038,7 +1645,7 @@ mod tests {
             "^^^"
         );
 
-        let result = parse_caret_tool_invocations(text, 123, 0).unwrap();
+        let (result, _) = parse_caret_tool_invocations(text, 123, 0, None).unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].name, "list_files");
 
@@ -2070,7 +1677,7 @@ mod tests {
             "^^^"
         );
 
-        let result = parse_caret_tool_invocations(text, 123, 0).unwrap();
+        let (result, _) = parse_caret_tool_invocations(text, 123, 0, None).unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].name, "list_files");
 
@@ -2103,7 +1710,8 @@ mod tests {
         let request_id = 456;
         let start_tool_count = 0; // Not used in new format
 
-        let result = parse_caret_tool_invocations(text, request_id, start_tool_count).unwrap();
+        let (result, _) =
+            parse_caret_tool_invocations(text, request_id, start_tool_count, None).unwrap();
         assert_eq!(result.len(), 1);
 
         // Tool ID should follow the format: "tool-<request_id>-<tool_index_in_request>"
@@ -2132,7 +1740,7 @@ mod tests {
         );
 
         let request_id = 789;
-        let result = parse_caret_tool_invocations(text, request_id, 0).unwrap();
+        let (result, _) = parse_caret_tool_invocations(text, request_id, 0, None).unwrap();
         assert_eq!(result.len(), 3);
 
         // First tool should get index 1
@@ -2147,6 +1755,4 @@ mod tests {
         assert_eq!(result[2].id, "tool-789-3");
         assert_eq!(result[2].name, "write_file");
     }
-
-
 }

--- a/crates/code_assistant/src/tools/parser_registry.rs
+++ b/crates/code_assistant/src/tools/parser_registry.rs
@@ -2,8 +2,7 @@
 
 use crate::agent::ToolSyntax;
 use crate::tools::{
-    parse_caret_tool_invocations_with_truncation, parse_xml_tool_invocations_with_truncation,
-    tool_use_filter::{SingleToolFilter, ToolUseFilter},
+    parse_caret_tool_invocations, parse_xml_tool_invocations, tool_use_filter::SingleToolFilter,
     ToolRequest,
 };
 use crate::ui::streaming::StreamProcessorTrait;
@@ -53,12 +52,7 @@ fn parse_and_truncate_caret_response(
         if let ContentBlock::Text { text } = block {
             // Parse Caret tool invocations and get truncation position
             let (block_tool_requests, truncated_text) =
-                parse_caret_tool_invocations_with_truncation(
-                    text,
-                    request_id,
-                    tool_requests.len(),
-                    Some(&filter),
-                )?;
+                parse_caret_tool_invocations(text, request_id, tool_requests.len(), Some(&filter))?;
 
             tool_requests.extend(block_tool_requests.clone());
 
@@ -102,12 +96,8 @@ fn parse_and_truncate_xml_response(
     for block in &response.content {
         if let ContentBlock::Text { text } = block {
             // Parse XML tool invocations and get truncation position
-            let (block_tool_requests, truncated_text) = parse_xml_tool_invocations_with_truncation(
-                text,
-                request_id,
-                tool_requests.len(),
-                Some(&filter),
-            )?;
+            let (block_tool_requests, truncated_text) =
+                parse_xml_tool_invocations(text, request_id, tool_requests.len(), Some(&filter))?;
 
             tool_requests.extend(block_tool_requests.clone());
 

--- a/crates/code_assistant/src/tools/parser_registry.rs
+++ b/crates/code_assistant/src/tools/parser_registry.rs
@@ -1,7 +1,11 @@
 //! Parser registry for different tool invocation syntaxes
 
 use crate::agent::ToolSyntax;
-use crate::tools::{parse_caret_tool_invocations, parse_xml_tool_invocations, ToolRequest};
+use crate::tools::{
+    parse_caret_tool_invocations_with_truncation, parse_xml_tool_invocations_with_truncation,
+    tool_use_filter::{SingleToolFilter, ToolUseFilter},
+    ToolRequest,
+};
 use crate::ui::streaming::StreamProcessorTrait;
 use crate::ui::UserInterface;
 use anyhow::Result;
@@ -43,6 +47,7 @@ fn parse_and_truncate_caret_response(
 ) -> Result<(Vec<ToolRequest>, LLMResponse)> {
     let mut tool_requests = Vec::new();
     let mut truncated_content = Vec::new();
+    let filter = SingleToolFilter;
 
     for block in &response.content {
         if let ContentBlock::Text { text } = block {
@@ -52,6 +57,7 @@ fn parse_and_truncate_caret_response(
                     text,
                     request_id,
                     tool_requests.len(),
+                    Some(&filter),
                 )?;
 
             tool_requests.extend(block_tool_requests.clone());
@@ -91,12 +97,17 @@ fn parse_and_truncate_xml_response(
 ) -> Result<(Vec<ToolRequest>, LLMResponse)> {
     let mut tool_requests = Vec::new();
     let mut truncated_content = Vec::new();
+    let filter = SingleToolFilter;
 
     for block in &response.content {
         if let ContentBlock::Text { text } = block {
             // Parse XML tool invocations and get truncation position
-            let (block_tool_requests, truncated_text) =
-                parse_xml_tool_invocations_with_truncation(text, request_id, tool_requests.len())?;
+            let (block_tool_requests, truncated_text) = parse_xml_tool_invocations_with_truncation(
+                text,
+                request_id,
+                tool_requests.len(),
+                Some(&filter),
+            )?;
 
             tool_requests.extend(block_tool_requests.clone());
 
@@ -147,114 +158,6 @@ fn parse_json_response(
     }
 
     Ok((tool_requests, response.clone()))
-}
-
-/// Parse Caret tool invocations and return both tool requests and truncated text
-fn parse_caret_tool_invocations_with_truncation(
-    text: &str,
-    request_id: u64,
-    start_tool_count: usize,
-) -> Result<(Vec<ToolRequest>, String)> {
-    // Parse tool requests using existing function
-    let all_tool_requests = parse_caret_tool_invocations(text, request_id, start_tool_count)?;
-
-    if all_tool_requests.is_empty() {
-        // No tools found, return original text
-        return Ok((all_tool_requests, text.to_string()));
-    }
-
-    // Only keep the first tool request to enforce single tool per message
-    let tool_requests = vec![all_tool_requests[0].clone()];
-
-    // Find the end position of the first tool to truncate text
-    let truncated_text = find_first_caret_tool_end_and_truncate(text)?;
-
-    Ok((tool_requests, truncated_text))
-}
-
-/// Parse XML tool invocations and return both tool requests and truncated text
-fn parse_xml_tool_invocations_with_truncation(
-    text: &str,
-    request_id: u64,
-    start_tool_count: usize,
-) -> Result<(Vec<ToolRequest>, String)> {
-    // Parse tool requests using existing function
-    let all_tool_requests = parse_xml_tool_invocations(text, request_id, start_tool_count)?;
-
-    if all_tool_requests.is_empty() {
-        // No tools found, return original text
-        return Ok((all_tool_requests, text.to_string()));
-    }
-
-    // Only keep the first tool request to enforce single tool per message
-    let tool_requests = vec![all_tool_requests[0].clone()];
-
-    // Find the end position of the first tool to truncate text
-    let truncated_text = find_first_tool_end_and_truncate(text)?;
-
-    Ok((tool_requests, truncated_text))
-}
-
-/// Find the end of the first caret tool and truncate there
-fn find_first_caret_tool_end_and_truncate(text: &str) -> Result<String> {
-    let tool_start_regex = regex::Regex::new(r"(?m)^\^\^\^([a-zA-Z0-9_]+)$").unwrap();
-    let tool_end_regex = regex::Regex::new(r"(?m)^\^\^\^$").unwrap();
-
-    // Find the first tool start
-    if let Some(start_match) = tool_start_regex.find(text) {
-        let after_start = &text[start_match.end()..];
-
-        // Find the corresponding tool end
-        if let Some(end_match) = tool_end_regex.find(after_start) {
-            let end_pos = start_match.end() + end_match.end();
-            return Ok(text[..end_pos].to_string());
-        }
-    }
-
-    // No complete tool found, return original text
-    Ok(text.to_string())
-}
-
-/// Find the end of the first tool in text and truncate there
-fn find_first_tool_end_and_truncate(text: &str) -> Result<String> {
-    let mut current_pos = 0;
-    let mut in_tool = false;
-    let mut tool_depth = 0;
-
-    while current_pos < text.len() {
-        if let Some(tag_start) = text[current_pos..].find('<') {
-            let absolute_pos = current_pos + tag_start;
-
-            // Look for tool tags
-            if let Some(tag_end) = text[absolute_pos..].find('>') {
-                let tag_content = &text[absolute_pos + 1..absolute_pos + tag_end];
-
-                if tag_content.starts_with("tool:") {
-                    // Tool start tag
-                    in_tool = true;
-                    tool_depth += 1;
-                } else if tag_content.starts_with("/tool:") {
-                    // Tool end tag
-                    if in_tool {
-                        tool_depth -= 1;
-                        if tool_depth == 0 {
-                            // Found the end of the first tool, truncate here
-                            let end_pos = absolute_pos + tag_end + 1;
-                            return Ok(text[..end_pos].to_string());
-                        }
-                    }
-                }
-                current_pos = absolute_pos + tag_end + 1;
-            } else {
-                current_pos = absolute_pos + 1;
-            }
-        } else {
-            break;
-        }
-    }
-
-    // No complete tool found, return original text
-    Ok(text.to_string())
 }
 
 /// XML-based tool invocation parser

--- a/crates/code_assistant/src/tools/parser_registry.rs
+++ b/crates/code_assistant/src/tools/parser_registry.rs
@@ -2,7 +2,7 @@
 
 use crate::agent::ToolSyntax;
 use crate::tools::{
-    parse_caret_tool_invocations, parse_xml_tool_invocations, tool_use_filter::SingleToolFilter,
+    parse_caret_tool_invocations, parse_xml_tool_invocations, tool_use_filter::SmartToolFilter,
     ToolRequest,
 };
 use crate::ui::streaming::StreamProcessorTrait;
@@ -46,7 +46,7 @@ fn parse_and_truncate_caret_response(
 ) -> Result<(Vec<ToolRequest>, LLMResponse)> {
     let mut tool_requests = Vec::new();
     let mut truncated_content = Vec::new();
-    let filter = SingleToolFilter;
+    let filter = SmartToolFilter::new();
 
     for block in &response.content {
         if let ContentBlock::Text { text } = block {
@@ -91,7 +91,7 @@ fn parse_and_truncate_xml_response(
 ) -> Result<(Vec<ToolRequest>, LLMResponse)> {
     let mut tool_requests = Vec::new();
     let mut truncated_content = Vec::new();
-    let filter = SingleToolFilter;
+    let filter = SmartToolFilter::new();
 
     for block in &response.content {
         if let ContentBlock::Text { text } = block {

--- a/crates/code_assistant/src/tools/tests.rs
+++ b/crates/code_assistant/src/tools/tests.rs
@@ -900,7 +900,7 @@ async fn test_xml_parsing_fails_with_valid_first_block_and_invalid_second() {
 <param:project>qwen-"#;
 
     // Currently this fails completely, losing the valid first tool block
-    let result = parse_xml_tool_invocations(text, 123, 0);
+    let result = parse_xml_tool_invocations(text, 123, 0, None);
 
     // This assertion will currently fail because the function returns an error
     // instead of returning the valid first tool block
@@ -916,7 +916,7 @@ async fn test_xml_parsing_fails_with_valid_first_block_and_invalid_second() {
 
 #[tokio::test]
 async fn test_xml_parsing_with_multiple_valid_blocks_should_limit_to_first() {
-    use crate::tools::parse::parse_xml_tool_invocations_with_filter;
+    use crate::tools::parse::parse_xml_tool_invocations;
     use crate::tools::tool_use_filter::SingleToolFilter;
 
     // Test case where we have multiple valid blocks but want to limit to first
@@ -944,7 +944,8 @@ And finally modify the file:
 
     // With the new system, this should return only the first tool and truncate after it
     let filter = SingleToolFilter;
-    let result = parse_xml_tool_invocations_with_filter(text, 123, 0, Some(&filter)).unwrap();
+    let (result, _truncated_text) =
+        parse_xml_tool_invocations(text, 123, 0, Some(&filter)).unwrap();
 
     // Should only get the first tool
     assert_eq!(result.len(), 1);
@@ -959,7 +960,7 @@ And finally modify the file:
 
 #[tokio::test]
 async fn test_xml_parsing_with_truncation_preserves_valid_tool() {
-    use crate::tools::parse::parse_xml_tool_invocations_with_truncation;
+    use crate::tools::parse::parse_xml_tool_invocations;
     use crate::tools::tool_use_filter::SingleToolFilter;
 
     // Test that truncation function can extract valid tool even with invalid following content
@@ -974,7 +975,7 @@ async fn test_xml_parsing_with_truncation_preserves_valid_tool() {
 <param:project>incomplete-"#;
 
     let filter = SingleToolFilter;
-    let result = parse_xml_tool_invocations_with_truncation(text, 123, 0, Some(&filter));
+    let result = parse_xml_tool_invocations(text, 123, 0, Some(&filter));
 
     // Should succeed and return the valid first tool
     assert!(

--- a/crates/code_assistant/src/tools/tests.rs
+++ b/crates/code_assistant/src/tools/tests.rs
@@ -1002,3 +1002,467 @@ async fn test_xml_parsing_with_truncation_preserves_valid_tool() {
         "Text should end cleanly after first tool block"
     );
 }
+
+#[tokio::test]
+async fn test_xml_parsing_with_smart_filter_allows_multiple_read_tools() {
+    use crate::tools::parse::parse_xml_tool_invocations;
+    use crate::tools::tool_use_filter::SmartToolFilter;
+
+    let text = r#"Let me analyze the project structure:
+
+<tool:read_files>
+<param:project>test-project</param:project>
+<param:path>package.json</param:path>
+</tool:read_files>
+
+Now let me list the directories:
+
+<tool:list_files>
+<param:project>test-project</param:project>
+<param:paths>src</param:paths>
+</tool:list_files>
+
+Let me search for specific patterns:
+
+<tool:search_files>
+<param:project>test-project</param:project>
+<param:regex>function.*\(</param:regex>
+</tool:search_files>
+
+But I shouldn't be able to write files yet:
+
+<tool:write_file>
+<param:project>test-project</param:project>
+<param:path>test.txt</param:path>
+<param:content>test content</param:content>
+</tool:write_file>"#;
+
+    let filter = SmartToolFilter::new();
+    let (tools, truncated_text) = parse_xml_tool_invocations(text, 123, 0, Some(&filter)).unwrap();
+
+    // Should get the first three read tools but not the write tool
+    assert_eq!(tools.len(), 3);
+    assert_eq!(tools[0].name, "read_files");
+    assert_eq!(tools[1].name, "list_files");
+    assert_eq!(tools[2].name, "search_files");
+
+    // Text should be truncated after the search_files block
+    assert!(truncated_text.ends_with("</tool:search_files>"));
+    assert!(!truncated_text.contains("<tool:write_file>"));
+}
+
+#[tokio::test]
+async fn test_xml_parsing_with_smart_filter_blocks_write_after_read() {
+    use crate::tools::parse::parse_xml_tool_invocations;
+    use crate::tools::tool_use_filter::SmartToolFilter;
+
+    let text = r#"First I'll read a file:
+
+<tool:read_files>
+<param:project>test-project</param:project>
+<param:path>config.json</param:path>
+</tool:read_files>
+
+Now I want to modify it immediately:
+
+<tool:replace_in_file>
+<param:project>test-project</param:project>
+<param:path>config.json</param:path>
+<param:diff>some diff content</param:diff>
+</tool:replace_in_file>"#;
+
+    let filter = SmartToolFilter::new();
+    let (tools, truncated_text) = parse_xml_tool_invocations(text, 123, 0, Some(&filter)).unwrap();
+
+    // Should only get the read tool, not the replace tool
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].name, "read_files");
+
+    // Text should be truncated before the replace_in_file tool
+    assert!(truncated_text.contains("</tool:read_files>"));
+    assert!(!truncated_text.contains("<tool:replace_in_file>"));
+}
+
+#[tokio::test]
+async fn test_xml_parsing_with_unlimited_filter_allows_all_tools() {
+    use crate::tools::parse::parse_xml_tool_invocations;
+    use crate::tools::tool_use_filter::UnlimitedToolFilter;
+
+    let text = r#"I'll do multiple operations:
+
+<tool:read_files>
+<param:project>test-project</param:project>
+<param:path>file1.txt</param:path>
+</tool:read_files>
+
+<tool:write_file>
+<param:project>test-project</param:project>
+<param:path>file2.txt</param:path>
+<param:content>new content</param:content>
+</tool:write_file>
+
+<tool:execute_command>
+<param:project>test-project</param:project>
+<param:command_line>ls -la</param:command_line>
+</tool:execute_command>"#;
+
+    let filter = UnlimitedToolFilter;
+    let (tools, truncated_text) = parse_xml_tool_invocations(text, 123, 0, Some(&filter)).unwrap();
+
+    // Should get all three tools
+    assert_eq!(tools.len(), 3);
+    assert_eq!(tools[0].name, "read_files");
+    assert_eq!(tools[1].name, "write_file");
+    assert_eq!(tools[2].name, "execute_command");
+
+    // Text should contain all tool blocks
+    assert!(truncated_text.contains("</tool:read_files>"));
+    assert!(truncated_text.contains("</tool:write_file>"));
+    assert!(truncated_text.contains("</tool:execute_command>"));
+}
+
+#[tokio::test]
+async fn test_caret_parsing_with_single_tool_filter() {
+    use crate::tools::parse::parse_caret_tool_invocations;
+    use crate::tools::tool_use_filter::SingleToolFilter;
+
+    let text = concat!(
+        "I'll read some files first:\n\n",
+        "^^^read_files\n",
+        "project: test-project\n",
+        "paths: [\n",
+        "file1.txt\n",
+        "file2.txt\n",
+        "]\n",
+        "^^^\n\n",
+        "Then I'll write a new file:\n\n",
+        "^^^write_file\n",
+        "project: test-project\n",
+        "path: new_file.txt\n",
+        "content: test content\n",
+        "^^^"
+    );
+
+    let filter = SingleToolFilter;
+    let (tools, truncated_text) =
+        parse_caret_tool_invocations(text, 123, 0, Some(&filter)).unwrap();
+
+    // Should only get the first tool due to SingleToolFilter
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].name, "read_files");
+    assert_eq!(tools[0].input["project"], "test-project");
+
+    // Text should be truncated after the first tool block
+    assert!(truncated_text.contains("^^^read_files"));
+    assert!(truncated_text.contains("^^^"));
+    assert!(!truncated_text.contains("write_file"));
+}
+
+#[tokio::test]
+async fn test_caret_parsing_with_smart_filter_allows_multiple_read_tools() {
+    use crate::tools::parse::parse_caret_tool_invocations;
+    use crate::tools::tool_use_filter::SmartToolFilter;
+
+    let text = concat!(
+        "Let me analyze the project:\n\n",
+        "^^^read_files\n",
+        "project: test-project\n",
+        "paths: [\n",
+        "package.json\n",
+        "]\n",
+        "^^^\n\n",
+        "Now list the files:\n\n",
+        "^^^list_files\n",
+        "project: test-project\n",
+        "paths: [\n",
+        "src\n",
+        "]\n",
+        "^^^\n\n",
+        "Search for patterns:\n\n",
+        "^^^search_files\n",
+        "project: test-project\n",
+        "regex: function.*\\(\n",
+        "^^^\n\n",
+        "But I shouldn't write yet:\n\n",
+        "^^^write_file\n",
+        "project: test-project\n",
+        "path: test.txt\n",
+        "content: test\n",
+        "^^^"
+    );
+
+    let filter = SmartToolFilter::new();
+    let (tools, truncated_text) =
+        parse_caret_tool_invocations(text, 123, 0, Some(&filter)).unwrap();
+
+    // Should get the first three read tools but not the write tool
+    assert_eq!(tools.len(), 3);
+    assert_eq!(tools[0].name, "read_files");
+    assert_eq!(tools[1].name, "list_files");
+    assert_eq!(tools[2].name, "search_files");
+
+    // Text should be truncated before the write_file tool
+    assert!(truncated_text.contains("^^^search_files"));
+    assert!(!truncated_text.contains("write_file"));
+}
+
+#[tokio::test]
+async fn test_caret_parsing_with_smart_filter_blocks_write_after_read() {
+    use crate::tools::parse::parse_caret_tool_invocations;
+    use crate::tools::tool_use_filter::SmartToolFilter;
+
+    let text = concat!(
+        "First I'll read a file:\n\n",
+        "^^^read_files\n",
+        "project: test-project\n",
+        "paths: [\n",
+        "config.json\n",
+        "]\n",
+        "^^^\n\n",
+        "Now I want to modify it:\n\n",
+        "^^^replace_in_file\n",
+        "project: test-project\n",
+        "path: config.json\n",
+        "diff ---\n",
+        "some diff content\n",
+        "--- diff\n",
+        "^^^"
+    );
+
+    let filter = SmartToolFilter::new();
+    let (tools, truncated_text) =
+        parse_caret_tool_invocations(text, 123, 0, Some(&filter)).unwrap();
+
+    // Should only get the read tool, not the replace tool
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].name, "read_files");
+
+    // Text should be truncated before the replace_in_file tool
+    assert!(truncated_text.contains("^^^read_files"));
+    assert!(!truncated_text.contains("replace_in_file"));
+}
+
+#[tokio::test]
+async fn test_caret_parsing_with_unlimited_filter_allows_all_tools() {
+    use crate::tools::parse::parse_caret_tool_invocations;
+    use crate::tools::tool_use_filter::UnlimitedToolFilter;
+
+    let text = concat!(
+        "I'll do multiple operations:\n\n",
+        "^^^read_files\n",
+        "project: test-project\n",
+        "paths: [\n",
+        "file1.txt\n",
+        "]\n",
+        "^^^\n\n",
+        "^^^write_file\n",
+        "project: test-project\n",
+        "path: file2.txt\n",
+        "content: new content\n",
+        "^^^\n\n",
+        "^^^execute_command\n",
+        "project: test-project\n",
+        "command_line: ls -la\n",
+        "^^^"
+    );
+
+    let filter = UnlimitedToolFilter;
+    let (tools, truncated_text) =
+        parse_caret_tool_invocations(text, 123, 0, Some(&filter)).unwrap();
+
+    // Should get all three tools
+    assert_eq!(tools.len(), 3);
+    assert_eq!(tools[0].name, "read_files");
+    assert_eq!(tools[1].name, "write_file");
+    assert_eq!(tools[2].name, "execute_command");
+
+    // Text should contain all tool blocks
+    assert!(truncated_text.contains("^^^read_files"));
+    assert!(truncated_text.contains("^^^write_file"));
+    assert!(truncated_text.contains("^^^execute_command"));
+}
+
+#[tokio::test]
+async fn test_caret_parsing_with_truncation_preserves_valid_tool() {
+    use crate::tools::parse::parse_caret_tool_invocations;
+    use crate::tools::tool_use_filter::SingleToolFilter;
+
+    let text = concat!(
+        "I will analyze the project structure:\n\n",
+        "^^^read_files\n",
+        "project: first-project\n",
+        "paths: [\n",
+        "package.json\n",
+        "]\n",
+        "^^^\n\n",
+        "^^^read_files\n",
+        "project: incomplete-"
+    );
+
+    let filter = SingleToolFilter;
+    let (tools, truncated_text) =
+        parse_caret_tool_invocations(text, 123, 0, Some(&filter)).unwrap();
+
+    // Should succeed and return the valid first tool
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].name, "read_files");
+    assert_eq!(tools[0].input["project"], "first-project");
+
+    let paths = tools[0].input["paths"].as_array().unwrap();
+    assert_eq!(paths.len(), 1);
+    assert_eq!(paths[0], "package.json");
+
+    // Truncated text should end after the first tool block and not contain the incomplete second tool
+    assert!(truncated_text.contains("^^^read_files"));
+    assert!(truncated_text.contains("^^^"));
+
+    // The text should end cleanly after first tool block
+    assert!(
+        truncated_text.trim_end().ends_with("^^^"),
+        "Text should end cleanly after first tool block"
+    );
+}
+
+#[tokio::test]
+async fn test_caret_parsing_multiline_parameters_with_filter() {
+    use crate::tools::parse::parse_caret_tool_invocations;
+    use crate::tools::tool_use_filter::SingleToolFilter;
+
+    let text = concat!(
+        "I'll write a file with multiline content:\n\n",
+        "^^^write_file\n",
+        "project: test-project\n",
+        "path: test.txt\n",
+        "content ---\n",
+        "This is line 1\n",
+        "This is line 2\n",
+        "This is line 3\n",
+        "--- content\n",
+        "^^^\n\n",
+        "Then execute a command:\n\n",
+        "^^^execute_command\n",
+        "project: test-project\n",
+        "command_line ---\n",
+        "echo 'hello world'\n",
+        "--- command_line\n",
+        "^^^"
+    );
+
+    let filter = SingleToolFilter;
+    let (tools, truncated_text) =
+        parse_caret_tool_invocations(text, 123, 0, Some(&filter)).unwrap();
+
+    // Should only get the first tool
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].name, "write_file");
+    assert_eq!(tools[0].input["project"], "test-project");
+    assert_eq!(tools[0].input["path"], "test.txt");
+
+    let content = tools[0].input["content"].as_str().unwrap();
+    assert!(content.contains("This is line 1"));
+    assert!(content.contains("This is line 2"));
+    assert!(content.contains("This is line 3"));
+
+    // Text should be truncated after the first tool
+    assert!(truncated_text.contains("^^^write_file"));
+    assert!(!truncated_text.contains("execute_command"));
+}
+
+#[tokio::test]
+async fn test_caret_parsing_edge_case_empty_arrays_with_filter() {
+    use crate::tools::parse::parse_caret_tool_invocations;
+    use crate::tools::tool_use_filter::SingleToolFilter;
+
+    let text = concat!(
+        "Testing with empty arrays:\n\n",
+        "^^^list_files\n",
+        "project: test-project\n",
+        "paths: [\n",
+        "]\n",
+        "^^^\n\n",
+        "^^^read_files\n",
+        "project: test-project\n",
+        "paths: [\n",
+        "file1.txt\n",
+        "]\n",
+        "^^^"
+    );
+
+    let filter = SingleToolFilter;
+    let (tools, truncated_text) =
+        parse_caret_tool_invocations(text, 123, 0, Some(&filter)).unwrap();
+
+    // Should only get the first tool
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].name, "list_files");
+    assert_eq!(tools[0].input["project"], "test-project");
+
+    // Empty array should be preserved
+    let paths = tools[0].input["paths"].as_array().unwrap();
+    assert_eq!(paths.len(), 0);
+
+    // Text should be truncated after the first tool
+    assert!(truncated_text.contains("^^^list_files"));
+    assert!(!truncated_text.contains("read_files"));
+}
+
+#[tokio::test]
+async fn test_mixed_syntax_scenarios_with_filters() {
+    use crate::tools::parse::{parse_caret_tool_invocations, parse_xml_tool_invocations};
+    use crate::tools::tool_use_filter::{SingleToolFilter, SmartToolFilter};
+
+    // Test that each parser handles its own syntax correctly with filters
+
+    // XML with web tools (read operations)
+    let xml_text = r#"Let me fetch some web content:
+
+<tool:web_fetch>
+<param:url>https://example.com</param:url>
+</tool:web_fetch>
+
+<tool:web_search>
+<param:query>rust programming</param:query>
+<param:hits_page_number>1</param:hits_page_number>
+</tool:web_search>"#;
+
+    let smart_filter = SmartToolFilter::new();
+    let (xml_tools, _) = parse_xml_tool_invocations(xml_text, 123, 0, Some(&smart_filter)).unwrap();
+
+    // Should get both web tools (they're read operations)
+    assert_eq!(xml_tools.len(), 2);
+    assert_eq!(xml_tools[0].name, "web_fetch");
+    assert_eq!(xml_tools[1].name, "web_search");
+
+    // Caret with the same tools
+    let caret_text = concat!(
+        "Let me fetch some web content:\n\n",
+        "^^^web_fetch\n",
+        "url: https://example.com\n",
+        "^^^\n\n",
+        "^^^web_search\n",
+        "query: rust programming\n",
+        "hits_page_number: 1\n",
+        "^^^"
+    );
+
+    let (caret_tools, _) =
+        parse_caret_tool_invocations(caret_text, 123, 0, Some(&smart_filter)).unwrap();
+
+    // Should get both web tools (they're read operations)
+    assert_eq!(caret_tools.len(), 2);
+    assert_eq!(caret_tools[0].name, "web_fetch");
+    assert_eq!(caret_tools[1].name, "web_search");
+
+    // Test with SingleToolFilter - should only get first tool in both cases
+    let single_filter = SingleToolFilter;
+
+    let (xml_single, _) =
+        parse_xml_tool_invocations(xml_text, 123, 0, Some(&single_filter)).unwrap();
+    assert_eq!(xml_single.len(), 1);
+    assert_eq!(xml_single[0].name, "web_fetch");
+
+    let (caret_single, _) =
+        parse_caret_tool_invocations(caret_text, 123, 0, Some(&single_filter)).unwrap();
+    assert_eq!(caret_single.len(), 1);
+    assert_eq!(caret_single[0].name, "web_fetch");
+}

--- a/crates/code_assistant/src/tools/tool_use_filter.rs
+++ b/crates/code_assistant/src/tools/tool_use_filter.rs
@@ -1,0 +1,168 @@
+//! Tool use filtering system to control which tool blocks are allowed and when to truncate responses
+
+/// Trait for filtering tool use blocks during parsing
+/// This allows controlling which tools can be used and when to stop parsing
+pub trait ToolUseFilter: Send + Sync {
+    /// Called when a tool block has been completed successfully
+    /// Returns whether additional content (including more tool blocks) should be allowed after this tool
+    /// If false, the response will be truncated immediately after this tool block
+    fn allow_content_after_tool(&self, tool_name: &str, tool_count: usize) -> bool;
+
+    /// Called when a new tool block is encountered and the tool name has been parsed
+    /// Returns whether this tool block should be allowed at this position
+    /// If false, the response will be truncated before this tool block
+    fn allow_tool_at_position(&self, tool_name: &str, tool_count: usize) -> bool;
+}
+
+/// Default filter that allows only one tool per message
+/// This prevents the LLM from chaining multiple tools before seeing the results
+pub struct SingleToolFilter;
+
+impl ToolUseFilter for SingleToolFilter {
+    fn allow_content_after_tool(&self, _tool_name: &str, _tool_count: usize) -> bool {
+        // After any tool completes, no additional content is allowed
+        false
+    }
+
+    fn allow_tool_at_position(&self, _tool_name: &str, tool_count: usize) -> bool {
+        // Only allow the first tool (tool_count starts at 1)
+        tool_count == 1
+    }
+}
+
+/// Filter that allows unlimited tools (for backwards compatibility or special cases)
+pub struct UnlimitedToolFilter;
+
+impl ToolUseFilter for UnlimitedToolFilter {
+    fn allow_content_after_tool(&self, _tool_name: &str, _tool_count: usize) -> bool {
+        true
+    }
+
+    fn allow_tool_at_position(&self, _tool_name: &str, _tool_count: usize) -> bool {
+        true
+    }
+}
+
+/// Smart filter that prevents certain tool combinations that don't make logical sense
+/// For example, prevents file editing tools before file reading tools have had their results processed
+pub struct SmartToolFilter {}
+
+impl SmartToolFilter {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    /// Check if a tool is a "read" operation (doesn't modify state)
+    fn is_read_tool(&self, tool_name: &str) -> bool {
+        matches!(
+            tool_name,
+            "read_files"
+                | "list_files"
+                | "list_projects"
+                | "search_files"
+                | "web_fetch"
+                | "web_search"
+        )
+    }
+}
+
+impl ToolUseFilter for SmartToolFilter {
+    fn allow_content_after_tool(&self, tool_name: &str, _tool_count: usize) -> bool {
+        // Allow content after read tools, but not after write tools
+        // This allows the LLM to potentially chain multiple read tools
+        self.is_read_tool(tool_name)
+    }
+
+    fn allow_tool_at_position(&self, tool_name: &str, tool_count: usize) -> bool {
+        // First tool is always allowed
+        if tool_count == 1 {
+            return true;
+        }
+
+        // Allow read tools after other read tools (e.g., read file then list directory)
+        // But don't allow write tools after any tool (they need to see results first)
+        self.is_read_tool(tool_name)
+    }
+}
+
+impl Default for SmartToolFilter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_single_tool_filter() {
+        let filter = SingleToolFilter;
+
+        // First tool should be allowed
+        assert!(filter.allow_tool_at_position("read_files", 1));
+
+        // Second tool should not be allowed
+        assert!(!filter.allow_tool_at_position("list_files", 2));
+
+        // No content after any tool
+        assert!(!filter.allow_content_after_tool("read_files", 1));
+    }
+
+    #[test]
+    fn test_unlimited_tool_filter() {
+        let filter = UnlimitedToolFilter;
+
+        // All tools should be allowed
+        assert!(filter.allow_tool_at_position("read_files", 1));
+        assert!(filter.allow_tool_at_position("list_files", 2));
+        assert!(filter.allow_tool_at_position("write_file", 3));
+
+        // Content after all tools should be allowed
+        assert!(filter.allow_content_after_tool("read_files", 1));
+        assert!(filter.allow_content_after_tool("write_file", 2));
+    }
+
+    #[test]
+    fn test_smart_tool_filter() {
+        let filter = SmartToolFilter::new();
+
+        // First tool always allowed
+        assert!(filter.allow_tool_at_position("read_files", 1));
+        assert!(filter.allow_tool_at_position("write_file", 1));
+
+        // Read tools can follow other tools
+        assert!(filter.allow_tool_at_position("list_files", 2));
+        assert!(filter.allow_tool_at_position("search_files", 2));
+        assert!(filter.allow_tool_at_position("read_files", 2));
+        assert!(filter.allow_tool_at_position("web_fetch", 2));
+
+        // Write tools should not be allowed as second tool
+        assert!(!filter.allow_tool_at_position("write_file", 2));
+        assert!(!filter.allow_tool_at_position("replace_in_file", 2));
+        assert!(!filter.allow_tool_at_position("delete_files", 2));
+        assert!(!filter.allow_tool_at_position("execute_command", 2));
+
+        // Content allowed after read tools but not write tools
+        assert!(filter.allow_content_after_tool("read_files", 1));
+        assert!(filter.allow_content_after_tool("list_files", 1));
+        assert!(!filter.allow_content_after_tool("write_file", 1));
+        assert!(!filter.allow_content_after_tool("replace_in_file", 1));
+    }
+
+    #[test]
+    fn test_tool_classification() {
+        let filter = SmartToolFilter::new();
+
+        // Test read tool classification
+        assert!(filter.is_read_tool("read_files"));
+        assert!(filter.is_read_tool("list_files"));
+        assert!(filter.is_read_tool("search_files"));
+        assert!(filter.is_read_tool("web_fetch"));
+        assert!(filter.is_read_tool("web_search"));
+        assert!(!filter.is_read_tool("write_file"));
+        assert!(!filter.is_read_tool("replace_in_file"));
+        assert!(!filter.is_read_tool("delete_files"));
+        assert!(!filter.is_read_tool("execute_command"));
+    }
+}

--- a/crates/code_assistant/src/ui/gpui/chat_sidebar.rs
+++ b/crates/code_assistant/src/ui/gpui/chat_sidebar.rs
@@ -7,6 +7,7 @@ use gpui::{
     div, prelude::*, px, AppContext, Context, Entity, FocusHandle, Focusable, MouseButton,
     MouseUpEvent, SharedString, Styled, Window,
 };
+use gpui_component::scroll::ScrollbarAxis;
 use gpui_component::{ActiveTheme, Icon, StyledExt};
 use std::time::SystemTime;
 use tracing::{debug, trace, warn};
@@ -443,7 +444,7 @@ impl Render for ChatSidebar {
                 .bg(cx.theme().sidebar)
                 .border_r_1()
                 .border_color(cx.theme().sidebar_border)
-                .overflow_hidden()
+                //.overflow_hidden()
                 .flex()
                 .flex_col()
                 .child(
@@ -485,26 +486,28 @@ impl Render for ChatSidebar {
                         ),
                 )
                 .child(
-                    // Chat list area
-                    div()
-                        .flex_1()
-                        .overflow_hidden()
-                        .flex()
-                        .flex_col()
-                        .gap_1()
-                        .p_2()
-                        .children(self.items.clone())
-                        .when(self.items.is_empty(), |s| {
-                            s.child(
-                                div()
-                                    .px_3()
-                                    .py_4()
-                                    .text_center()
-                                    .text_sm()
-                                    .text_color(cx.theme().muted_foreground)
-                                    .child("No chats yet"),
-                            )
-                        }),
+                    // Chat list area - outer container with padding
+                    div().flex_1().p_2().min_h(px(0.)).child(
+                        div()
+                            .id("chat-items")
+                            .h_full()
+                            .scrollable(ScrollbarAxis::Vertical)
+                            .flex()
+                            .flex_col()
+                            .gap_1()
+                            .children(self.items.clone())
+                            .when(self.items.is_empty(), |s| {
+                                s.child(
+                                    div()
+                                        .px_1()
+                                        .py_4()
+                                        .text_center()
+                                        .text_sm()
+                                        .text_color(cx.theme().muted_foreground)
+                                        .child("No chats yet"),
+                                )
+                            }),
+                    ),
                 )
         }
     }

--- a/crates/code_assistant/src/ui/gpui/chat_sidebar.rs
+++ b/crates/code_assistant/src/ui/gpui/chat_sidebar.rs
@@ -444,7 +444,6 @@ impl Render for ChatSidebar {
                 .bg(cx.theme().sidebar)
                 .border_r_1()
                 .border_color(cx.theme().sidebar_border)
-                //.overflow_hidden()
                 .flex()
                 .flex_col()
                 .child(

--- a/crates/code_assistant/src/ui/gpui/chat_sidebar.rs
+++ b/crates/code_assistant/src/ui/gpui/chat_sidebar.rs
@@ -487,9 +487,10 @@ impl Render for ChatSidebar {
                 )
                 .child(
                     // Chat list area - outer container with padding
-                    div().flex_1().p_2().min_h(px(0.)).child(
+                    div().flex_1().min_h(px(0.)).child(
                         div()
                             .id("chat-items")
+                            .p_2()
                             .h_full()
                             .scrollable(ScrollbarAxis::Vertical)
                             .flex()

--- a/crates/code_assistant/src/ui/gpui/mod.rs
+++ b/crates/code_assistant/src/ui/gpui/mod.rs
@@ -83,6 +83,7 @@ pub enum BackendResponse {
     },
     PendingMessageForEdit {
         session_id: String,
+        #[allow(dead_code)]
         message: String,
     },
     PendingMessageUpdated {

--- a/crates/code_assistant/src/ui/gpui/root.rs
+++ b/crates/code_assistant/src/ui/gpui/root.rs
@@ -9,8 +9,8 @@ use crate::persistence::ChatMetadata;
 use crate::ui::ui_events::UiEvent;
 use crate::ui::StreamingState;
 use gpui::{
-    div, prelude::*, px, rgba, App, Context, CursorStyle, Entity, FocusHandle, Focusable,
-    MouseButton, MouseUpEvent,
+    div, prelude::*, px, App, Context, CursorStyle, Entity, FocusHandle, Focusable, MouseButton,
+    MouseUpEvent,
 };
 use gpui_component::input::TextInput;
 use gpui_component::input::{InputEvent, InputState};
@@ -234,7 +234,7 @@ impl RootView {
         match event {
             InputEvent::Change(text) => {
                 if let Some(session_id) = &self.current_session_id {
-                    debug!("Current session: {} - saving draft", session_id);
+                    trace!("Current session: {} - saving draft", session_id);
                     // Save draft immediately for now (no debouncing for simplicity)
                     if let Some(gpui) = cx.try_global::<Gpui>() {
                         gpui.save_draft_for_session(session_id, text);
@@ -494,17 +494,24 @@ impl Render for RootView {
 
                                         div()
                                             .flex_1()
-                                            .border_1()
-                                            .border_color(if is_focused {
-                                                cx.theme().primary // Blue border when focused
-                                            } else if cx.theme().is_dark() {
-                                                rgba(0x555555FF).into() // Brighter border for dark theme
+                                            .border(if is_focused {
+                                                px(2.)
                                             } else {
-                                                rgba(0x999999FF).into() // Darker border for light theme
+                                                px(1.)
+                                            })
+                                            .p(if is_focused {
+                                                px(0.)
+                                            } else {
+                                                px(1.)
+                                            })
+                                            .border_color(if is_focused {
+                                                cx.theme().primary
+                                            } else {
+                                                cx.theme().sidebar_border
                                             })
                                             .rounded_md()
                                             .track_focus(&text_input_handle)
-                                            .child(TextInput::new(&self.text_input))
+                                            .child(TextInput::new(&self.text_input).appearance(false))
                                     })
                                     .children({
                                         // Get current session activity state from global Gpui

--- a/crates/code_assistant/src/ui/streaming/caret_processor.rs
+++ b/crates/code_assistant/src/ui/streaming/caret_processor.rs
@@ -1,4 +1,5 @@
 //! Caret-style tool invocation processor for streaming responses
+use crate::tools::tool_use_filter::{SmartToolFilter, ToolUseFilter};
 use crate::ui::streaming::{DisplayFragment, StreamProcessorTrait};
 use crate::ui::{UIError, UserInterface};
 use llm::{Message, MessageContent, StreamingChunk};
@@ -37,6 +38,20 @@ enum ParserState {
     },
 }
 
+/// Streaming state for managing tool filtering and buffering
+#[derive(Debug, PartialEq, Clone)]
+enum StreamingState {
+    /// Stream everything immediately (before any tools)
+    PreFirstTool,
+    /// Buffer content between tools until next tool is evaluated
+    BufferingAfterTool {
+        last_tool_name: String,
+        buffered_fragments: Vec<DisplayFragment>,
+    },
+    /// Stop streaming (tool was denied)
+    Blocked,
+}
+
 pub struct CaretStreamProcessor {
     ui: Arc<Box<dyn UserInterface>>,
     request_id: u64,
@@ -47,7 +62,9 @@ pub struct CaretStreamProcessor {
     multiline_start_regex: Regex,
     multiline_end_regex: Regex,
     current_tool_id: String,
-    complete_tool_emitted: bool,
+    current_tool_name: String,
+    filter: Box<dyn ToolUseFilter>,
+    streaming_state: StreamingState,
 }
 
 impl StreamProcessorTrait for CaretStreamProcessor {
@@ -62,15 +79,26 @@ impl StreamProcessorTrait for CaretStreamProcessor {
             multiline_start_regex: Regex::new(r"^([a-zA-Z0-9_]+)\s+---$").unwrap(),
             multiline_end_regex: Regex::new(r"^---\s+([a-zA-Z0-9_]+)$").unwrap(),
             current_tool_id: String::new(),
-            complete_tool_emitted: false,
+            current_tool_name: String::new(),
+            filter: Box::new(SmartToolFilter::new()),
+            streaming_state: StreamingState::PreFirstTool,
         }
     }
 
     fn process(&mut self, chunk: &StreamingChunk) -> Result<(), UIError> {
-        if let StreamingChunk::Text(text) = chunk {
-            self.buffer.push_str(text);
+        match chunk {
+            StreamingChunk::Text(text) => {
+                self.buffer.push_str(text);
+                self.process_buffer()?;
+            }
+            StreamingChunk::StreamingComplete => {
+                // Emit any remaining buffered fragments since no more content is coming
+                self.flush_buffered_content()?;
+            }
+            _ => {
+                // Other chunk types are not handled by caret processor
+            }
         }
-        self.process_buffer()?;
         Ok(())
     }
 
@@ -598,6 +626,7 @@ impl CaretStreamProcessor {
             let tool_name = caps.get(1).unwrap().as_str();
             self.tool_counter += 1; // Increment first, so first tool gets counter 1
             self.current_tool_id = format!("tool-{}-{}", self.request_id, self.tool_counter);
+            self.current_tool_name = tool_name.to_string();
             let tool_id = self.current_tool_id.clone();
             self.send_tool_start(tool_name, &tool_id)?;
             self.state = ParserState::InsideTool;
@@ -612,6 +641,8 @@ impl CaretStreamProcessor {
             let tool_id = self.current_tool_id.clone();
             self.send_tool_end(&tool_id)?;
             self.state = ParserState::OutsideTool;
+            // Clear current tool info
+            self.current_tool_name.clear();
             // Note: Any trailing newlines after this will be buffered and trimmed naturally
         } else if let Some(caps) = self.multiline_start_regex.captures(line) {
             let param_name = caps.get(1).unwrap().as_str().to_string();
@@ -675,32 +706,150 @@ impl CaretStreamProcessor {
         Ok(params)
     }
 
-    /// Emit fragments through this central function that blocks output after complete tool blocks
+    /// Emit fragments through this central function that handles filtering and buffering
     fn emit_fragment(&mut self, fragment: DisplayFragment) -> Result<(), UIError> {
-        // Check if we already emitted a complete tool block
-        if self.complete_tool_emitted {
-            // Check if this is just whitespace content - if so, ignore silently
-            if let DisplayFragment::PlainText(text) = &fragment {
-                if text.trim().is_empty() {
-                    // Just whitespace after tool block - ignore silently
-                    return Ok(());
+        match &self.streaming_state {
+            StreamingState::Blocked => {
+                // Already blocked, check if this is just whitespace and ignore silently
+                if let DisplayFragment::PlainText(text) = &fragment {
+                    if text.trim().is_empty() {
+                        return Ok(());
+                    }
+                }
+                // Non-whitespace content after blocking - return the blocking error
+                return Err(UIError::IOError(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "Tool limit reached - no additional text after complete tool block allowed",
+                )));
+            }
+            StreamingState::PreFirstTool => {
+                // Before first tool, emit everything immediately
+                match &fragment {
+                    DisplayFragment::ToolName { name, .. } => {
+                        // First tool starting - check if it's allowed (should always be allowed)
+                        if !self.filter.allow_tool_at_position(name, 1) {
+                            // First tool denied - block streaming
+                            self.streaming_state = StreamingState::Blocked;
+                            return Err(UIError::IOError(std::io::Error::new(
+                                std::io::ErrorKind::InvalidData,
+                                "Tool limit reached - no additional text after complete tool block allowed",
+                            )));
+                        }
+                        // Emit the tool name fragment
+                        self.ui.display_fragment(&fragment)?;
+                    }
+                    DisplayFragment::ToolEnd { .. } => {
+                        // Tool ended - emit fragment and check if we should buffer after this tool
+                        self.ui.display_fragment(&fragment)?;
+
+                        // Get the tool name from current_tool_id or extract from somewhere
+                        let tool_name = self.extract_tool_name_from_current_context();
+
+                        if self.filter.allow_content_after_tool(&tool_name, 1) {
+                            // Transition to buffering state
+                            self.streaming_state = StreamingState::BufferingAfterTool {
+                                last_tool_name: tool_name,
+                                buffered_fragments: Vec::new(),
+                            };
+                        } else {
+                            // No content allowed after this tool - block
+                            self.streaming_state = StreamingState::Blocked;
+                        }
+                    }
+                    _ => {
+                        // Regular fragment - emit immediately
+                        self.ui.display_fragment(&fragment)?;
+                    }
                 }
             }
+            StreamingState::BufferingAfterTool {
+                last_tool_name,
+                buffered_fragments,
+            } => {
+                match &fragment {
+                    DisplayFragment::ToolName { name, .. } => {
+                        // New tool starting - check if it's allowed
+                        let tool_count = self.tool_counter + 1; // Next tool count
+                        if self
+                            .filter
+                            .allow_tool_at_position(name, tool_count as usize)
+                        {
+                            // Tool allowed - emit all buffered fragments first
+                            let mut buffered = buffered_fragments.clone();
+                            for buffered_fragment in buffered.drain(..) {
+                                self.ui.display_fragment(&buffered_fragment)?;
+                            }
+                            // Then emit the tool name fragment
+                            self.ui.display_fragment(&fragment)?;
+                            // Update state to continue buffering after this tool
+                            self.streaming_state = StreamingState::BufferingAfterTool {
+                                last_tool_name: name.clone(),
+                                buffered_fragments: Vec::new(),
+                            };
+                        } else {
+                            // Tool denied - discard buffered content and block
+                            self.streaming_state = StreamingState::Blocked;
+                            return Err(UIError::IOError(std::io::Error::new(
+                                std::io::ErrorKind::InvalidData,
+                                "Tool limit reached - no additional text after complete tool block allowed",
+                            )));
+                        }
+                    }
+                    DisplayFragment::ToolEnd { .. } => {
+                        // Tool ended - emit fragment and check if we should continue buffering
+                        self.ui.display_fragment(&fragment)?;
 
-            // Non-whitespace content after complete tool block - return the blocking error
-            return Err(UIError::IOError(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                "Tool limit reached - no additional text after complete tool block allowed",
-            )));
+                        let tool_name = last_tool_name.clone();
+                        let tool_count = self.tool_counter as usize;
+
+                        if self.filter.allow_content_after_tool(&tool_name, tool_count) {
+                            // Continue buffering
+                            self.streaming_state = StreamingState::BufferingAfterTool {
+                                last_tool_name: tool_name,
+                                buffered_fragments: Vec::new(),
+                            };
+                        } else {
+                            // No content allowed after this tool - block
+                            self.streaming_state = StreamingState::Blocked;
+                        }
+                    }
+                    DisplayFragment::ToolParameter { .. } => {
+                        // Tool parameter - emit immediately (we've already decided to allow the tool)
+                        self.ui.display_fragment(&fragment)?;
+                    }
+                    DisplayFragment::PlainText(_) | DisplayFragment::ThinkingText(_) => {
+                        // Text or thinking - buffer it until we know if next tool is allowed
+                        if let StreamingState::BufferingAfterTool {
+                            buffered_fragments, ..
+                        } = &mut self.streaming_state
+                        {
+                            buffered_fragments.push(fragment);
+                        }
+                    }
+                }
+            }
         }
 
-        // Track when we emit a ToolEnd fragment to mark complete tool emission
-        if let DisplayFragment::ToolEnd { .. } = &fragment {
-            self.complete_tool_emitted = true;
-        }
+        Ok(())
+    }
 
-        // Emit the fragment
-        self.ui.display_fragment(&fragment)
+    /// Extract tool name from current context (helper method)
+    fn extract_tool_name_from_current_context(&self) -> String {
+        self.current_tool_name.clone()
+    }
+
+    /// Flush any buffered content when streaming completes
+    fn flush_buffered_content(&mut self) -> Result<(), UIError> {
+        if let StreamingState::BufferingAfterTool {
+            buffered_fragments, ..
+        } = &mut self.streaming_state
+        {
+            // Emit all buffered fragments since no more tools are coming
+            for fragment in buffered_fragments.drain(..) {
+                self.ui.display_fragment(&fragment)?;
+            }
+        }
+        Ok(())
     }
 
     fn send_plain_text(&mut self, text: &str) -> Result<(), UIError> {

--- a/crates/code_assistant/src/ui/streaming/caret_processor.rs
+++ b/crates/code_assistant/src/ui/streaming/caret_processor.rs
@@ -9,14 +9,17 @@ use std::sync::Arc;
 enum ParserState {
     OutsideTool,
     InsideTool,
+    #[allow(dead_code)]
     CollectingName {
         partial_name: String,
         tool_id: String,
     },
+    #[allow(dead_code)]
     CollectingType {
         param_name: String,
         tool_id: String,
     },
+    #[allow(dead_code)]
     CollectingValue {
         param_name: String,
         tool_id: String,

--- a/crates/code_assistant/src/ui/streaming/json_processor.rs
+++ b/crates/code_assistant/src/ui/streaming/json_processor.rs
@@ -184,6 +184,12 @@ impl StreamProcessorTrait for JsonStreamProcessor {
                 self.process_json_stream(content)
             }
 
+            StreamingChunk::StreamingComplete => {
+                // JSON processor doesn't need buffering like XML/Caret processors
+                // Just acknowledge the completion
+                Ok(())
+            }
+
             StreamingChunk::Text(text) => self.process_text_with_thinking_tags(text),
         }
     }

--- a/crates/code_assistant/src/ui/streaming/xml_processor.rs
+++ b/crates/code_assistant/src/ui/streaming/xml_processor.rs
@@ -1,4 +1,5 @@
 use super::{DisplayFragment, StreamProcessorTrait};
+use crate::tools::tool_use_filter::{SmartToolFilter, ToolUseFilter};
 use crate::ui::{UIError, UserInterface};
 use anyhow::Result;
 use llm::{ContentBlock, Message, MessageContent, StreamingChunk};
@@ -27,8 +28,20 @@ struct ProcessorState {
     at_block_start: bool,
     // Counter for tools processed in this request
     tool_counter: u64,
-    // Track wether we emitted a complete tool block already
-    complete_tool_emitted: bool,
+}
+
+/// Streaming state for managing tool filtering and buffering
+#[derive(Debug, PartialEq, Clone)]
+enum StreamingState {
+    /// Stream everything immediately (before any tools)
+    PreFirstTool,
+    /// Buffer content between tools until next tool is evaluated
+    BufferingAfterTool {
+        last_tool_name: String,
+        buffered_fragments: Vec<DisplayFragment>,
+    },
+    /// Stop streaming (tool was denied)
+    Blocked,
 }
 
 /// Manages the conversion of LLM streaming chunks to display fragments using XML-style tags
@@ -36,6 +49,8 @@ pub struct XmlStreamProcessor {
     state: ProcessorState,
     ui: Arc<Box<dyn UserInterface>>,
     request_id: u64,
+    filter: Box<dyn ToolUseFilter>,
+    streaming_state: StreamingState,
 }
 
 // Define tag types we need to process
@@ -56,6 +71,8 @@ impl StreamProcessorTrait for XmlStreamProcessor {
             state: ProcessorState::default(),
             ui,
             request_id,
+            filter: Box::new(SmartToolFilter::new()),
+            streaming_state: StreamingState::PreFirstTool,
         }
     }
 
@@ -88,7 +105,7 @@ impl StreamProcessorTrait for XmlStreamProcessor {
                 // If this is the first part with tool info, send a ToolName fragment
                 if let (Some(name), Some(id)) = (tool_name, tool_id) {
                     if !name.is_empty() && !id.is_empty() {
-                        self.ui.display_fragment(&DisplayFragment::ToolName {
+                        self.emit_fragment(DisplayFragment::ToolName {
                             name: name.clone(),
                             id: id.clone(),
                         })?;
@@ -98,8 +115,12 @@ impl StreamProcessorTrait for XmlStreamProcessor {
                 // For now, show the JSON as plain text
                 // In a more advanced implementation, we could parse the JSON
                 // and extract parameter names/values
-                self.ui
-                    .display_fragment(&DisplayFragment::PlainText(content.clone()))
+                self.emit_fragment(DisplayFragment::PlainText(content.clone()))
+            }
+
+            StreamingChunk::StreamingComplete => {
+                // Emit any remaining buffered fragments since no more content is coming
+                self.flush_buffered_content()
             }
 
             // For text chunks, we need to parse for tags
@@ -342,7 +363,7 @@ impl XmlStreamProcessor {
                                 format!("tool-{}-{}", self.request_id, self.state.tool_counter);
 
                             // Send fragment with tool name
-                            self.ui.display_fragment(&DisplayFragment::ToolName {
+                            self.emit_fragment(DisplayFragment::ToolName {
                                 name: self.state.tool_name.clone(),
                                 id: self.state.tool_id.clone(),
                             })?;
@@ -358,10 +379,7 @@ impl XmlStreamProcessor {
                             let tool_id = self.state.tool_id.clone();
 
                             // Send fragment for tool end with the original tool ID
-                            self.ui
-                                .display_fragment(&DisplayFragment::ToolEnd { id: tool_id })?;
-
-                            self.state.complete_tool_emitted = true;
+                            self.emit_fragment(DisplayFragment::ToolEnd { id: tool_id })?;
                         }
 
                         // Always reset tool state when we see any tool end tag
@@ -486,43 +504,161 @@ impl XmlStreamProcessor {
         Ok(())
     }
 
-    fn emit_text(&self, text: &str) -> Result<(), UIError> {
-        if self.state.complete_tool_emitted {
-            // Already processed one complete tool block.
-            // Always trigger tool limit after any tool completes to stop streaming
-            return Err(UIError::IOError(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                "Tool limit reached - no additional text after complete tool block allowed",
-            )));
-        }
-        if self.state.in_thinking {
+    fn emit_text(&mut self, text: &str) -> Result<(), UIError> {
+        let fragment = if self.state.in_thinking {
             // In thinking mode, text is displayed as thinking text
-            self.ui
-                .display_fragment(&DisplayFragment::ThinkingText(text.to_string()))
+            DisplayFragment::ThinkingText(text.to_string())
         } else if self.state.in_param {
             // In parameter mode, text is collected as a parameter value
             // Only send if we have a valid tool_id
             if !self.state.tool_id.is_empty() {
-                self.ui.display_fragment(&DisplayFragment::ToolParameter {
+                DisplayFragment::ToolParameter {
                     name: self.state.param_name.clone(),
                     value: text.to_string(),
                     tool_id: self.state.tool_id.clone(),
-                })
+                }
             } else {
                 // Log the issue and treat as plain text
                 warn!(
                     "Parameter '{}' found outside of tool context, treating as plain text",
                     self.state.param_name
                 );
-                self.ui
-                    .display_fragment(&DisplayFragment::PlainText(text.to_string()))
+                DisplayFragment::PlainText(text.to_string())
             }
         } else {
             // All other text (including inside tool tags but not in params)
             // is displayed as plain text
-            self.ui
-                .display_fragment(&DisplayFragment::PlainText(text.to_string()))
+            DisplayFragment::PlainText(text.to_string())
+        };
+
+        self.emit_fragment(fragment)
+    }
+
+    /// Emit fragments through this central function that handles filtering and buffering
+    fn emit_fragment(&mut self, fragment: DisplayFragment) -> Result<(), UIError> {
+        match &self.streaming_state {
+            StreamingState::Blocked => {
+                // Already blocked, check if this is just whitespace and ignore silently
+                if let DisplayFragment::PlainText(text) = &fragment {
+                    if text.trim().is_empty() {
+                        return Ok(());
+                    }
+                }
+                // Non-whitespace content after blocking - return the blocking error
+                return Err(UIError::IOError(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "Tool limit reached - no additional text after complete tool block allowed",
+                )));
+            }
+            StreamingState::PreFirstTool => {
+                // Before first tool, emit everything immediately
+                match &fragment {
+                    DisplayFragment::ToolName { name, .. } => {
+                        // First tool starting - check if it's allowed (should always be allowed)
+                        if !self.filter.allow_tool_at_position(name, 1) {
+                            // First tool denied - block streaming
+                            self.streaming_state = StreamingState::Blocked;
+                            return Err(UIError::IOError(std::io::Error::new(
+                                std::io::ErrorKind::InvalidData,
+                                "Tool limit reached - no additional text after complete tool block allowed",
+                            )));
+                        }
+                        // Emit the tool name fragment
+                        self.ui.display_fragment(&fragment)?;
+                    }
+                    DisplayFragment::ToolEnd { .. } => {
+                        // Tool ended - emit fragment and check if we should buffer after this tool
+                        self.ui.display_fragment(&fragment)?;
+
+                        // Get the tool name from processor state
+                        let tool_name = self.state.tool_name.clone();
+
+                        if self.filter.allow_content_after_tool(&tool_name, 1) {
+                            // Transition to buffering state
+                            self.streaming_state = StreamingState::BufferingAfterTool {
+                                last_tool_name: tool_name,
+                                buffered_fragments: Vec::new(),
+                            };
+                        } else {
+                            // No content allowed after this tool - block
+                            self.streaming_state = StreamingState::Blocked;
+                        }
+                    }
+                    _ => {
+                        // Regular fragment - emit immediately
+                        self.ui.display_fragment(&fragment)?;
+                    }
+                }
+            }
+            StreamingState::BufferingAfterTool {
+                last_tool_name,
+                buffered_fragments,
+            } => {
+                match &fragment {
+                    DisplayFragment::ToolName { name, .. } => {
+                        // New tool starting - check if it's allowed
+                        let tool_count = self.state.tool_counter + 1; // Next tool count
+                        if self
+                            .filter
+                            .allow_tool_at_position(name, tool_count as usize)
+                        {
+                            // Tool allowed - emit all buffered fragments first
+                            let mut buffered = buffered_fragments.clone();
+                            for buffered_fragment in buffered.drain(..) {
+                                self.ui.display_fragment(&buffered_fragment)?;
+                            }
+                            // Then emit the tool name fragment
+                            self.ui.display_fragment(&fragment)?;
+                            // Update state to continue buffering after this tool
+                            self.streaming_state = StreamingState::BufferingAfterTool {
+                                last_tool_name: name.clone(),
+                                buffered_fragments: Vec::new(),
+                            };
+                        } else {
+                            // Tool denied - discard buffered content and block
+                            self.streaming_state = StreamingState::Blocked;
+                            return Err(UIError::IOError(std::io::Error::new(
+                                std::io::ErrorKind::InvalidData,
+                                "Tool limit reached - no additional text after complete tool block allowed",
+                            )));
+                        }
+                    }
+                    DisplayFragment::ToolEnd { .. } => {
+                        // Tool ended - emit fragment and check if we should continue buffering
+                        self.ui.display_fragment(&fragment)?;
+
+                        let tool_name = last_tool_name.clone();
+                        let tool_count = self.state.tool_counter as usize;
+
+                        if self.filter.allow_content_after_tool(&tool_name, tool_count) {
+                            // Continue buffering
+                            self.streaming_state = StreamingState::BufferingAfterTool {
+                                last_tool_name: tool_name,
+                                buffered_fragments: Vec::new(),
+                            };
+                        } else {
+                            // No content allowed after this tool - block
+                            self.streaming_state = StreamingState::Blocked;
+                        }
+                    }
+                    DisplayFragment::ToolParameter { .. } => {
+                        // Tool parameter - emit immediately (we've already decided to allow the tool)
+                        self.ui.display_fragment(&fragment)?;
+                    }
+                    DisplayFragment::PlainText(_) | DisplayFragment::ThinkingText(_) => {
+                        // Text or thinking - buffer it
+                        if let StreamingState::BufferingAfterTool {
+                            buffered_fragments, ..
+                        } = &mut self.streaming_state
+                        {
+                            buffered_fragments.push(fragment);
+                        }
+                    }
+                }
+            }
         }
+
+        Ok(())
     }
 
     /// Detect what kind of tag we're seeing and extract any tag information
@@ -773,5 +909,19 @@ impl XmlStreamProcessor {
         }
 
         Ok(fragments)
+    }
+
+    /// Flush any buffered content when streaming completes
+    fn flush_buffered_content(&mut self) -> Result<(), UIError> {
+        if let StreamingState::BufferingAfterTool {
+            buffered_fragments, ..
+        } = &mut self.streaming_state
+        {
+            // Emit all buffered fragments since no more tools are coming
+            for fragment in buffered_fragments.drain(..) {
+                self.ui.display_fragment(&fragment)?;
+            }
+        }
+        Ok(())
     }
 }

--- a/crates/code_assistant/src/ui/streaming/xml_processor_tests.rs
+++ b/crates/code_assistant/src/ui/streaming/xml_processor_tests.rs
@@ -834,4 +834,192 @@ mod tests {
 
         assert_fragments_match(&expected_fragments, &fragments);
     }
+
+    #[test]
+    fn test_smart_filter_allows_content_after_read_tools() {
+        let test_ui = TestUI::new();
+        let ui_arc = Arc::new(Box::new(test_ui.clone()) as Box<dyn UserInterface>);
+        let mut processor = XmlStreamProcessor::new(ui_arc, 42);
+
+        // Process a complete read tool block followed by text
+        // Read tools should allow content after them according to SmartToolFilter
+        let input = "<tool:read_files><param:project>test</param:project></tool:read_files>";
+        let result = processor.process(&StreamingChunk::Text(input.to_string()));
+        assert!(result.is_ok(), "Initial tool processing should succeed");
+
+        // Now try to process text after the complete read tool block
+        let additional_text = "This should be allowed after read tools";
+        let result = processor.process(&StreamingChunk::Text(additional_text.to_string()));
+
+        // Should succeed - content is allowed after read tools
+        assert!(
+            result.is_ok(),
+            "Should allow content after read tools with SmartToolFilter"
+        );
+
+        // Send StreamingComplete to flush any buffered content
+        let result = processor.process(&StreamingChunk::StreamingComplete);
+        assert!(result.is_ok(), "StreamingComplete should succeed");
+
+        let fragments = test_ui.get_fragments();
+
+        // Should have 4 fragments: ToolName, ToolParameter, ToolEnd, PlainText
+        assert_eq!(fragments.len(), 4);
+        assert!(matches!(fragments[0], DisplayFragment::ToolName { .. }));
+        assert!(matches!(
+            fragments[1],
+            DisplayFragment::ToolParameter { .. }
+        ));
+        assert!(matches!(fragments[2], DisplayFragment::ToolEnd { .. }));
+
+        // The additional text should be buffered and emitted as PlainText
+        if let DisplayFragment::PlainText(text) = &fragments[3] {
+            assert!(text.contains("This should be allowed after read tools"));
+        } else {
+            panic!("Expected PlainText fragment for additional content");
+        }
+    }
+
+    #[test]
+    fn test_smart_filter_allows_chaining_read_tools() {
+        let test_ui = TestUI::new();
+        let ui_arc = Arc::new(Box::new(test_ui.clone()) as Box<dyn UserInterface>);
+        let mut processor = XmlStreamProcessor::new(ui_arc, 42);
+
+        // Process first read tool
+        let input1 = "<tool:read_files><param:project>test</param:project></tool:read_files>";
+        let result = processor.process(&StreamingChunk::Text(input1.to_string()));
+        assert!(result.is_ok(), "First read tool should succeed");
+
+        // Process text between tools
+        let between_text = "Now let me list the files:";
+        let result = processor.process(&StreamingChunk::Text(between_text.to_string()));
+        assert!(result.is_ok(), "Text between read tools should be allowed");
+
+        // Process second read tool
+        let input2 = "<tool:list_files><param:project>test</param:project></tool:list_files>";
+        let result = processor.process(&StreamingChunk::Text(input2.to_string()));
+        assert!(result.is_ok(), "Second read tool should be allowed");
+
+        // Send StreamingComplete to flush any buffered content
+        let result = processor.process(&StreamingChunk::StreamingComplete);
+        assert!(result.is_ok(), "StreamingComplete should succeed");
+
+        let fragments = test_ui.get_fragments();
+
+        // Should have fragments for both tools plus the text between
+        // First tool: ToolName, ToolParameter, ToolEnd
+        // Text: PlainText
+        // Second tool: ToolName, ToolParameter, ToolEnd
+        assert_eq!(fragments.len(), 7);
+
+        // Verify the sequence
+        assert!(matches!(fragments[0], DisplayFragment::ToolName { .. }));
+        assert!(matches!(
+            fragments[1],
+            DisplayFragment::ToolParameter { .. }
+        ));
+        assert!(matches!(fragments[2], DisplayFragment::ToolEnd { .. }));
+        assert!(matches!(fragments[3], DisplayFragment::PlainText(_)));
+        assert!(matches!(fragments[4], DisplayFragment::ToolName { .. }));
+        assert!(matches!(
+            fragments[5],
+            DisplayFragment::ToolParameter { .. }
+        ));
+        assert!(matches!(fragments[6], DisplayFragment::ToolEnd { .. }));
+    }
+
+    #[test]
+    fn test_smart_filter_blocks_write_tool_after_read_tool() {
+        let test_ui = TestUI::new();
+        let ui_arc = Arc::new(Box::new(test_ui.clone()) as Box<dyn UserInterface>);
+        let mut processor = XmlStreamProcessor::new(ui_arc, 42);
+
+        // Process first read tool
+        let input1 = "<tool:read_files><param:project>test</param:project></tool:read_files>";
+        let result = processor.process(&StreamingChunk::Text(input1.to_string()));
+        assert!(result.is_ok(), "First read tool should succeed");
+
+        // Process text between tools
+        let between_text = "Now let me write to a file:";
+        let result = processor.process(&StreamingChunk::Text(between_text.to_string()));
+        assert!(result.is_ok(), "Text between tools should be buffered");
+
+        // Try to process a write tool - this should be blocked
+        let write_tool = "<tool:write_file><param:project>test</param:project><param:path>output.txt</param:path><param:content>test</param:content></tool:write_file>";
+        let result = processor.process(&StreamingChunk::Text(write_tool.to_string()));
+
+        // Should get the blocking error
+        assert!(
+            result.is_err(),
+            "Write tool after read tool should be blocked by SmartToolFilter"
+        );
+
+        let error_msg = result.unwrap_err().to_string();
+        assert!(
+            error_msg.contains("Tool limit reached"),
+            "Error should mention tool limit"
+        );
+
+        let fragments = test_ui.get_fragments();
+
+        // Should only have fragments for the first read tool
+        // The buffered text and write tool should have been discarded
+        assert_eq!(fragments.len(), 3);
+        assert!(matches!(fragments[0], DisplayFragment::ToolName { .. }));
+        assert!(matches!(
+            fragments[1],
+            DisplayFragment::ToolParameter { .. }
+        ));
+        assert!(matches!(fragments[2], DisplayFragment::ToolEnd { .. }));
+    }
+
+    #[test]
+    fn test_smart_filter_blocks_write_tool_immediately() {
+        let test_ui = TestUI::new();
+        let ui_arc = Arc::new(Box::new(test_ui.clone()) as Box<dyn UserInterface>);
+        let mut processor = XmlStreamProcessor::new(ui_arc, 42);
+
+        // Process a complete write tool block followed by text
+        // Write tools should block further content according to SmartToolFilter
+        let input = "<tool:write_file><param:project>test</param:project><param:path>test.txt</param:path><param:content>hello</param:content></tool:write_file>";
+        let result = processor.process(&StreamingChunk::Text(input.to_string()));
+        assert!(result.is_ok(), "Initial tool processing should succeed");
+
+        // Now try to process non-whitespace text after the complete tool block
+        let additional_text = "This should be blocked";
+        let result = processor.process(&StreamingChunk::Text(additional_text.to_string()));
+
+        // Should get the blocking error
+        assert!(
+            result.is_err(),
+            "Should get error when trying to emit non-whitespace after complete tool"
+        );
+
+        let error_msg = result.unwrap_err().to_string();
+        assert!(
+            error_msg.contains("Tool limit reached"),
+            "Error should mention tool limit"
+        );
+
+        let fragments = test_ui.get_fragments();
+
+        // Should have exactly 4 fragments: ToolName, 3 ToolParameters, ToolEnd
+        // The additional text should NOT have been processed
+        assert_eq!(fragments.len(), 5);
+        assert!(matches!(fragments[0], DisplayFragment::ToolName { .. }));
+        assert!(matches!(
+            fragments[1],
+            DisplayFragment::ToolParameter { .. }
+        ));
+        assert!(matches!(
+            fragments[2],
+            DisplayFragment::ToolParameter { .. }
+        ));
+        assert!(matches!(
+            fragments[3],
+            DisplayFragment::ToolParameter { .. }
+        ));
+        assert!(matches!(fragments[4], DisplayFragment::ToolEnd { .. }));
+    }
 }

--- a/crates/code_assistant/src/ui/ui_events.rs
+++ b/crates/code_assistant/src/ui/ui_events.rs
@@ -74,7 +74,6 @@ pub enum UiEvent {
     /// Send user message to active session (triggers agent)
     SendUserMessage { message: String, session_id: String },
     /// Update metadata for a single session without refreshing the entire list
-    #[allow(dead_code)]
     UpdateSessionMetadata { metadata: ChatMetadata },
     /// Update activity state for a single session
     UpdateSessionActivityState {
@@ -84,6 +83,7 @@ pub enum UiEvent {
     /// Queue a user message while agent is running
     QueueUserMessage { message: String, session_id: String },
     /// Request to edit pending message (move back to input)
+    #[allow(dead_code)]
     RequestPendingMessageEdit { session_id: String },
     /// Update pending message display
     UpdatePendingMessage { message: Option<String> },

--- a/crates/llm/src/aicore_converse.rs
+++ b/crates/llm/src/aicore_converse.rs
@@ -658,6 +658,9 @@ impl AiCoreClient {
                 )?;
             }
 
+            // Send StreamingComplete to indicate streaming has finished
+            callback(&StreamingChunk::StreamingComplete)?;
+
             // End recording if a recorder is available
             if let Some(recorder) = &self.recorder {
                 recorder.end_recording()?;

--- a/crates/llm/src/anthropic.rs
+++ b/crates/llm/src/anthropic.rs
@@ -1080,6 +1080,9 @@ impl AnthropicClient {
                 )?;
             }
 
+            // Send StreamingComplete to indicate streaming has finished
+            callback(&StreamingChunk::StreamingComplete)?;
+
             // End recording if a recorder is available
             if let Some(recorder) = &self.recorder {
                 recorder.end_recording()?;

--- a/crates/llm/src/anthropic_playback.rs
+++ b/crates/llm/src/anthropic_playback.rs
@@ -159,6 +159,9 @@ impl LLMProvider for RecordingProvider {
                 }
             }
 
+            // Send StreamingComplete to indicate streaming has finished
+            callback(&StreamingChunk::StreamingComplete)?;
+
             // Return the final response
             Ok(response)
         } else {

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -57,6 +57,8 @@ pub enum StreamingChunk {
     RateLimit { seconds_remaining: u64 },
     /// Clear rate limit notification
     RateLimitClear,
+    /// Indicates that streaming from the LLM has completed
+    StreamingComplete,
 }
 
 pub type StreamingCallback = Box<dyn Fn(&StreamingChunk) -> Result<()> + Send + Sync>;

--- a/crates/llm/src/ollama.rs
+++ b/crates/llm/src/ollama.rs
@@ -265,6 +265,9 @@ impl OllamaClient {
             }
         }
 
+        // Send StreamingComplete to indicate streaming has finished
+        streaming_callback(&StreamingChunk::StreamingComplete)?;
+
         // Build final response
         let mut content = Vec::new();
 

--- a/crates/llm/src/openai.rs
+++ b/crates/llm/src/openai.rs
@@ -689,6 +689,9 @@ impl OpenAIClient {
             )?;
         }
 
+        // Send StreamingComplete to indicate streaming has finished
+        streaming_callback(&StreamingChunk::StreamingComplete)?;
+
         let mut content = Vec::new();
         if let Some(text) = accumulated_content {
             content.push(ContentBlock::Text { text });

--- a/crates/llm/src/vertex.rs
+++ b/crates/llm/src/vertex.rs
@@ -654,6 +654,9 @@ impl VertexClient {
             )?;
         }
 
+        // Send StreamingComplete to indicate streaming has finished
+        streaming_callback(&StreamingChunk::StreamingComplete)?;
+
         // End recording if a recorder is available
         if let Some(recorder) = &self.recorder {
             recorder.end_recording()?;


### PR DESCRIPTION
There is now the concept of a ToolFilter. The SmartToolFilter allows chaining multiple read-only tool invocations, also with content and thinking in between. But it blocks streaming more content after a write tool. If the LLM has streamed content after one ore more read-only tool calls, and then outputs a writing tool call, the content after the last read-only tool is also blocked/truncated. In the streaming processors, this is achieved by buffering all streaming chunks after the first tool call.