### PR TITLE
Multi instance safety

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1411,6 +1411,7 @@ dependencies = [
  "derive_more 2.1.1",
  "dirs 5.0.1",
  "dotenv",
+ "fs2",
  "fs_explorer",
  "futures",
  "git",
@@ -2735,6 +2736,16 @@ dependencies = [
  "cc",
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1424,6 +1424,7 @@ dependencies = [
  "keepawake",
  "llm",
  "md5",
+ "notify",
  "open",
  "percent-encoding",
  "rand 0.8.5",

--- a/crates/code_assistant/Cargo.toml
+++ b/crates/code_assistant/Cargo.toml
@@ -22,6 +22,7 @@ tokio = { version = "1.48", features = ["full"] }
 futures = "0.3"
 tempfile = "3.23"
 fs2 = "0.4"
+notify = { version = "7", features = ["macos_fsevent"] }
 
 # Terminal UI
 rustyline = "12.0.0"

--- a/crates/code_assistant/Cargo.toml
+++ b/crates/code_assistant/Cargo.toml
@@ -21,6 +21,7 @@ percent-encoding = "2.3"
 tokio = { version = "1.48", features = ["full"] }
 futures = "0.3"
 tempfile = "3.23"
+fs2 = "0.4"
 
 # Terminal UI
 rustyline = "12.0.0"

--- a/crates/code_assistant/assets/icons/lock.svg
+++ b/crates/code_assistant/assets/icons/lock.svg
@@ -1,0 +1,5 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="3.5" y="7" width="9" height="6.5" rx="1.5" stroke="black" stroke-width="1.5"/>
+<path d="M5.5 7V5C5.5 3.61929 6.61929 2.5 8 2.5C9.38071 2.5 10.5 3.61929 10.5 5V7" stroke="black" stroke-width="1.5" stroke-linecap="round"/>
+<circle cx="8" cy="10" r="1" fill="black"/>
+</svg>

--- a/crates/code_assistant/src/acp/ui.rs
+++ b/crates/code_assistant/src/acp/ui.rs
@@ -735,7 +735,8 @@ impl UserInterface for ACPUserUI {
             | UiEvent::RollbackStreaming { .. }
             | UiEvent::ShowTransientStatus { .. }
             | UiEvent::ClearTransientStatus
-            | UiEvent::RefreshCurrentSession { .. } => {
+            | UiEvent::RefreshCurrentSession { .. }
+            | UiEvent::AppendMessages { .. } => {
                 // These are UI management events, not relevant for ACP
                 // (RollbackStreaming: ACP cannot retract already-sent notifications)
             }

--- a/crates/code_assistant/src/acp/ui.rs
+++ b/crates/code_assistant/src/acp/ui.rs
@@ -734,7 +734,8 @@ impl UserInterface for ACPUserUI {
             | UiEvent::UpdateBranchInfo { .. }
             | UiEvent::RollbackStreaming { .. }
             | UiEvent::ShowTransientStatus { .. }
-            | UiEvent::ClearTransientStatus => {
+            | UiEvent::ClearTransientStatus
+            | UiEvent::RefreshCurrentSession { .. } => {
                 // These are UI management events, not relevant for ACP
                 // (RollbackStreaming: ACP cannot retract already-sent notifications)
             }

--- a/crates/code_assistant/src/acp/ui.rs
+++ b/crates/code_assistant/src/acp/ui.rs
@@ -711,7 +711,7 @@ impl UserInterface for ACPUserUI {
             // Events that don't translate to ACP
             UiEvent::SetMessages { .. }
             | UiEvent::DisplayCompactionSummary { .. }
-            | UiEvent::StreamingStarted(_)
+            | UiEvent::StreamingStarted { .. }
             | UiEvent::StreamingStopped { .. }
             | UiEvent::RefreshChatList
             | UiEvent::UpdateChatList { .. }

--- a/crates/code_assistant/src/agent/persistence.rs
+++ b/crates/code_assistant/src/agent/persistence.rs
@@ -169,9 +169,8 @@ impl AgentStatePersistence for FileStatePersistence {
         session.next_request_id = next_request_id.unwrap_or(0);
         session.updated_at = SystemTime::now();
 
-        // Save to file
-        let json = serde_json::to_string_pretty(&session)?;
-        std::fs::write(&self.state_file_path, json)?;
+        // Save atomically
+        crate::utils::file_utils::atomic_write_json(&self.state_file_path, &session)?;
 
         debug!("Agent state saved successfully");
         Ok(())

--- a/crates/code_assistant/src/agent/runner.rs
+++ b/crates/code_assistant/src/agent/runner.rs
@@ -94,8 +94,8 @@ pub struct Agent {
     session_name: String,
     // Whether to inject naming reminders (disabled for tests)
     enable_naming_reminders: bool,
-    // Shared pending message with SessionInstance
-    pending_message_ref: Option<Arc<Mutex<Option<String>>>>,
+    // Shared pending message with SessionInstance (structured content blocks)
+    pending_message_ref: Option<Arc<Mutex<Option<Vec<llm::ContentBlock>>>>>,
     // File trees for projects (used in system prompt)
     file_trees: HashMap<String, String>,
     // Available project names (used in system prompt)
@@ -189,7 +189,10 @@ impl Agent {
     }
 
     /// Set the shared pending message reference from SessionInstance
-    pub fn set_pending_message_ref(&mut self, pending_ref: Arc<Mutex<Option<String>>>) {
+    pub fn set_pending_message_ref(
+        &mut self,
+        pending_ref: Arc<Mutex<Option<Vec<llm::ContentBlock>>>>,
+    ) {
         self.pending_message_ref = Some(pending_ref);
     }
 
@@ -244,7 +247,7 @@ impl Agent {
     }
 
     /// Get and clear the pending message from shared state
-    fn get_and_clear_pending_message(&self) -> Option<String> {
+    fn get_and_clear_pending_message(&self) -> Option<Vec<llm::ContentBlock>> {
         if let Some(ref pending_ref) = self.pending_message_ref {
             let mut pending = pending_ref.lock().ok()?;
             pending.take()
@@ -414,14 +417,15 @@ impl Agent {
 
         loop {
             // Check for pending user message and add it to history at start of each iteration
-            if let Some(pending_message) = self.get_and_clear_pending_message() {
-                debug!("Processing pending user message: {}", pending_message);
-                self.append_message(Message::new_user(pending_message.clone()))?;
+            if let Some(pending_blocks) = self.get_and_clear_pending_message() {
+                let text_summary = crate::utils::content::text_summary_from_blocks(&pending_blocks);
+                debug!("Processing pending user message: {}", text_summary);
+                self.append_message(Message::new_user_content(pending_blocks))?;
 
                 // Notify UI about the user message
                 self.ui
                     .send_event(UiEvent::DisplayUserInput {
-                        content: pending_message,
+                        content: text_summary,
                         attachments: Vec::new(),
                         node_id: None, // Pending messages don't have node_id yet
                     })

--- a/crates/code_assistant/src/agent/runner.rs
+++ b/crates/code_assistant/src/agent/runner.rs
@@ -363,13 +363,24 @@ impl Agent {
         Ok(())
     }
 
-    /// Adds a message to the history and saves the state.
-    /// This adds the message to both the tree structure and the linearized history.
-    pub fn append_message(&mut self, message: Message) -> Result<()> {
-        // Add to tree structure
-        let parent_id = self.active_path.last().copied();
-        let node_id = self.next_node_id;
+    /// Pre-allocate the next node_id without creating a node.
+    /// The returned ID is guaranteed to be used by the next `append_message` call
+    /// (or `append_message_with_node_id`).
+    pub fn reserve_node_id(&mut self) -> crate::persistence::NodeId {
+        let id = self.next_node_id;
         self.next_node_id += 1;
+        id
+    }
+
+    /// Adds a message to the history using a pre-allocated node_id.
+    /// Use `reserve_node_id()` to obtain the ID before streaming starts,
+    /// then call this after streaming completes.
+    pub fn append_message_with_node_id(
+        &mut self,
+        message: Message,
+        node_id: crate::persistence::NodeId,
+    ) -> Result<()> {
+        let parent_id = self.active_path.last().copied();
 
         let node = crate::persistence::MessageNode {
             id: node_id,
@@ -387,6 +398,14 @@ impl Agent {
 
         self.save_state()?;
         Ok(())
+    }
+
+    /// Adds a message to the history and saves the state.
+    /// This adds the message to both the tree structure and the linearized history.
+    /// Allocates a new node_id automatically.
+    pub fn append_message(&mut self, message: Message) -> Result<()> {
+        let node_id = self.reserve_node_id();
+        self.append_message_with_node_id(message, node_id)
     }
 
     /// Save the current plan state as a snapshot on the last assistant message in the tree.
@@ -439,8 +458,17 @@ impl Agent {
 
             let messages = self.render_tool_results_in_messages();
 
+            // Pre-allocate the node_id for this assistant message.
+            // This is passed to the UI with StreamingStarted so the container
+            // is tagged from the start, and then used in append_message_with_node_id
+            // to guarantee the same ID is persisted.
+            let reserved_node_id = self.reserve_node_id();
+
             // 1. Get LLM response (without adding to history yet)
-            let (llm_response, request_id) = match self.get_next_assistant_message(messages).await {
+            let (llm_response, request_id) = match self
+                .get_next_assistant_message(messages, reserved_node_id)
+                .await
+            {
                 Ok(result) => {
                     // Successful response — reset the retry counter
                     streaming_retry_count = 0;
@@ -523,12 +551,13 @@ impl Agent {
                 Err(e) => return Err(e),
             };
 
-            // 2. Add original LLM response to message history if it has content
+            // 2. Add original LLM response to message history using the pre-allocated node_id
             if !llm_response.content.is_empty() {
-                self.append_message(
+                self.append_message_with_node_id(
                     Message::new_assistant_content(llm_response.content.clone())
                         .with_request_id(request_id)
                         .with_usage(llm_response.usage.clone()),
+                    reserved_node_id,
                 )?;
             }
 
@@ -1393,9 +1422,12 @@ impl Agent {
     }
 
     /// Gets the next assistant message from the LLM provider.
+    /// `node_id` is the pre-allocated persistence node ID for this assistant message,
+    /// sent to the UI with `StreamingStarted` so the container is tagged from the start.
     async fn get_next_assistant_message(
         &mut self,
         messages: Vec<Message>,
+        node_id: crate::persistence::NodeId,
     ) -> Result<(llm::LLMResponse, u64)> {
         // Generate and increment request ID
         let request_id = self.next_request_id;
@@ -1403,9 +1435,15 @@ impl Agent {
 
         // Inform UI that a new LLM request is starting
         self.ui
-            .send_event(UiEvent::StreamingStarted(request_id))
+            .send_event(UiEvent::StreamingStarted {
+                request_id,
+                node_id,
+            })
             .await?;
-        debug!("Starting LLM request with ID: {}", request_id);
+        debug!(
+            "Starting LLM request with ID: {}, node_id: {}",
+            request_id, node_id
+        );
 
         // Inject naming reminder if session is not named yet
         let messages_with_reminder = self.inject_naming_reminder_if_needed(messages);

--- a/crates/code_assistant/src/agent/sub_agent.rs
+++ b/crates/code_assistant/src/agent/sub_agent.rs
@@ -693,7 +693,7 @@ impl UserInterface for SubAgentUiAdapter {
                 self.send_output_update().await;
             }
 
-            UiEvent::StreamingStarted(_) => {
+            UiEvent::StreamingStarted { .. } => {
                 tracing::debug!("SubAgentUiAdapter: StreamingStarted");
                 self.set_activity(SubAgentActivity::Streaming);
                 self.send_output_update().await;

--- a/crates/code_assistant/src/app/gpui.rs
+++ b/crates/code_assistant/src/app/gpui.rs
@@ -1,5 +1,6 @@
 use super::AgentRunConfig;
 use crate::config::DefaultProjectManager;
+use crate::session::watcher::SessionWatcher;
 use crate::session::{SessionConfig, SessionManager};
 use crate::ui::gpui::terminal_executor::GpuiTerminalCommandExecutor;
 use crate::ui::{self, UserInterface};
@@ -7,7 +8,7 @@ use anyhow::Result;
 use llm::factory::create_llm_client_from_model;
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 pub fn run(config: AgentRunConfig) -> Result<()> {
     // Create shared state between GUI and backend
@@ -36,6 +37,10 @@ pub fn run(config: AgentRunConfig) -> Result<()> {
     let default_model = config.model.clone();
     let base_session_model_config =
         crate::persistence::SessionModelConfig::new(default_model.clone());
+
+    // Clone persistence before it is moved into SessionManager so the
+    // filesystem watcher can use it to resolve the sessions directory.
+    let persistence_for_watcher = persistence.clone();
 
     // Create the new SessionManager
     let multi_session_manager = Arc::new(Mutex::new(SessionManager::new(
@@ -188,6 +193,25 @@ pub fn run(config: AgentRunConfig) -> Result<()> {
                     }
                 }
             }
+
+            // Start the filesystem watcher for cross-instance awareness.
+            // The watcher runs in the background and emits UI events when
+            // other code-assistant instances modify session files.
+
+            let _session_watcher = match SessionWatcher::start(
+                &persistence_for_watcher,
+                gui_for_thread.event_sender(),
+                gui_for_thread.current_session_id_ref(),
+            ) {
+                Ok(watcher) => {
+                    info!("Filesystem session watcher started");
+                    Some(watcher)
+                }
+                Err(e) => {
+                    warn!("Failed to start filesystem session watcher: {e}");
+                    None
+                }
+            };
 
             crate::ui::backend::handle_backend_events(
                 backend_event_rx,

--- a/crates/code_assistant/src/config.rs
+++ b/crates/code_assistant/src/config.rs
@@ -175,7 +175,7 @@ pub fn save_project(name: &str, project: &Project) -> Result<()> {
     let config_path = get_config_path()?;
     let mut projects = load_projects()?;
     projects.insert(name.to_string(), project.clone());
-    let content = serde_json::to_string_pretty(&projects)?;
-    std::fs::write(config_path, content)?;
+
+    crate::utils::file_utils::atomic_write_json(&config_path, &projects)?;
     Ok(())
 }

--- a/crates/code_assistant/src/persistence.rs
+++ b/crates/code_assistant/src/persistence.rs
@@ -10,6 +10,7 @@ use tracing::{debug, info, warn};
 use crate::session::SessionConfig;
 use crate::tools::ToolRequest;
 use crate::types::{PlanState, ToolSyntax};
+use crate::utils::file_utils::{atomic_write, atomic_write_json, lock_exclusive};
 
 // ============================================================================
 // Session Branching Types
@@ -568,16 +569,31 @@ impl FileSessionPersistence {
         Ok(chats_dir.join("metadata.json"))
     }
 
+    fn metadata_lock_path(&self) -> Result<PathBuf> {
+        let chats_dir = self.ensure_chats_dir()?;
+        Ok(chats_dir.join("metadata.lock"))
+    }
+
+    /// Returns the sessions directory path.
+    ///
+    /// Used by callers that need to interact with per-session lock files.
+    pub fn sessions_dir(&self) -> Result<PathBuf> {
+        self.ensure_chats_dir()
+    }
+
     pub fn save_chat_session(&mut self, session: &ChatSession) -> Result<()> {
         let mut session = session.clone();
         session.ensure_config()?;
 
         let session_path = self.chat_file_path(&session.id)?;
         debug!("Saving chat session to {}", session_path.display());
-        let json = serde_json::to_string_pretty(&session)?;
-        std::fs::write(session_path, json)?;
+        atomic_write_json(&session_path, &session)?;
 
-        // Update metadata
+        // Update metadata under an advisory lock so concurrent processes
+        // don't lose each other's changes.
+        let metadata_lock_path = self.metadata_lock_path()?;
+        let _lock = lock_exclusive(&metadata_lock_path)?;
+
         let metadata_path = self.metadata_file_path()?;
         let mut metadata_list: Vec<ChatMetadata> = if metadata_path.exists() {
             let content = std::fs::read_to_string(&metadata_path)?;
@@ -590,7 +606,6 @@ impl FileSessionPersistence {
         let (total_usage, last_usage, tokens_limit) = calculate_session_usage(&session);
 
         // Update or add metadata for this session
-
         let new_metadata = ChatMetadata {
             id: session.id.clone(),
             name: session.name.clone(),
@@ -611,8 +626,7 @@ impl FileSessionPersistence {
             metadata_list.push(new_metadata);
         }
 
-        let metadata_json = serde_json::to_string_pretty(&metadata_list)?;
-        std::fs::write(metadata_path, metadata_json)?;
+        atomic_write_json(&metadata_path, &metadata_list)?;
 
         Ok(())
     }
@@ -684,7 +698,10 @@ impl FileSessionPersistence {
             std::fs::remove_file(session_path)?;
         }
 
-        // Update metadata to remove this session
+        // Update metadata under lock
+        let metadata_lock_path = self.metadata_lock_path()?;
+        let _lock = lock_exclusive(&metadata_lock_path)?;
+
         let metadata_path = self.metadata_file_path()?;
         if metadata_path.exists() {
             let content = std::fs::read_to_string(&metadata_path)?;
@@ -693,8 +710,7 @@ impl FileSessionPersistence {
 
             metadata_list.retain(|m| m.id != session_id);
 
-            let metadata_json = serde_json::to_string_pretty(&metadata_list)?;
-            std::fs::write(metadata_path, metadata_json)?;
+            atomic_write_json(&metadata_path, &metadata_list)?;
         }
 
         Ok(())
@@ -835,11 +851,15 @@ impl FileSessionPersistence {
         Ok(metadata_list)
     }
 
-    /// Helper method to save metadata list to file
+    /// Helper method to save metadata list to file.
+    ///
+    /// Acquires the metadata lock and writes atomically.
     fn save_metadata_list(&self, metadata_list: &[ChatMetadata]) -> Result<()> {
+        let metadata_lock_path = self.metadata_lock_path()?;
+        let _lock = lock_exclusive(&metadata_lock_path)?;
+
         let metadata_path = self.metadata_file_path()?;
-        let metadata_json = serde_json::to_string_pretty(metadata_list)?;
-        std::fs::write(metadata_path, metadata_json)?;
+        atomic_write_json(&metadata_path, metadata_list)?;
         Ok(())
     }
 
@@ -1026,9 +1046,8 @@ impl DraftStorage {
         draft.set_message(text_content.to_string());
         draft.attachments = attachments.to_vec();
 
-        // Serialize and save
-        let draft_json = serde_json::to_string_pretty(&draft)?;
-        std::fs::write(&file_path, draft_json)?;
+        // Serialize and save atomically
+        atomic_write_json(&file_path, &draft)?;
 
         Ok(())
     }

--- a/crates/code_assistant/src/persistence.rs
+++ b/crates/code_assistant/src/persistence.rs
@@ -10,7 +10,7 @@ use tracing::{debug, info, warn};
 use crate::session::SessionConfig;
 use crate::tools::ToolRequest;
 use crate::types::{PlanState, ToolSyntax};
-use crate::utils::file_utils::{atomic_write, atomic_write_json, lock_exclusive};
+use crate::utils::file_utils::{atomic_write_json, lock_exclusive};
 
 // ============================================================================
 // Session Branching Types

--- a/crates/code_assistant/src/session/instance.rs
+++ b/crates/code_assistant/src/session/instance.rs
@@ -888,15 +888,38 @@ impl UserInterface for ProxyUI {
             }
         }
 
-        // First fragment indicates streaming has started - transition from WaitingForResponse
-        // But only if the agent is still running (not Idle)
-        let current_state = self
-            .session_activity_state
-            .lock()
-            .map(|s| s.clone())
-            .unwrap_or(SessionActivityState::Idle);
-        if matches!(current_state, SessionActivityState::WaitingForResponse) {
-            self.update_activity_state(SessionActivityState::AgentRunning);
+        // Transition from WaitingForResponse to AgentRunning only when the
+        // fragment actually produces something visible in the UI. Some
+        // providers emit empty deltas (e.g. an empty PlainText at the start
+        // of a content block) or purely structural events which would
+        // otherwise hide the activity spinner before any content appears in
+        // the MessagesView.
+        let has_visible_content = match fragment {
+            DisplayFragment::PlainText(s) => !s.is_empty(),
+            DisplayFragment::ThinkingText { text, .. } => !text.is_empty(),
+            DisplayFragment::ReasoningSummaryDelta(s) => !s.is_empty(),
+            DisplayFragment::ToolParameter { value, .. } => !value.is_empty(),
+            DisplayFragment::ToolOutput { chunk, .. } => !chunk.is_empty(),
+            DisplayFragment::Image { .. }
+            | DisplayFragment::ToolName { .. }
+            | DisplayFragment::ReasoningSummaryStart
+            | DisplayFragment::CompactionDivider { .. } => true,
+            DisplayFragment::ToolEnd { .. }
+            | DisplayFragment::ToolTerminal { .. }
+            | DisplayFragment::ReasoningComplete
+            | DisplayFragment::HiddenToolCompleted => false,
+        };
+
+        if has_visible_content {
+            // Only transition if the agent is still running (not Idle)
+            let current_state = self
+                .session_activity_state
+                .lock()
+                .map(|s| s.clone())
+                .unwrap_or(SessionActivityState::Idle);
+            if matches!(current_state, SessionActivityState::WaitingForResponse) {
+                self.update_activity_state(SessionActivityState::AgentRunning);
+            }
         }
 
         // Only forward to real UI if session is connected

--- a/crates/code_assistant/src/session/instance.rs
+++ b/crates/code_assistant/src/session/instance.rs
@@ -95,6 +95,19 @@ pub struct SessionInstance {
     /// or abort.  Prevents two code-assistant processes from running an
     /// agent for the same session simultaneously.
     pub agent_lock: Option<AgentLockGuard>,
+
+    /// The active_path that the UI has been told about (either via full load
+    /// or via `AppendMessages`).  Used by the file-watcher refresh logic to
+    /// determine which nodes are truly "new" and avoid duplicate appends.
+    ///
+    /// Updated when:
+    /// - A full session load sends all messages to the UI
+    /// - An incremental append tells the UI about new nodes
+    /// - A reload happens while the local agent is running (streaming covers UI)
+    pub last_ui_synced_path: crate::persistence::ConversationPath,
+
+    /// Number of tool executions the UI has been told about.
+    pub last_ui_synced_tool_count: usize,
 }
 
 impl SessionInstance {
@@ -104,6 +117,9 @@ impl SessionInstance {
         if let Some(path) = session.config.effective_project_path() {
             let _ = sandbox_context.register_root(path);
         }
+
+        let initial_path = session.active_path.clone();
+        let initial_tool_count = session.tool_executions.len();
 
         Self {
             session,
@@ -116,6 +132,8 @@ impl SessionInstance {
             sandbox_context,
             sub_agent_cancellation_registry: Arc::new(SubAgentCancellationRegistry::default()),
             agent_lock: None,
+            last_ui_synced_path: initial_path,
+            last_ui_synced_tool_count: initial_tool_count,
         }
     }
 

--- a/crates/code_assistant/src/session/instance.rs
+++ b/crates/code_assistant/src/session/instance.rs
@@ -785,7 +785,7 @@ impl UserInterface for ProxyUI {
     async fn send_event(&self, event: UiEvent) -> Result<(), UIError> {
         // Handle special events that need buffer management and activity state updates
         match &event {
-            UiEvent::StreamingStarted(_) => {
+            UiEvent::StreamingStarted { .. } => {
                 // Clear fragment buffer at start of new LLM request
                 if let Ok(mut buffer) = self.fragment_buffer.lock() {
                     buffer.clear();

--- a/crates/code_assistant/src/session/instance.rs
+++ b/crates/code_assistant/src/session/instance.rs
@@ -30,6 +30,10 @@ pub enum SessionActivityState {
     RateLimited { seconds_remaining: u64 },
     /// Agent terminated with an error
     Errored { message: String },
+    /// Agent is running in another code-assistant process.
+    /// The session is view-only in this instance: the user can browse
+    /// messages but cannot send or queue new ones.
+    RunningExternally,
 }
 
 impl SessionActivityState {
@@ -38,6 +42,12 @@ impl SessionActivityState {
     /// agent is explicitly started.
     pub fn is_terminal(&self) -> bool {
         matches!(self, Self::Idle | Self::Errored { .. })
+    }
+
+    /// Whether the session is locked by another code-assistant instance.
+    #[allow(dead_code)]
+    pub fn is_running_externally(&self) -> bool {
+        matches!(self, Self::RunningExternally)
     }
 }
 

--- a/crates/code_assistant/src/session/instance.rs
+++ b/crates/code_assistant/src/session/instance.rs
@@ -492,6 +492,111 @@ impl SessionInstance {
         Ok(messages_data)
     }
 
+    /// Convert a specific subset of nodes (by their IDs) to UI MessageData.
+    /// Used for incremental updates when new nodes are appended to the active path.
+    pub fn convert_messages_from_nodes(
+        &self,
+        node_ids: &[crate::persistence::NodeId],
+        tool_syntax: crate::types::ToolSyntax,
+    ) -> Result<Vec<MessageData>, anyhow::Error> {
+        struct DummyUI;
+        #[async_trait::async_trait]
+        impl crate::ui::UserInterface for DummyUI {
+            async fn send_event(
+                &self,
+                _event: crate::ui::UiEvent,
+            ) -> Result<(), crate::ui::UIError> {
+                Ok(())
+            }
+            fn display_fragment(
+                &self,
+                _fragment: &crate::ui::DisplayFragment,
+            ) -> Result<(), crate::ui::UIError> {
+                Ok(())
+            }
+            fn should_streaming_continue(&self) -> bool {
+                true
+            }
+            fn notify_rate_limit(&self, _seconds_remaining: u64) {}
+            fn clear_rate_limit(&self) {}
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
+            }
+        }
+
+        let dummy_ui: std::sync::Arc<dyn crate::ui::UserInterface> = std::sync::Arc::new(DummyUI);
+        let mut processor = create_stream_processor(tool_syntax, dummy_ui, 0);
+
+        let mut messages_data = Vec::new();
+
+        for &node_id in node_ids {
+            let Some(node) = self.session.message_nodes.get(&node_id) else {
+                continue;
+            };
+            let message = &node.message;
+
+            if message.is_compaction_summary {
+                let summary = match &message.content {
+                    llm::MessageContent::Text(text) => text.trim().to_string(),
+                    llm::MessageContent::Structured(blocks) => blocks
+                        .iter()
+                        .filter_map(|block| match block {
+                            llm::ContentBlock::Text { text, .. } => Some(text.as_str()),
+                            llm::ContentBlock::Thinking { thinking, .. } => Some(thinking.as_str()),
+                            _ => None,
+                        })
+                        .collect::<Vec<_>>()
+                        .join("\n")
+                        .trim()
+                        .to_string(),
+                };
+                messages_data.push(MessageData {
+                    role: MessageRole::User,
+                    fragments: vec![crate::ui::DisplayFragment::CompactionDivider { summary }],
+                    node_id: Some(node_id),
+                    branch_info: self.session.get_branch_info(node_id),
+                });
+                continue;
+            }
+
+            // Skip tool-result user messages
+            if message.role == llm::MessageRole::User {
+                match &message.content {
+                    llm::MessageContent::Text(text) if text.trim().is_empty() => continue,
+                    llm::MessageContent::Structured(blocks) => {
+                        let has_tool_results = blocks
+                            .iter()
+                            .any(|block| matches!(block, llm::ContentBlock::ToolResult { .. }));
+                        if has_tool_results {
+                            continue;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+
+            match processor.extract_fragments_from_message(message) {
+                Ok(fragments) => {
+                    let role = match message.role {
+                        llm::MessageRole::User => MessageRole::User,
+                        llm::MessageRole::Assistant => MessageRole::Assistant,
+                    };
+                    messages_data.push(MessageData {
+                        role,
+                        fragments,
+                        node_id: Some(node_id),
+                        branch_info: self.session.get_branch_info(node_id),
+                    });
+                }
+                Err(e) => {
+                    error!("Failed to extract fragments from message: {}", e);
+                }
+            }
+        }
+
+        Ok(messages_data)
+    }
+
     /// Convert tool executions to UI tool result data
     pub fn convert_tool_executions_to_ui_data(
         &self,

--- a/crates/code_assistant/src/session/instance.rs
+++ b/crates/code_assistant/src/session/instance.rs
@@ -11,6 +11,7 @@ use crate::ui::gpui::elements::MessageRole;
 use crate::ui::streaming::create_stream_processor;
 use crate::ui::ui_events::{MessageData, UiEvent};
 use crate::ui::{DisplayFragment, UIError, UserInterface};
+use crate::utils::file_utils::AgentLockGuard;
 use async_trait::async_trait;
 use sandbox::SandboxContext;
 use tracing::{debug, error};
@@ -78,6 +79,13 @@ pub struct SessionInstance {
 
     /// Cancellation registry for sub-agents running in agent tasks
     pub sub_agent_cancellation_registry: Arc<SubAgentCancellationRegistry>,
+
+    /// Exclusive cross-process lock held while an agent is running.
+    ///
+    /// Acquired before spawning the agent task, released on task completion
+    /// or abort.  Prevents two code-assistant processes from running an
+    /// agent for the same session simultaneously.
+    pub agent_lock: Option<AgentLockGuard>,
 }
 
 impl SessionInstance {
@@ -98,6 +106,7 @@ impl SessionInstance {
             pending_message: Arc::new(Mutex::new(None)),
             sandbox_context,
             sub_agent_cancellation_registry: Arc::new(SubAgentCancellationRegistry::default()),
+            agent_lock: None,
         }
     }
 
@@ -137,12 +146,14 @@ impl SessionInstance {
         }
     }
 
-    /// Terminate the running agent
+    /// Terminate the running agent and release the cross-process agent lock.
     pub fn terminate_agent(&mut self) {
         if let Some(handle) = self.task_handle.take() {
             handle.abort();
             self.clear_fragment_buffer();
         }
+        // Release the cross-process agent lock
+        self.agent_lock = None;
     }
 
     /// Add a message with optional branching support.

--- a/crates/code_assistant/src/session/instance.rs
+++ b/crates/code_assistant/src/session/instance.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use llm::Message;
+use llm::{ContentBlock, Message};
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 use tokio::task::JoinHandle;
@@ -80,8 +80,8 @@ pub struct SessionInstance {
     /// Current activity state of this session
     pub activity_state: Arc<Mutex<SessionActivityState>>,
 
-    /// Pending user message that will be processed by the next agent iteration
-    pub pending_message: Arc<Mutex<Option<String>>>,
+    /// Pending user message (structured content blocks) that will be processed by the next agent iteration
+    pub pending_message: Arc<Mutex<Option<Vec<ContentBlock>>>>,
 
     /// Tracks sandbox-approved roots for this session
     pub sandbox_context: Arc<SandboxContext>,
@@ -349,7 +349,9 @@ impl SessionInstance {
 
         if let Ok(pending) = self.pending_message.lock() {
             events.push(UiEvent::UpdatePendingMessage {
-                message: pending.clone(),
+                message: pending
+                    .as_ref()
+                    .map(|blocks| crate::utils::content::text_summary_from_blocks(blocks)),
             });
         }
 

--- a/crates/code_assistant/src/session/instance.rs
+++ b/crates/code_assistant/src/session/instance.rs
@@ -45,7 +45,6 @@ impl SessionActivityState {
     }
 
     /// Whether the session is locked by another code-assistant instance.
-    #[allow(dead_code)]
     pub fn is_running_externally(&self) -> bool {
         matches!(self, Self::RunningExternally)
     }

--- a/crates/code_assistant/src/session/manager.rs
+++ b/crates/code_assistant/src/session/manager.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use llm::Message;
+use llm::{ContentBlock, Message};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -1041,31 +1041,17 @@ impl SessionManager {
         }
     }
 
-    /// Queue a user message for a running agent session
+    /// Queue a text-only user message for a running agent session
+    #[allow(dead_code)]
     pub fn queue_user_message(&mut self, session_id: &str, message: String) -> Result<()> {
-        // Get the active session instance and update shared pending message
-        let session_instance = self
-            .active_sessions
-            .get(session_id)
-            .ok_or_else(|| anyhow::anyhow!("Session not found: {session_id}"))?;
-
-        // Update the shared pending message
-        let mut pending = session_instance.pending_message.lock().unwrap();
-        match pending.as_mut() {
-            Some(existing) => {
-                // Append to existing message with newline separator
-                if !existing.is_empty() && !existing.ends_with('\n') {
-                    existing.push('\n');
-                }
-                existing.push_str(&message);
-            }
-            None => {
-                // Set as new pending message
-                *pending = Some(message);
-            }
-        }
-
-        Ok(())
+        self.queue_structured_user_message(
+            session_id,
+            vec![ContentBlock::Text {
+                text: message,
+                start_time: None,
+                end_time: None,
+            }],
+        )
     }
 
     /// Check for completed agent tasks and handle their results
@@ -1128,26 +1114,28 @@ impl SessionManager {
     pub fn queue_structured_user_message(
         &mut self,
         session_id: &str,
-        content_blocks: Vec<llm::ContentBlock>,
+        content_blocks: Vec<ContentBlock>,
     ) -> Result<()> {
-        // For now, convert structured content to text representation for pending messages
-        // In the future, we could extend pending messages to support structured content
-        let text_representation = content_blocks
-            .iter()
-            .filter_map(|block| match block {
-                llm::ContentBlock::Text { text, .. } => Some(text.clone()),
-                llm::ContentBlock::Image { media_type, .. } => {
-                    Some(format!("[Image: {media_type}]"))
-                }
-                _ => None,
-            })
-            .collect::<Vec<_>>()
-            .join("\n");
+        let session_instance = self
+            .active_sessions
+            .get(session_id)
+            .ok_or_else(|| anyhow::anyhow!("Session not found: {session_id}"))?;
 
-        self.queue_user_message(session_id, text_representation)
+        let mut pending = session_instance.pending_message.lock().unwrap();
+        match pending.as_mut() {
+            Some(existing) => {
+                // Append new content blocks to existing pending blocks
+                existing.extend(content_blocks);
+            }
+            None => {
+                *pending = Some(content_blocks);
+            }
+        }
+
+        Ok(())
     }
 
-    /// Get and clear pending message for editing
+    /// Get and clear pending message for editing (returns text-only summary for UI)
     pub fn request_pending_message_for_edit(&mut self, session_id: &str) -> Result<Option<String>> {
         // Get the active session instance and take the pending message
         let session_instance = self
@@ -1156,10 +1144,12 @@ impl SessionManager {
             .ok_or_else(|| anyhow::anyhow!("Session not found: {session_id}"))?;
 
         let mut pending = session_instance.pending_message.lock().unwrap();
-        Ok(pending.take())
+        Ok(pending
+            .take()
+            .map(|blocks| crate::utils::content::text_summary_from_blocks(&blocks)))
     }
 
-    /// Get current pending message without clearing it
+    /// Get current pending message text summary without clearing it
     pub fn get_pending_message(&self, session_id: &str) -> Result<Option<String>> {
         let session_instance = self
             .active_sessions
@@ -1167,6 +1157,8 @@ impl SessionManager {
             .ok_or_else(|| anyhow::anyhow!("Session not found: {session_id}"))?;
 
         let pending = session_instance.pending_message.lock().unwrap();
-        Ok(pending.clone())
+        Ok(pending
+            .as_ref()
+            .map(|blocks| crate::utils::content::text_summary_from_blocks(blocks)))
     }
 }

--- a/crates/code_assistant/src/session/manager.rs
+++ b/crates/code_assistant/src/session/manager.rs
@@ -272,11 +272,14 @@ impl SessionManager {
             .get_mut(session_id)
             .ok_or_else(|| anyhow::anyhow!("Session not found: {session_id}"))?;
 
-        // If the agent is running locally on this session, skip the refresh.
-        // Streaming events already keep the UI up-to-date; reloading from
-        // persistence would produce duplicates.
+        // If the agent is running locally on this session, don't emit any
+        // events (streaming already keeps the UI up-to-date). But DO reload
+        // from persistence so that `active_path` stays in sync — otherwise
+        // the first refresh after the agent finishes would see the entire
+        // turn as "new" and append duplicates.
         let activity = session_instance.get_activity_state();
         if !activity.is_terminal() && !activity.is_running_externally() {
+            session_instance.reload_from_persistence(&self.persistence)?;
             return Ok(Vec::new());
         }
 

--- a/crates/code_assistant/src/session/manager.rs
+++ b/crates/code_assistant/src/session/manager.rs
@@ -272,6 +272,14 @@ impl SessionManager {
             .get_mut(session_id)
             .ok_or_else(|| anyhow::anyhow!("Session not found: {session_id}"))?;
 
+        // If the agent is running locally on this session, skip the refresh.
+        // Streaming events already keep the UI up-to-date; reloading from
+        // persistence would produce duplicates.
+        let activity = session_instance.get_activity_state();
+        if !activity.is_terminal() && !activity.is_running_externally() {
+            return Ok(Vec::new());
+        }
+
         // Capture old active path before reload
         let old_path = session_instance.session.active_path.clone();
         let old_tool_count = session_instance.session.tool_executions.len();

--- a/crates/code_assistant/src/session/manager.rs
+++ b/crates/code_assistant/src/session/manager.rs
@@ -289,9 +289,25 @@ impl SessionManager {
 
         let new_path = &session_instance.session.active_path;
 
-        // Case 1: Paths are identical → no-op
-        if *new_path == old_path {
+        let new_tool_count = session_instance.session.tool_executions.len();
+
+        // Case 1: Paths identical and no new tool results → true no-op
+        if *new_path == old_path && new_tool_count == old_tool_count {
             return Ok(Vec::new());
+        }
+
+        // Case 1b: Paths identical but new tool results appeared
+        if *new_path == old_path {
+            let all_tool_results = session_instance.convert_tool_executions_to_ui_data()?;
+            let new_tool_results: Vec<_> =
+                all_tool_results.into_iter().skip(old_tool_count).collect();
+            if new_tool_results.is_empty() {
+                return Ok(Vec::new());
+            }
+            return Ok(vec![UiEvent::AppendMessages {
+                messages: Vec::new(),
+                tool_results: new_tool_results,
+            }]);
         }
 
         // Case 2: Old path is a strict prefix of new path → append-only
@@ -311,11 +327,12 @@ impl SessionManager {
 
             // Collect tool results that are new since last time
             let all_tool_results = session_instance.convert_tool_executions_to_ui_data()?;
-            let new_tool_results = all_tool_results.into_iter().skip(old_tool_count).collect();
+            let new_tool_results: Vec<_> =
+                all_tool_results.into_iter().skip(old_tool_count).collect();
 
             let mut events = Vec::new();
 
-            if !messages_data.is_empty() {
+            if !messages_data.is_empty() || !new_tool_results.is_empty() {
                 events.push(UiEvent::AppendMessages {
                     messages: messages_data,
                     tool_results: new_tool_results,

--- a/crates/code_assistant/src/session/manager.rs
+++ b/crates/code_assistant/src/session/manager.rs
@@ -231,6 +231,19 @@ impl SessionManager {
             policy: sandbox_policy_for_event,
         });
 
+        // Check if another process holds the agent lock for this session.
+        // If so, mark it as RunningExternally so the UI disables input.
+        if self.is_agent_locked_externally(&session_id) {
+            debug!(
+                "Session {} has an agent running in another process",
+                session_id
+            );
+            ui_events.push(UiEvent::UpdateSessionActivityState {
+                session_id: session_id.clone(),
+                activity_state: crate::session::instance::SessionActivityState::RunningExternally,
+            });
+        }
+
         // Set as active
         self.active_session_id = Some(session_id.clone());
 
@@ -340,7 +353,6 @@ impl SessionManager {
 
     /// Start an agent for a session (message must already be added via add_user_message)
     #[allow(clippy::too_many_arguments)]
-
     pub async fn start_agent_for_session(
         &mut self,
         session_id: &str,

--- a/crates/code_assistant/src/session/manager.rs
+++ b/crates/code_assistant/src/session/manager.rs
@@ -215,7 +215,12 @@ impl SessionManager {
         // Generate UI events for connecting to this session
         let mut ui_events = {
             let session_instance = self.active_sessions.get_mut(&session_id).unwrap();
-            session_instance.generate_session_connect_events()?
+            let events = session_instance.generate_session_connect_events()?;
+            // Mark what the UI now knows about (baseline for future incremental diffs)
+            session_instance.last_ui_synced_path = session_instance.session.active_path.clone();
+            session_instance.last_ui_synced_tool_count =
+                session_instance.session.tool_executions.len();
+            events
         };
 
         ui_events.push(UiEvent::UpdateCurrentModel {
@@ -262,10 +267,19 @@ impl SessionManager {
     /// Incremental refresh of the currently viewed session.
     ///
     /// Reloads the session from persistence and compares the on-disk
-    /// `active_path` with the in-memory version.  Returns:
-    /// - `Ok(vec![])` if nothing changed (our own writes)
-    /// - `Ok(vec![AppendMessages { .. }])` if new nodes were appended
+    /// `active_path` against `last_ui_synced_path` (what the UI already shows).
+    ///
+    /// Returns:
+    /// - `Ok(vec![])` if nothing changed or the UI already has these messages
+    /// - `Ok(vec![AppendMessages { .. }])` if new nodes were appended externally
     /// - `Ok(vec![SetMessages { .. }])` if the paths diverged (full reload fallback)
+    ///
+    /// The key insight: we compare against `last_ui_synced_path` rather than
+    /// the pre-reload `session.active_path`. This eliminates the race between
+    /// a locally running agent's final `save_state()` and the file-watcher
+    /// debounce — even if the state has already transitioned to Idle by the
+    /// time the debounce fires, `last_ui_synced_path` was advanced during
+    /// prior "while running" reloads, so no spurious diff is detected.
     pub fn refresh_session_incremental(&mut self, session_id: &str) -> Result<Vec<UiEvent>> {
         let session_instance = self
             .active_sessions
@@ -274,55 +288,63 @@ impl SessionManager {
 
         // If the agent is running locally on this session, don't emit any
         // events (streaming already keeps the UI up-to-date). But DO reload
-        // from persistence so that `active_path` stays in sync — otherwise
-        // the first refresh after the agent finishes would see the entire
-        // turn as "new" and append duplicates.
+        // from persistence so that `last_ui_synced_path` stays in sync —
+        // this prevents the first refresh after Idle from seeing everything
+        // as "new".
         let activity = session_instance.get_activity_state();
         if !activity.is_terminal() && !activity.is_running_externally() {
             session_instance.reload_from_persistence(&self.persistence)?;
+            // Advance the UI-synced baseline to match what's on disk,
+            // since the local streaming UI is keeping up in real-time.
+            session_instance.last_ui_synced_path = session_instance.session.active_path.clone();
+            session_instance.last_ui_synced_tool_count =
+                session_instance.session.tool_executions.len();
             return Ok(Vec::new());
         }
-
-        // Capture old active path before reload
-        let old_path = session_instance.session.active_path.clone();
-        let old_tool_count = session_instance.session.tool_executions.len();
 
         // Reload from disk
         session_instance.reload_from_persistence(&self.persistence)?;
 
-        let new_path = &session_instance.session.active_path;
-
+        let new_path = session_instance.session.active_path.clone();
         let new_tool_count = session_instance.session.tool_executions.len();
 
+        // Compare against what the UI already has (not the pre-reload disk state).
+        let synced_path = &session_instance.last_ui_synced_path;
+        let synced_tool_count = session_instance.last_ui_synced_tool_count;
+
         // Case 1: Paths identical and no new tool results → true no-op
-        if *new_path == old_path && new_tool_count == old_tool_count {
+        if new_path == *synced_path && new_tool_count == synced_tool_count {
             return Ok(Vec::new());
         }
 
         // Case 1b: Paths identical but new tool results appeared
-        if *new_path == old_path {
+        if new_path == *synced_path {
             let all_tool_results = session_instance.convert_tool_executions_to_ui_data()?;
-            let new_tool_results: Vec<_> =
-                all_tool_results.into_iter().skip(old_tool_count).collect();
+            let new_tool_results: Vec<_> = all_tool_results
+                .into_iter()
+                .skip(synced_tool_count)
+                .collect();
             if new_tool_results.is_empty() {
                 return Ok(Vec::new());
             }
+            // Advance baseline
+            session_instance.last_ui_synced_tool_count = new_tool_count;
             return Ok(vec![UiEvent::AppendMessages {
                 messages: Vec::new(),
                 tool_results: new_tool_results,
             }]);
         }
 
-        // Case 2: Old path is a strict prefix of new path → append-only
-        if new_path.len() > old_path.len() && new_path.starts_with(&old_path) {
+        // Case 2: Synced path is a strict prefix of new path → append-only
+        if new_path.len() > synced_path.len() && new_path.starts_with(synced_path) {
             debug!(
                 "Incremental refresh for {session_id}: {} new node(s)",
-                new_path.len() - old_path.len()
+                new_path.len() - synced_path.len()
             );
 
             // Convert only the new nodes to MessageData
             let tool_syntax = session_instance.session.config.tool_syntax;
-            let new_node_ids = &new_path[old_path.len()..];
+            let new_node_ids = &new_path[synced_path.len()..];
 
             // Build messages for the new nodes only
             let messages_data =
@@ -330,8 +352,10 @@ impl SessionManager {
 
             // Collect tool results that are new since last time
             let all_tool_results = session_instance.convert_tool_executions_to_ui_data()?;
-            let new_tool_results: Vec<_> =
-                all_tool_results.into_iter().skip(old_tool_count).collect();
+            let new_tool_results: Vec<_> = all_tool_results
+                .into_iter()
+                .skip(synced_tool_count)
+                .collect();
 
             let mut events = Vec::new();
 
@@ -347,12 +371,19 @@ impl SessionManager {
                 plan: session_instance.session.plan.clone(),
             });
 
+            // Advance baseline
+            session_instance.last_ui_synced_path = new_path;
+            session_instance.last_ui_synced_tool_count = new_tool_count;
+
             return Ok(events);
         }
 
         // Case 3: Paths diverged → full reload fallback
         debug!("Incremental refresh for {session_id}: paths diverged, full reload");
         let ui_events = session_instance.generate_session_connect_events()?;
+        // After full reload, reset baseline to current disk state
+        session_instance.last_ui_synced_path = session_instance.session.active_path.clone();
+        session_instance.last_ui_synced_tool_count = session_instance.session.tool_executions.len();
         Ok(ui_events)
     }
 

--- a/crates/code_assistant/src/session/manager.rs
+++ b/crates/code_assistant/src/session/manager.rs
@@ -286,16 +286,12 @@ impl SessionManager {
             .get_mut(session_id)
             .ok_or_else(|| anyhow::anyhow!("Session not found: {session_id}"))?;
 
-        // If the agent is running locally on this session, don't emit any
-        // events (streaming already keeps the UI up-to-date). But DO reload
-        // from persistence so that `last_ui_synced_path` stays in sync —
-        // this prevents the first refresh after Idle from seeing everything
-        // as "new".
+        // If the agent is running locally, streaming keeps the UI up-to-date.
+        // Just reload from persistence to advance the baseline so future diffs
+        // (after the agent finishes) don't see already-streamed content as "new".
         let activity = session_instance.get_activity_state();
         if !activity.is_terminal() && !activity.is_running_externally() {
             session_instance.reload_from_persistence(&self.persistence)?;
-            // Advance the UI-synced baseline to match what's on disk,
-            // since the local streaming UI is keeping up in real-time.
             session_instance.last_ui_synced_path = session_instance.session.active_path.clone();
             session_instance.last_ui_synced_tool_count =
                 session_instance.session.tool_executions.len();
@@ -312,7 +308,7 @@ impl SessionManager {
         let synced_path = &session_instance.last_ui_synced_path;
         let synced_tool_count = session_instance.last_ui_synced_tool_count;
 
-        // Case 1: Paths identical and no new tool results → true no-op
+        // Case 1: Paths identical and no new tool results → no-op
         if new_path == *synced_path && new_tool_count == synced_tool_count {
             return Ok(Vec::new());
         }
@@ -327,7 +323,6 @@ impl SessionManager {
             if new_tool_results.is_empty() {
                 return Ok(Vec::new());
             }
-            // Advance baseline
             session_instance.last_ui_synced_tool_count = new_tool_count;
             return Ok(vec![UiEvent::AppendMessages {
                 messages: Vec::new(),
@@ -335,22 +330,19 @@ impl SessionManager {
             }]);
         }
 
-        // Case 2: Synced path is a strict prefix of new path → append-only
+        // Case 2: Synced path is a strict prefix of new path → append only new nodes
         if new_path.len() > synced_path.len() && new_path.starts_with(synced_path) {
             debug!(
                 "Incremental refresh for {session_id}: {} new node(s)",
                 new_path.len() - synced_path.len()
             );
 
-            // Convert only the new nodes to MessageData
             let tool_syntax = session_instance.session.config.tool_syntax;
             let new_node_ids = &new_path[synced_path.len()..];
 
-            // Build messages for the new nodes only
             let messages_data =
                 session_instance.convert_messages_from_nodes(new_node_ids, tool_syntax)?;
 
-            // Collect tool results that are new since last time
             let all_tool_results = session_instance.convert_tool_executions_to_ui_data()?;
             let new_tool_results: Vec<_> = all_tool_results
                 .into_iter()
@@ -366,22 +358,19 @@ impl SessionManager {
                 });
             }
 
-            // Always update plan (may have changed independently of messages)
             events.push(UiEvent::UpdatePlan {
                 plan: session_instance.session.plan.clone(),
             });
 
-            // Advance baseline
             session_instance.last_ui_synced_path = new_path;
             session_instance.last_ui_synced_tool_count = new_tool_count;
 
             return Ok(events);
         }
 
-        // Case 3: Paths diverged → full reload fallback
+        // Case 3: Paths diverged → full reload
         debug!("Incremental refresh for {session_id}: paths diverged, full reload");
         let ui_events = session_instance.generate_session_connect_events()?;
-        // After full reload, reset baseline to current disk state
         session_instance.last_ui_synced_path = session_instance.session.active_path.clone();
         session_instance.last_ui_synced_tool_count = session_instance.session.tool_executions.len();
         Ok(ui_events)
@@ -411,6 +400,11 @@ impl SessionManager {
         // Save the session state with the new message
         self.persistence
             .save_chat_session(&session_instance.session)?;
+
+        // Advance the UI-synced baseline: the user message is displayed immediately
+        // by the UI, so the file watcher should not treat it as "new".
+        session_instance.last_ui_synced_path = session_instance.session.active_path.clone();
+        session_instance.last_ui_synced_tool_count = session_instance.session.tool_executions.len();
 
         Ok(node_id)
     }

--- a/crates/code_assistant/src/session/manager.rs
+++ b/crates/code_assistant/src/session/manager.rs
@@ -17,6 +17,7 @@ use crate::session::sleep_inhibitor::SleepInhibitor;
 use crate::session::{SessionConfig, SessionState};
 use crate::ui::ui_events::UiEvent;
 use crate::ui::UserInterface;
+use crate::utils::file_utils;
 use command_executor::{CommandExecutor, SandboxedCommandExecutor};
 use llm::LLMProvider;
 use sandbox::SandboxPolicy;
@@ -339,6 +340,7 @@ impl SessionManager {
 
     /// Start an agent for a session (message must already be added via add_user_message)
     #[allow(clippy::too_many_arguments)]
+
     pub async fn start_agent_for_session(
         &mut self,
         session_id: &str,
@@ -348,6 +350,18 @@ impl SessionManager {
         ui: Arc<dyn UserInterface>,
         permission_handler: Option<Arc<dyn PermissionMediator>>,
     ) -> Result<()> {
+        // Acquire exclusive cross-process agent lock.
+        // This prevents another code-assistant instance from running an agent
+        // for the same session concurrently.
+        let sessions_dir = self.persistence.sessions_dir()?;
+        let agent_lock = file_utils::try_acquire_agent_lock(&sessions_dir, session_id)?
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Cannot start agent for session {session_id}: \
+                     another code-assistant instance is already running an agent for this session"
+                )
+            })?;
+
         // Prepare session - need to scope the mutable borrow carefully
         let (
             session_config,
@@ -489,13 +503,18 @@ impl SessionManager {
         // Load the session state into the agent
         agent.load_from_session_state(session_state).await?;
 
-        // Spawn the agent task
+        // Spawn the agent task.
+        //
+        // The `_agent_lock` guard is moved into the task so the cross-process
+        // lock is held for exactly as long as the agent is running and released
+        // automatically on completion, error, panic, or task abort.
         let session_id_clone = session_id.to_string();
         let ui_clone = ui.clone();
         let sleep_inhibitor = self.sleep_inhibitor.clone();
         sleep_inhibitor.agent_started();
 
         let task_handle = tokio::spawn(async move {
+            let _agent_lock = agent_lock; // moved in — released on drop
             debug!("Starting agent for session {}", session_id_clone);
 
             // Use catch_unwind to ensure cleanup runs even if the agent panics.
@@ -796,6 +815,25 @@ impl SessionManager {
         }
 
         None
+    }
+
+    /// Check whether a session's agent lock is held by another process.
+    ///
+    /// Returns `true` if an external process is running an agent for this
+    /// session. Used by the UI to decide whether to disable the message input.
+    pub fn is_agent_locked_externally(&self, session_id: &str) -> bool {
+        // If *we* have the session in our active_sessions with a running task,
+        // the lock is ours, not external.
+        if let Some(instance) = self.active_sessions.get(session_id) {
+            if !instance.get_activity_state().is_terminal() {
+                return false; // Our own agent holds the lock
+            }
+        }
+
+        let Ok(sessions_dir) = self.persistence.sessions_dir() else {
+            return false;
+        };
+        file_utils::is_agent_locked(&sessions_dir, session_id)
     }
 
     /// Get the latest session ID for auto-resuming

--- a/crates/code_assistant/src/session/manager.rs
+++ b/crates/code_assistant/src/session/manager.rs
@@ -259,6 +259,75 @@ impl SessionManager {
         Ok(ui_events)
     }
 
+    /// Incremental refresh of the currently viewed session.
+    ///
+    /// Reloads the session from persistence and compares the on-disk
+    /// `active_path` with the in-memory version.  Returns:
+    /// - `Ok(vec![])` if nothing changed (our own writes)
+    /// - `Ok(vec![AppendMessages { .. }])` if new nodes were appended
+    /// - `Ok(vec![SetMessages { .. }])` if the paths diverged (full reload fallback)
+    pub fn refresh_session_incremental(&mut self, session_id: &str) -> Result<Vec<UiEvent>> {
+        let session_instance = self
+            .active_sessions
+            .get_mut(session_id)
+            .ok_or_else(|| anyhow::anyhow!("Session not found: {session_id}"))?;
+
+        // Capture old active path before reload
+        let old_path = session_instance.session.active_path.clone();
+        let old_tool_count = session_instance.session.tool_executions.len();
+
+        // Reload from disk
+        session_instance.reload_from_persistence(&self.persistence)?;
+
+        let new_path = &session_instance.session.active_path;
+
+        // Case 1: Paths are identical → no-op
+        if *new_path == old_path {
+            return Ok(Vec::new());
+        }
+
+        // Case 2: Old path is a strict prefix of new path → append-only
+        if new_path.len() > old_path.len() && new_path.starts_with(&old_path) {
+            debug!(
+                "Incremental refresh for {session_id}: {} new node(s)",
+                new_path.len() - old_path.len()
+            );
+
+            // Convert only the new nodes to MessageData
+            let tool_syntax = session_instance.session.config.tool_syntax;
+            let new_node_ids = &new_path[old_path.len()..];
+
+            // Build messages for the new nodes only
+            let messages_data =
+                session_instance.convert_messages_from_nodes(new_node_ids, tool_syntax)?;
+
+            // Collect tool results that are new since last time
+            let all_tool_results = session_instance.convert_tool_executions_to_ui_data()?;
+            let new_tool_results = all_tool_results.into_iter().skip(old_tool_count).collect();
+
+            let mut events = Vec::new();
+
+            if !messages_data.is_empty() {
+                events.push(UiEvent::AppendMessages {
+                    messages: messages_data,
+                    tool_results: new_tool_results,
+                });
+            }
+
+            // Always update plan (may have changed independently of messages)
+            events.push(UiEvent::UpdatePlan {
+                plan: session_instance.session.plan.clone(),
+            });
+
+            return Ok(events);
+        }
+
+        // Case 3: Paths diverged → full reload fallback
+        debug!("Incremental refresh for {session_id}: paths diverged, full reload");
+        let ui_events = session_instance.generate_session_connect_events()?;
+        Ok(ui_events)
+    }
+
     /// Add a user message to a session and return the new node_id.
     /// This is used to add the message before displaying it in the UI,
     /// ensuring the node_id is available for the edit button.

--- a/crates/code_assistant/src/session/mod.rs
+++ b/crates/code_assistant/src/session/mod.rs
@@ -11,6 +11,7 @@ use std::path::PathBuf;
 pub mod instance;
 pub mod manager;
 pub mod sleep_inhibitor;
+pub mod watcher;
 
 // Main session manager
 pub use manager::SessionManager;

--- a/crates/code_assistant/src/session/watcher.rs
+++ b/crates/code_assistant/src/session/watcher.rs
@@ -1,0 +1,213 @@
+//! Filesystem watcher for cross-instance session awareness.
+//!
+//! Monitors the sessions directory for changes made by other code-assistant
+//! processes and emits UI events so the current instance stays up to date.
+//!
+//! # Watched events
+//!
+//! | File pattern | Trigger | UI effect |
+//! |---|---|---|
+//! | `metadata.json` | Create / Modify / Remove | Refresh sidebar session list |
+//! | `<session_id>.json` | Modify | Reload session if currently viewed |
+//! | `<session_id>.agent.lock` | Create / Remove | Update activity state (agent running elsewhere) |
+//!
+//! # Cross-platform notes
+//!
+//! The `notify` crate uses the platform-native backend:
+//! - **macOS**: FSEvents (via the `macos_fsevent` feature)
+//! - **Linux**: inotify
+//! - **Windows**: ReadDirectoryChangesW
+//!
+//! Different backends produce different event sequences for the same logical
+//! operation.  For example, an atomic write (tmp + rename) may generate
+//! `Create` + `Modify` on some platforms, a single `Modify` on others, or
+//! even multiple `Modify` events in quick succession.
+//!
+//! To handle this, the watcher collects raw events into a set of *dirty
+//! files* and flushes them on a debounce timer.  This guarantees at most one
+//! UI reaction per logical change, regardless of platform.
+
+use crate::persistence::FileSessionPersistence;
+use crate::session::instance::SessionActivityState;
+use crate::ui::ui_events::UiEvent;
+use crate::utils::file_utils;
+
+use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher};
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tracing::{debug, trace, warn};
+
+/// How long to wait after the last filesystem event before flushing.
+/// Short enough to feel responsive, long enough to coalesce bursts.
+const DEBOUNCE_DURATION: Duration = Duration::from_millis(300);
+
+/// A handle to the background filesystem watcher.
+///
+/// Dropping this stops the watcher.
+pub struct SessionWatcher {
+    _watcher: RecommendedWatcher,
+}
+
+/// Categorised dirty-file set, accumulated between debounce flushes.
+#[derive(Default)]
+struct DirtySet {
+    /// `metadata.json` was touched → refresh sidebar.
+    metadata_dirty: bool,
+    /// Session JSON files that changed on disk.
+    /// We only reload the currently-viewed one, but we track all of them
+    /// in case the user switches sessions between accumulation and flush.
+    changed_session_ids: HashSet<String>,
+    /// Agent lock files that appeared or disappeared.
+    changed_agent_locks: HashSet<String>,
+}
+
+impl SessionWatcher {
+    /// Start watching the sessions directory.
+    ///
+    /// `event_tx` is used to push UI events (e.g. `RefreshChatList`,
+    /// `UpdateSessionActivityState`) into the existing event loop.
+    ///
+    /// `current_session_id` is read at flush time to decide whether a
+    /// session-file change requires reloading the currently viewed session.
+    pub fn start(
+        persistence: &FileSessionPersistence,
+        event_tx: async_channel::Sender<UiEvent>,
+        current_session_id: Arc<Mutex<Option<String>>>,
+    ) -> anyhow::Result<Self> {
+        let sessions_dir = persistence.sessions_dir()?;
+        debug!("Starting filesystem watcher on {}", sessions_dir.display());
+
+        let dirty = Arc::new(Mutex::new(DirtySet::default()));
+
+        // --- notify callback (sync, runs on notify's background thread) ---
+        let dirty_for_callback = dirty.clone();
+        let mut watcher =
+            notify::recommended_watcher(move |res: Result<Event, notify::Error>| match res {
+                Ok(event) => accumulate_event(&dirty_for_callback, &event),
+                Err(e) => warn!("Filesystem watcher error: {e}"),
+            })?;
+
+        watcher.watch(&sessions_dir, RecursiveMode::NonRecursive)?;
+
+        // --- debounce flush task (async, runs on the tokio runtime) ---
+        let rt = tokio::runtime::Handle::current();
+        rt.spawn(flush_loop(
+            dirty,
+            sessions_dir,
+            event_tx,
+            current_session_id,
+        ));
+
+        Ok(Self { _watcher: watcher })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Accumulate (sync, notify thread)
+// ---------------------------------------------------------------------------
+
+/// Classify a raw filesystem event and add it to the dirty set.
+fn accumulate_event(dirty: &Mutex<DirtySet>, event: &Event) {
+    for path in &event.paths {
+        let Some(file_name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+
+        let mut set = dirty.lock().unwrap();
+
+        if file_name == "metadata.json" {
+            trace!("Watcher: metadata.json changed ({:?})", event.kind);
+            set.metadata_dirty = true;
+            continue;
+        }
+
+        if let Some(session_id) = file_name.strip_suffix(".agent.lock") {
+            trace!(
+                "Watcher: agent lock changed for {session_id} ({:?})",
+                event.kind
+            );
+            set.changed_agent_locks.insert(session_id.to_string());
+            continue;
+        }
+
+        if let Some(session_id) = file_name.strip_suffix(".json") {
+            // Skip non-session JSON files
+            if session_id.ends_with(".ui_state") || session_id == "metadata" {
+                continue;
+            }
+            trace!(
+                "Watcher: session file changed for {session_id} ({:?})",
+                event.kind
+            );
+            set.changed_session_ids.insert(session_id.to_string());
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Flush (async, tokio runtime)
+// ---------------------------------------------------------------------------
+
+/// Periodically drain the dirty set and emit UI events.
+async fn flush_loop(
+    dirty: Arc<Mutex<DirtySet>>,
+    sessions_dir: PathBuf,
+    event_tx: async_channel::Sender<UiEvent>,
+    current_session_id: Arc<Mutex<Option<String>>>,
+) {
+    loop {
+        tokio::time::sleep(DEBOUNCE_DURATION).await;
+
+        // Take the dirty set (swap with a fresh default).
+        let snapshot = {
+            let mut set = dirty.lock().unwrap();
+            std::mem::take(&mut *set)
+        };
+
+        // Nothing to do?
+        if !snapshot.metadata_dirty
+            && snapshot.changed_session_ids.is_empty()
+            && snapshot.changed_agent_locks.is_empty()
+        {
+            continue;
+        }
+
+        // 1) Sidebar refresh
+        if snapshot.metadata_dirty {
+            debug!("Watcher flush: refreshing chat list");
+            let _ = event_tx.try_send(UiEvent::RefreshChatList);
+        }
+
+        // 2) Agent lock changes → activity state updates
+        for session_id in &snapshot.changed_agent_locks {
+            let is_locked = file_utils::is_agent_locked(&sessions_dir, session_id);
+
+            let activity_state = if is_locked {
+                SessionActivityState::AgentRunning
+            } else {
+                SessionActivityState::Idle
+            };
+
+            debug!("Watcher flush: agent lock for {session_id} → {activity_state:?}");
+            let _ = event_tx.try_send(UiEvent::UpdateSessionActivityState {
+                session_id: session_id.clone(),
+                activity_state,
+            });
+        }
+
+        // 3) Session file changes → reload currently viewed session
+        if !snapshot.changed_session_ids.is_empty() {
+            let current = current_session_id.lock().unwrap().clone();
+            if let Some(current_id) = current {
+                if snapshot.changed_session_ids.contains(&current_id) {
+                    debug!("Watcher flush: reloading current session {current_id}");
+                    let _ = event_tx.try_send(UiEvent::RefreshCurrentSession {
+                        session_id: current_id,
+                    });
+                }
+            }
+        }
+    }
+}

--- a/crates/code_assistant/src/session/watcher.rs
+++ b/crates/code_assistant/src/session/watcher.rs
@@ -181,11 +181,38 @@ async fn flush_loop(
         }
 
         // 2) Agent lock changes → activity state updates
+        //
+        // The watcher exists to mirror the activity of agents running in
+        // *other* code-assistant instances.  For locks held by our own
+        // process the local SessionManager / ProxyUI track the activity
+        // state with much finer granularity (WaitingForResponse,
+        // RateLimited, Errored, …).  Overwriting those with the coarse
+        // AgentRunning derived from the lock file would e.g. hide the
+        // pre-stream spinner as soon as the lock file appears — which is
+        // before any fragment has arrived.
+        //
+        // Therefore: if the lock file belongs to us (PID matches), skip the
+        // event entirely.  For foreign locks we emit RunningExternally so
+        // the UI shows the "session blocked" state (disabled input, lock
+        // icon in sidebar).  When a lock disappears we also skip if we can
+        // no longer tell who owned it from our side — the local agent, if
+        // it was ours, will have already broadcast Idle via the
+        // SessionManager cleanup path.
         for session_id in &snapshot.changed_agent_locks {
             let is_locked = file_utils::is_agent_locked(&sessions_dir, session_id);
+            let belongs_to_us =
+                file_utils::agent_lock_belongs_to_current_process(&sessions_dir, session_id);
+
+            if belongs_to_us {
+                trace!(
+                    "Watcher flush: skipping agent lock event for own session {session_id} \
+                     (locked={is_locked})"
+                );
+                continue;
+            }
 
             let activity_state = if is_locked {
-                SessionActivityState::AgentRunning
+                SessionActivityState::RunningExternally
             } else {
                 SessionActivityState::Idle
             };

--- a/crates/code_assistant/src/tools/impls/read_files.rs
+++ b/crates/code_assistant/src/tools/impls/read_files.rs
@@ -34,12 +34,16 @@ pub struct ReadFilesInput {
     pub project: String,
     pub paths: Vec<String>,
     /// If true, prefix each line with its line number (1-indexed)
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "is_false")]
     pub prefix_line_numbers: bool,
     /// If true, bypass the file size limit check. Use when you explicitly need to read
     /// a large file in full.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "is_false")]
     pub ignore_size_limit: bool,
+}
+
+fn is_false(b: &bool) -> bool {
+    !b
 }
 
 /// Content of a loaded file with optional line offset information

--- a/crates/code_assistant/src/ui/backend.rs
+++ b/crates/code_assistant/src/ui/backend.rs
@@ -12,7 +12,7 @@ use sandbox::SandboxPolicy;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use tracing::{debug, error, info, trace};
+use tracing::{debug, error, info, trace, warn};
 
 // Unified event type for all UI→Backend communication
 #[derive(Debug, Clone)]
@@ -107,6 +107,13 @@ pub enum BackendEvent {
 
     /// Clear the Errored state on a session (user dismissed the error banner)
     ClearSessionError {
+        session_id: String,
+    },
+
+    /// Incremental session refresh triggered by the file watcher.
+    /// Compares the on-disk state with the in-memory state and emits only
+    /// the delta (new messages appended by an external process).
+    RefreshSession {
         session_id: String,
     },
 }
@@ -363,6 +370,10 @@ pub async fn handle_backend_events(
                     .await;
                 None // No backend response needed
             }
+
+            BackendEvent::RefreshSession { session_id } => {
+                handle_refresh_session(&multi_session_manager, &session_id, &ui).await
+            }
         };
 
         // Send response back to UI only if there is one
@@ -465,6 +476,39 @@ async fn handle_load_session(
             Some(BackendResponse::Error {
                 message: e.to_string(),
             })
+        }
+    }
+}
+
+async fn handle_refresh_session(
+    multi_session_manager: &Arc<Mutex<SessionManager>>,
+    session_id: &str,
+    ui: &Arc<dyn UserInterface>,
+) -> Option<BackendResponse> {
+    let ui_events_result = {
+        let mut manager = multi_session_manager.lock().await;
+        manager.refresh_session_incremental(session_id)
+    };
+
+    match ui_events_result {
+        Ok(ui_events) => {
+            if !ui_events.is_empty() {
+                trace!(
+                    "Incremental refresh for {session_id}: {} UI events",
+                    ui_events.len()
+                );
+                for event in ui_events {
+                    if let Err(e) = ui.send_event(event).await {
+                        error!("Failed to send UI event: {}", e);
+                    }
+                }
+            }
+            None
+        }
+        Err(e) => {
+            warn!("Incremental refresh failed for {session_id}, falling back: {e}");
+            // Fall back to full reload
+            handle_load_session(multi_session_manager, session_id, ui).await
         }
     }
 }

--- a/crates/code_assistant/src/ui/gpui/chat_sidebar.rs
+++ b/crates/code_assistant/src/ui/gpui/chat_sidebar.rs
@@ -134,7 +134,9 @@ impl Render for ChatListItem {
         let is_active = !matches!(self.activity_state, SessionActivityState::Idle);
         let is_errored = matches!(self.activity_state, SessionActivityState::Errored { .. });
         let activity_color = match &self.activity_state {
-            SessionActivityState::AgentRunning => cx.theme().info,
+            SessionActivityState::AgentRunning | SessionActivityState::RunningExternally => {
+                cx.theme().info
+            }
             SessionActivityState::WaitingForResponse => cx.theme().primary,
             SessionActivityState::RateLimited { .. } => cx.theme().warning,
             SessionActivityState::Errored { .. } => cx.theme().danger,

--- a/crates/code_assistant/src/ui/gpui/chat_sidebar.rs
+++ b/crates/code_assistant/src/ui/gpui/chat_sidebar.rs
@@ -133,10 +133,11 @@ impl Render for ChatListItem {
 
         let is_active = !matches!(self.activity_state, SessionActivityState::Idle);
         let is_errored = matches!(self.activity_state, SessionActivityState::Errored { .. });
+        let is_externally_locked =
+            matches!(self.activity_state, SessionActivityState::RunningExternally);
         let activity_color = match &self.activity_state {
-            SessionActivityState::AgentRunning | SessionActivityState::RunningExternally => {
-                cx.theme().info
-            }
+            SessionActivityState::AgentRunning => cx.theme().info,
+            SessionActivityState::RunningExternally => cx.theme().warning,
             SessionActivityState::WaitingForResponse => cx.theme().primary,
             SessionActivityState::RateLimited { .. } => cx.theme().warning,
             SessionActivityState::Errored { .. } => cx.theme().danger,
@@ -194,7 +195,15 @@ impl Render for ChatListItem {
                                 .text_color(activity_color),
                         )
                     })
-                    .when(is_active && !is_errored, |el| {
+                    .when(is_externally_locked, |el| {
+                        el.child(
+                            gpui::svg()
+                                .size(px(12.))
+                                .path("icons/lock.svg")
+                                .text_color(activity_color),
+                        )
+                    })
+                    .when(is_active && !is_errored && !is_externally_locked, |el| {
                         el.child(
                             gpui::svg()
                                 .size(px(12.))

--- a/crates/code_assistant/src/ui/gpui/elements.rs
+++ b/crates/code_assistant/src/ui/gpui/elements.rs
@@ -14,7 +14,7 @@ use std::cell::Cell;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use tracing::{trace, warn};
+use tracing::{debug, trace, warn};
 
 /// Maximum height for rendered images in pixels
 const MAX_IMAGE_HEIGHT: f32 = 80.0;
@@ -836,7 +836,7 @@ impl MessageContainer {
             }
         }
 
-        warn!(
+        debug!(
             "GPUI replace_tool_parameter: tool block not found for tool_id='{}', param='{}'",
             tool_id, name
         );

--- a/crates/code_assistant/src/ui/gpui/input_area.rs
+++ b/crates/code_assistant/src/ui/gpui/input_area.rs
@@ -69,6 +69,7 @@ pub struct InputArea {
     // Agent state for button rendering
     agent_is_running: bool,
     cancel_enabled: bool,
+    externally_locked: bool,
 
     // Context usage ratio (0.0–1.0)
     context_usage_ratio: Option<f32>,
@@ -123,6 +124,7 @@ impl InputArea {
 
             agent_is_running: false,
             cancel_enabled: false,
+            externally_locked: false,
             context_usage_ratio: None,
 
             branch_parent_id: None,
@@ -249,9 +251,15 @@ impl InputArea {
     }
 
     /// Update agent state for button rendering
-    pub fn set_agent_state(&mut self, agent_is_running: bool, cancel_enabled: bool) {
+    pub fn set_agent_state(
+        &mut self,
+        agent_is_running: bool,
+        cancel_enabled: bool,
+        externally_locked: bool,
+    ) {
         self.agent_is_running = agent_is_running;
         self.cancel_enabled = cancel_enabled;
+        self.externally_locked = externally_locked;
     }
 
     /// Update the context usage ratio (0.0–1.0)
@@ -549,6 +557,33 @@ impl InputArea {
                         ),
                 )
             })
+            // Externally locked banner
+            .when(self.externally_locked, |parent| {
+                parent.child(
+                    div()
+                        .px_3()
+                        .py_2()
+                        .bg(cx.theme().warning.opacity(0.1))
+                        .border_b_1()
+                        .border_color(cx.theme().warning.opacity(0.3))
+                        .flex()
+                        .flex_row()
+                        .items_center()
+                        .gap_2()
+                        .child(
+                            Icon::default()
+                                .path(SharedString::from("icons/lock.svg"))
+                                .text_color(cx.theme().warning)
+                                .size(px(14.)),
+                        )
+                        .child(
+                            div()
+                                .text_sm()
+                                .text_color(cx.theme().warning)
+                                .child("Session is active in another instance"),
+                        ),
+                )
+            })
             // Attachments area - show image previews when available
             .when(!self.attachments.is_empty(), |parent| {
                 parent.child(
@@ -571,6 +606,7 @@ impl InputArea {
                     .items_start()
                     .p_2()
                     .gap_2()
+                    .when(self.externally_locked, |el| el.opacity(0.45))
                     // Left column: text field + selector row (share same width)
                     .child(
                         div()
@@ -655,8 +691,8 @@ impl InputArea {
                             .children({
                                 let mut buttons = Vec::new();
 
-                                // Send button - enabled when input has content
-                                let send_enabled = has_input_content;
+                                // Send button - enabled when input has content and not externally locked
+                                let send_enabled = has_input_content && !self.externally_locked;
 
                                 let mut send_button = div()
                                     .id("send-btn")

--- a/crates/code_assistant/src/ui/gpui/mod.rs
+++ b/crates/code_assistant/src/ui/gpui/mod.rs
@@ -1379,6 +1379,19 @@ impl Gpui {
                 cx.refresh().expect("Failed to refresh windows");
             }
 
+            UiEvent::RefreshCurrentSession { session_id } => {
+                // Another process modified the session file on disk.
+                // Re-trigger the load-session flow which reloads from
+                // persistence and rebuilds the message list.
+                debug!("UI: RefreshCurrentSession for {session_id}");
+                let current = self.current_session_id.lock().unwrap().clone();
+                if current.as_deref() == Some(session_id.as_str()) {
+                    if let Some(sender) = self.backend_event_sender.lock().unwrap().as_ref() {
+                        let _ = sender.try_send(BackendEvent::LoadSession { session_id });
+                    }
+                }
+            }
+
             // Resource events - logged for now, can be extended for features like "follow mode"
             UiEvent::ResourceLoaded { project, path } => {
                 trace!(
@@ -1826,6 +1839,20 @@ impl Gpui {
 
     pub fn get_current_session_id(&self) -> Option<String> {
         self.current_session_id.lock().unwrap().clone()
+    }
+
+    /// Returns a clone of the shared current-session-id mutex.
+    ///
+    /// Used by the filesystem watcher to know which session is being viewed.
+    pub fn current_session_id_ref(&self) -> Arc<Mutex<Option<String>>> {
+        self.current_session_id.clone()
+    }
+
+    /// Returns a clone of the UI event sender channel.
+    ///
+    /// Used by the filesystem watcher to inject events into the UI loop.
+    pub fn event_sender(&self) -> async_channel::Sender<UiEvent> {
+        self.event_sender.lock().unwrap().clone()
     }
 
     pub fn get_current_error(&self) -> Option<String> {

--- a/crates/code_assistant/src/ui/gpui/mod.rs
+++ b/crates/code_assistant/src/ui/gpui/mod.rs
@@ -1016,9 +1016,10 @@ impl Gpui {
                 tool_results,
             } => {
                 // Incremental update: append new messages without clearing existing ones.
-                // Safety net: deduplicate by node_id to avoid double-appending messages
-                // that the UI already has (e.g. due to race between agent Idle transition
-                // and file-watcher debounce).
+                // Deduplicate by node_id to avoid double-appending messages that the UI
+                // already has (e.g. due to race between agent Idle transition and
+                // file-watcher debounce — the streaming container already has the
+                // pre-allocated node_id).
                 let existing_node_ids: std::collections::HashSet<crate::persistence::NodeId> = {
                     let queue = self.message_queue.lock().unwrap();
                     queue
@@ -1030,18 +1031,18 @@ impl Gpui {
                         })
                         .collect()
                 };
+
                 let messages: Vec<_> = messages
                     .into_iter()
                     .filter(|msg| match msg.node_id {
                         Some(id) if existing_node_ids.contains(&id) => {
-                            trace!("AppendMessages: skipping duplicate node_id {}", id);
+                            debug!("AppendMessages: skipping duplicate node_id {}", id);
                             false
                         }
                         _ => true,
                     })
                     .collect();
                 if messages.is_empty() && tool_results.is_empty() {
-                    // Nothing new to append after deduplication
                     return;
                 }
 
@@ -1143,7 +1144,10 @@ impl Gpui {
                 self.notify_messages_appended(old_len, cx);
             }
 
-            UiEvent::StreamingStarted(request_id) => {
+            UiEvent::StreamingStarted {
+                request_id,
+                node_id,
+            } => {
                 let old_len;
                 {
                     let mut queue = self.message_queue.lock().unwrap();
@@ -1161,23 +1165,25 @@ impl Gpui {
                     };
 
                     if needs_new_container {
-                        // Create new assistant container
+                        // Create new assistant container with pre-allocated node_id
                         let sid = self.current_session_id.lock().unwrap().clone();
                         let assistant_container = cx
                             .new(|cx| {
                                 let container =
                                     MessageContainer::with_role(MessageRole::Assistant, cx);
                                 container.set_current_request_id(request_id);
+                                container.set_node_id(Some(node_id));
                                 container.set_session_id(sid);
                                 container
                             })
                             .expect("Failed to create new container");
                         queue.push(assistant_container);
                     } else if let Some(last_container) = last_container {
-                        // Reuse existing container — no push, just update request_id
+                        // Reuse existing container — no push, just update request_id and node_id
                         drop(queue);
                         self.update_container(&last_container, cx, |container, cx| {
                             container.set_current_request_id(request_id);
+                            container.set_node_id(Some(node_id));
                             cx.notify();
                         });
                         return;
@@ -1321,7 +1327,7 @@ impl Gpui {
                 activity_state,
             } => {
                 debug!(
-                    "UI: UpdateSessionActivityState event for session {} with state {:?}",
+                    "UI: UpdateSessionActivityState for session {} → {:?}",
                     session_id, activity_state
                 );
 
@@ -2461,9 +2467,8 @@ impl UserInterface for Gpui {
     async fn send_event(&self, event: UiEvent) -> Result<(), UIError> {
         // Handle special events that need state management
         match &event {
-            UiEvent::StreamingStarted(request_id) => {
+            UiEvent::StreamingStarted { request_id, .. } => {
                 // Store the request ID
-
                 *self.current_request_id.lock().unwrap() = *request_id;
                 // Clear any existing error/notification when new operation starts
                 *self.current_error.lock().unwrap() = None;

--- a/crates/code_assistant/src/ui/gpui/mod.rs
+++ b/crates/code_assistant/src/ui/gpui/mod.rs
@@ -1016,6 +1016,35 @@ impl Gpui {
                 tool_results,
             } => {
                 // Incremental update: append new messages without clearing existing ones.
+                // Safety net: deduplicate by node_id to avoid double-appending messages
+                // that the UI already has (e.g. due to race between agent Idle transition
+                // and file-watcher debounce).
+                let existing_node_ids: std::collections::HashSet<crate::persistence::NodeId> = {
+                    let queue = self.message_queue.lock().unwrap();
+                    queue
+                        .iter()
+                        .filter_map(|container| {
+                            cx.update_entity(container, |c, _cx| c.node_id())
+                                .ok()
+                                .flatten()
+                        })
+                        .collect()
+                };
+                let messages: Vec<_> = messages
+                    .into_iter()
+                    .filter(|msg| match msg.node_id {
+                        Some(id) if existing_node_ids.contains(&id) => {
+                            trace!("AppendMessages: skipping duplicate node_id {}", id);
+                            false
+                        }
+                        _ => true,
+                    })
+                    .collect();
+                if messages.is_empty() && tool_results.is_empty() {
+                    // Nothing new to append after deduplication
+                    return;
+                }
+
                 let old_len = self.message_queue.lock().unwrap().len();
 
                 let current_project = {

--- a/crates/code_assistant/src/ui/gpui/mod.rs
+++ b/crates/code_assistant/src/ui/gpui/mod.rs
@@ -311,8 +311,11 @@ impl Gpui {
         self.update_messages_view(cx, |view, cx| {
             if view.follow_tail {
                 view.scroll_to_bottom();
-                cx.notify(); // Trigger render so animation task can be spawned
             }
+            // Always notify so the list re-renders visible items that gained
+            // new blocks (e.g. thinking blocks created inside an existing
+            // MessageContainer).
+            cx.notify();
         });
     }
 

--- a/crates/code_assistant/src/ui/gpui/mod.rs
+++ b/crates/code_assistant/src/ui/gpui/mod.rs
@@ -1008,6 +1008,109 @@ impl Gpui {
                 self.notify_messages_reset(cx);
             }
 
+            UiEvent::AppendMessages {
+                messages,
+                tool_results,
+            } => {
+                // Incremental update: append new messages without clearing existing ones.
+                let old_len = self.message_queue.lock().unwrap().len();
+
+                let current_project = {
+                    let sid = self.current_session_id.lock().unwrap().clone();
+                    if let Some(ref session_id) = sid {
+                        let sessions = self.chat_sessions.lock().unwrap();
+                        sessions
+                            .iter()
+                            .find(|s| s.id == *session_id)
+                            .map(|s| s.initial_project.clone())
+                            .unwrap_or_default()
+                    } else {
+                        String::new()
+                    }
+                };
+
+                let session_id = self.current_session_id.lock().unwrap().clone();
+
+                for message_data in messages {
+                    let current_container = {
+                        let mut queue = self.message_queue.lock().unwrap();
+
+                        let needs_new_container = if let Some(last_container) = queue.last() {
+                            let last_role = cx
+                                .update_entity(last_container, |container, _cx| {
+                                    if container.is_user_message() {
+                                        MessageRole::User
+                                    } else {
+                                        MessageRole::Assistant
+                                    }
+                                })
+                                .expect("Failed to get container role");
+                            last_role == MessageRole::User || last_role != message_data.role
+                        } else {
+                            true
+                        };
+
+                        if needs_new_container {
+                            let container = cx
+                                .new(|cx| {
+                                    MessageContainer::with_role(message_data.role.clone(), cx)
+                                })
+                                .expect("Failed to create message container");
+
+                            let node_id = message_data.node_id;
+                            let branch_info = message_data.branch_info.clone();
+                            let sid = session_id.clone();
+                            self.update_container(&container, cx, |container, _cx| {
+                                container.set_current_project(current_project.clone());
+                                container.set_node_id(node_id);
+                                container.set_branch_info(branch_info);
+                                container.set_session_id(sid);
+                            });
+
+                            queue.push(container.clone());
+                            container
+                        } else {
+                            let container = queue.last().unwrap().clone();
+                            let sid = session_id.clone();
+                            self.update_container(&container, cx, |container, _cx| {
+                                container.set_current_project(current_project.clone());
+                                container.set_session_id(sid);
+                            });
+                            container
+                        }
+                    };
+
+                    self.process_fragments_for_container(
+                        &current_container,
+                        message_data.fragments,
+                        cx,
+                    );
+                }
+
+                // Apply tool results
+                for tool_result in tool_results {
+                    let ui_images: Vec<(String, String)> = tool_result
+                        .images
+                        .iter()
+                        .map(|img| (img.media_type.clone(), img.base64_data.clone()))
+                        .collect();
+                    self.update_all_messages(cx, |message_container, cx| {
+                        message_container.update_tool_status(
+                            &tool_result.tool_id,
+                            tool_result.status,
+                            tool_result.message.clone(),
+                            tool_result.output.clone(),
+                            tool_result.styled_output.clone(),
+                            tool_result.duration_seconds,
+                            ui_images.clone(),
+                            cx,
+                        );
+                    });
+                }
+
+                self.notify_messages_appended(old_len, cx);
+            }
+
             UiEvent::StreamingStarted(request_id) => {
                 let old_len;
                 {
@@ -1381,13 +1484,13 @@ impl Gpui {
 
             UiEvent::RefreshCurrentSession { session_id } => {
                 // Another process modified the session file on disk.
-                // Re-trigger the load-session flow which reloads from
-                // persistence and rebuilds the message list.
+                // Use incremental refresh which diffs the active path and only
+                // appends new messages (no-op if we wrote the change ourselves).
                 debug!("UI: RefreshCurrentSession for {session_id}");
                 let current = self.current_session_id.lock().unwrap().clone();
                 if current.as_deref() == Some(session_id.as_str()) {
                     if let Some(sender) = self.backend_event_sender.lock().unwrap().as_ref() {
-                        let _ = sender.try_send(BackendEvent::LoadSession { session_id });
+                        let _ = sender.try_send(BackendEvent::RefreshSession { session_id });
                     }
                 }
             }

--- a/crates/code_assistant/src/ui/gpui/root.rs
+++ b/crates/code_assistant/src/ui/gpui/root.rs
@@ -1276,13 +1276,17 @@ impl Render for RootView {
         }
 
         // Update InputArea with current agent state
+        let externally_locked = current_activity_state
+            .as_ref()
+            .is_some_and(|s| s.is_running_externally());
+
         let agent_is_running = if let Some(state) = &current_activity_state {
             !state.is_terminal()
         } else {
             false
         };
 
-        let cancel_enabled = if agent_is_running {
+        let cancel_enabled = if agent_is_running && !externally_locked {
             if let (Some(gpui), Some(session_id)) = (cx.try_global::<Gpui>(), &current_session_id) {
                 !gpui
                     .session_stop_requests
@@ -1315,7 +1319,7 @@ impl Render for RootView {
             });
 
         self.input_area.update(cx, |input_area, _cx| {
-            input_area.set_agent_state(agent_is_running, cancel_enabled);
+            input_area.set_agent_state(agent_is_running, cancel_enabled, externally_locked);
             input_area.set_context_usage_ratio(context_usage_ratio);
         });
 

--- a/crates/code_assistant/src/ui/gpui/root.rs
+++ b/crates/code_assistant/src/ui/gpui/root.rs
@@ -686,6 +686,18 @@ impl RootView {
                 None
             };
 
+            let is_externally_locked = matches!(
+                current_activity_state,
+                Some(crate::session::instance::SessionActivityState::RunningExternally)
+            );
+            if is_externally_locked {
+                tracing::warn!(
+                    "RootView: Cannot send message — session {} is running in another instance",
+                    session_id
+                );
+                return;
+            }
+
             let agent_is_running = if let Some(state) = current_activity_state {
                 !state.is_terminal()
             } else {

--- a/crates/code_assistant/src/ui/gpui/root.rs
+++ b/crates/code_assistant/src/ui/gpui/root.rs
@@ -686,11 +686,10 @@ impl RootView {
                 None
             };
 
-            let is_externally_locked = matches!(
-                current_activity_state,
-                Some(crate::session::instance::SessionActivityState::RunningExternally)
-            );
-            if is_externally_locked {
+            if current_activity_state
+                .as_ref()
+                .is_some_and(|s| s.is_running_externally())
+            {
                 tracing::warn!(
                     "RootView: Cannot send message — session {} is running in another instance",
                     session_id

--- a/crates/code_assistant/src/ui/gpui/settings.rs
+++ b/crates/code_assistant/src/ui/gpui/settings.rs
@@ -124,22 +124,12 @@ impl UiSettings {
     /// Persist settings to disk. Errors are logged but not propagated.
     pub fn save(&self) {
         let path = Self::settings_path();
-        if let Some(parent) = path.parent() {
-            if let Err(e) = std::fs::create_dir_all(parent) {
-                warn!("Failed to create config directory: {}", e);
-                return;
-            }
-        }
-        match serde_json::to_string_pretty(self) {
-            Ok(json) => {
-                if let Err(e) = std::fs::write(&path, json) {
-                    warn!("Failed to write UI settings to {}: {}", path.display(), e);
-                } else {
-                    debug!("Saved UI settings to {}", path.display());
-                }
+        match crate::utils::file_utils::atomic_write_json(&path, self) {
+            Ok(()) => {
+                debug!("Saved UI settings to {}", path.display());
             }
             Err(e) => {
-                warn!("Failed to serialize UI settings: {}", e);
+                warn!("Failed to save UI settings to {}: {}", path.display(), e);
             }
         }
     }

--- a/crates/code_assistant/src/ui/gpui/terminal_card_renderer.rs
+++ b/crates/code_assistant/src/ui/gpui/terminal_card_renderer.rs
@@ -6,13 +6,13 @@
 //!
 //! This replaces the old `ExecuteCommandOutputRenderer` (ToolOutputRenderer)
 //! with a unified `ToolBlockRenderer` that controls the entire card.
-
 use crate::ui::gpui::elements::{BlockView, ToolUseBlock};
 use crate::ui::gpui::file_icons;
 use crate::ui::gpui::terminal_pool::TerminalPool;
 use crate::ui::gpui::tool_block_renderers::{
     animated_card_body, CardRenderContext, ToolBlockRenderer, ToolBlockStyle,
 };
+use crate::ui::gpui::Gpui;
 use crate::ui::ToolStatus;
 use gpui::prelude::FluentBuilder;
 use gpui::AppContext as _; // brings .new() into scope on Context
@@ -165,11 +165,30 @@ impl ToolBlockRenderer for TerminalCardRenderer {
                 command_line_param
             );
             if !command_line_param.is_empty() {
+                // If the session is externally locked, show "Running…" instead of
+                // "Starting…" since we'll never get a local PTY for this tool.
+                let is_external = cx
+                    .try_global::<Gpui>()
+                    .and_then(|gpui| {
+                        gpui.current_session_activity_state
+                            .lock()
+                            .ok()
+                            .and_then(|state| state.clone())
+                    })
+                    .is_some_and(|s| s.is_running_externally());
+
+                let status_text = if is_external {
+                    "Running…"
+                } else {
+                    "Starting…"
+                };
+
                 return Some(
                     self.render_skeleton(
                         &tool.id,
                         &command_line_param,
                         working_dir_param.as_deref(),
+                        status_text,
                         theme,
                     )
                     .into_any_element(),
@@ -529,6 +548,7 @@ impl TerminalCardRenderer {
         _tool_id: &str,
         command: &str,
         working_dir: Option<&str>,
+        status_text: &str,
         theme: &gpui_component::theme::Theme,
     ) -> gpui::Div {
         let is_dark = is_dark_theme(theme);
@@ -588,7 +608,7 @@ impl TerminalCardRenderer {
                         div()
                             .text_size(rems(0.6875))
                             .text_color(theme.muted_foreground)
-                            .child("Starting…"),
+                            .child(status_text.to_string()),
                     ),
             )
             // Command line

--- a/crates/code_assistant/src/ui/gpui/ui_state.rs
+++ b/crates/code_assistant/src/ui/gpui/ui_state.rs
@@ -209,7 +209,7 @@ impl UiStateStore {
 /// Designed to be called from a background thread via `cx.background_spawn`.
 pub fn write_ui_state_files(files: Vec<(PathBuf, String)>) {
     for (path, json) in files {
-        if let Err(e) = std::fs::write(&path, &json) {
+        if let Err(e) = crate::utils::file_utils::atomic_write(&path, json.as_bytes()) {
             warn!("Failed to write UI state file {}: {}", path.display(), e);
         } else {
             debug!("Saved UI state to {}", path.display());

--- a/crates/code_assistant/src/ui/terminal/ui.rs
+++ b/crates/code_assistant/src/ui/terminal/ui.rs
@@ -244,7 +244,7 @@ impl UserInterface for TerminalUI {
                     let _ = renderer_guard.add_instruction_message(&formatted);
                 }
             }
-            UiEvent::StreamingStarted(request_id) => {
+            UiEvent::StreamingStarted { request_id, .. } => {
                 debug!("Streaming started for request {}", request_id);
                 self.cancel_flag.store(false, Ordering::SeqCst);
                 // Start a new message - this will finalize any existing live message

--- a/crates/code_assistant/src/ui/ui_events.rs
+++ b/crates/code_assistant/src/ui/ui_events.rs
@@ -96,8 +96,10 @@ pub enum UiEvent {
         session_id: Option<String>,
         tool_results: Vec<ToolResultData>,
     },
-    /// Streaming started for a request
-    StreamingStarted(u64),
+    /// Streaming started for a request.
+    /// The `node_id` is pre-allocated so the UI container is tagged from the start
+    /// with the same ID that will be used when the message is persisted.
+    StreamingStarted { request_id: u64, node_id: NodeId },
     /// Streaming stopped for a request
     StreamingStopped {
         id: u64,

--- a/crates/code_assistant/src/ui/ui_events.rs
+++ b/crates/code_assistant/src/ui/ui_events.rs
@@ -219,6 +219,11 @@ pub enum UiEvent {
         branch_info: BranchInfo,
     },
 
+    // === Cross-instance awareness ===
+    /// Another process modified the session file on disk for the currently
+    /// viewed session.  The UI should reload messages from persistence.
+    RefreshCurrentSession { session_id: String },
+
     // === Resource Events (for tool operations) ===
     /// A file was loaded/read by a tool
     ResourceLoaded { project: String, path: PathBuf },

--- a/crates/code_assistant/src/ui/ui_events.rs
+++ b/crates/code_assistant/src/ui/ui_events.rs
@@ -224,6 +224,13 @@ pub enum UiEvent {
     /// viewed session.  The UI should reload messages from persistence.
     RefreshCurrentSession { session_id: String },
 
+    /// Append new messages to the current session display (incremental update).
+    /// Used by the file watcher when an external agent appends messages.
+    AppendMessages {
+        messages: Vec<MessageData>,
+        tool_results: Vec<ToolResultData>,
+    },
+
     // === Resource Events (for tool operations) ===
     /// A file was loaded/read by a tool
     ResourceLoaded { project: String, path: PathBuf },

--- a/crates/code_assistant/src/utils/content.rs
+++ b/crates/code_assistant/src/utils/content.rs
@@ -2,6 +2,20 @@ use crate::persistence::DraftAttachment;
 use llm::ContentBlock;
 use std::time::SystemTime;
 
+/// Generate a text summary from content blocks for UI display.
+/// Images are shown as `[image/png]` etc., text blocks are joined with newlines.
+pub fn text_summary_from_blocks(blocks: &[ContentBlock]) -> String {
+    blocks
+        .iter()
+        .filter_map(|block| match block {
+            ContentBlock::Text { text, .. } => Some(text.clone()),
+            ContentBlock::Image { media_type, .. } => Some(format!("[{media_type}]")),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 pub fn content_blocks_from(message: &str, attachments: &[DraftAttachment]) -> Vec<ContentBlock> {
     let mut blocks = Vec::new();
 

--- a/crates/code_assistant/src/utils/file_utils.rs
+++ b/crates/code_assistant/src/utils/file_utils.rs
@@ -176,19 +176,32 @@ pub fn try_acquire_agent_lock(
             debug!("Agent lock already held for session {session_id}");
             Ok(None)
         }
+
         Err(e) => {
             // On some platforms the error kind for "already locked" may differ
-            // from WouldBlock.  Check the raw OS error.
-            #[cfg(unix)]
-            {
-                if let Some(raw) = e.raw_os_error() {
-                    // EAGAIN/EWOULDBLOCK: 11 on Linux, 35 on macOS
-                    if raw == 11 || raw == 35 {
-                        debug!(
-                            "Agent lock already held for session {session_id} (raw errno {raw})"
-                        );
-                        return Ok(None);
+            // from WouldBlock.  Check the raw OS error as a fallback.
+            if let Some(raw) = e.raw_os_error() {
+                let is_lock_busy = {
+                    #[cfg(unix)]
+                    {
+                        // EAGAIN/EWOULDBLOCK: 11 on Linux, 35 on macOS
+                        raw == 11 || raw == 35
                     }
+                    #[cfg(windows)]
+                    {
+                        // ERROR_LOCK_VIOLATION (33) or ERROR_IO_PENDING (997)
+                        raw == 33 || raw == 997
+                    }
+                    #[cfg(not(any(unix, windows)))]
+                    {
+                        let _ = raw;
+                        false
+                    }
+                };
+
+                if is_lock_busy {
+                    debug!("Agent lock already held for session {session_id} (raw os error {raw})");
+                    return Ok(None);
                 }
             }
             Err(anyhow::anyhow!(

--- a/crates/code_assistant/src/utils/file_utils.rs
+++ b/crates/code_assistant/src/utils/file_utils.rs
@@ -213,6 +213,27 @@ pub fn try_acquire_agent_lock(
     }
 }
 
+/// Check whether the agent lock for `session_id` is held by *this* process.
+///
+/// The lock file contains the PID of the process that acquired the lock (see
+/// [`try_acquire_agent_lock`]).  This function reads that PID and compares it
+/// to the current process.  It does **not** check whether the lock is
+/// actually held (use [`is_agent_locked`] for that); it only answers the
+/// question "is the lock file claimed by me?".
+///
+/// Returns `false` if the file does not exist, cannot be read, or contains a
+/// PID that differs from the current process.
+pub fn agent_lock_belongs_to_current_process(sessions_dir: &Path, session_id: &str) -> bool {
+    let lock_path = sessions_dir.join(format!("{session_id}.agent.lock"));
+    let Ok(content) = fs::read_to_string(&lock_path) else {
+        return false;
+    };
+    let Ok(pid) = content.trim().parse::<u32>() else {
+        return false;
+    };
+    pid == std::process::id()
+}
+
 /// Check whether a session's agent lock is currently held by another process.
 ///
 /// Returns `true` if the lock is held (i.e. we cannot acquire it),

--- a/crates/code_assistant/src/utils/file_utils.rs
+++ b/crates/code_assistant/src/utils/file_utils.rs
@@ -1,0 +1,322 @@
+//! Filesystem utilities for safe multi-process persistence.
+//!
+//! Provides:
+//! - **Atomic writes** via write-to-temp-then-rename, so a crash mid-write never
+//!   leaves a partially-written file.
+//! - **Advisory file locking** via `fs2` (`flock` on POSIX, `LockFile` on
+//!   Windows) to serialise read-modify-write cycles across processes.
+//! - **Per-session agent lock files** to enforce a single active agent loop per
+//!   session across independent code-assistant instances.
+
+use anyhow::{Context, Result};
+use fs2::FileExt;
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use tracing::debug;
+
+// ---------------------------------------------------------------------------
+// Atomic write
+// ---------------------------------------------------------------------------
+
+/// Write `data` to `path` atomically.
+///
+/// Creates a temporary file in the same directory, writes the content, then
+/// renames it over `path`.  On POSIX the rename is atomic; on Windows it uses
+/// `MoveFileEx(REPLACE_EXISTING)` which is as close to atomic as the OS allows.
+///
+/// If the process crashes between creating the temp file and renaming, a stale
+/// `.tmp*` file is left behind but `path` is never corrupted.
+pub fn atomic_write(path: &Path, data: &[u8]) -> Result<()> {
+    let dir = path
+        .parent()
+        .context("atomic_write: path has no parent directory")?;
+
+    // Ensure the directory exists (important for first-time writes)
+    fs::create_dir_all(dir)?;
+
+    let mut tmp = tempfile::NamedTempFile::new_in(dir).with_context(|| {
+        format!(
+            "atomic_write: failed to create temp file in {}",
+            dir.display()
+        )
+    })?;
+
+    tmp.write_all(data)
+        .context("atomic_write: failed to write data to temp file")?;
+
+    // Flush to OS before rename so the data is on disk.
+    tmp.as_file()
+        .sync_all()
+        .context("atomic_write: failed to sync temp file")?;
+
+    tmp.persist(path).with_context(|| {
+        format!(
+            "atomic_write: failed to rename temp file to {}",
+            path.display()
+        )
+    })?;
+
+    Ok(())
+}
+
+/// Convenience wrapper: serialise `data` as pretty JSON and write atomically.
+pub fn atomic_write_json<T: serde::Serialize + ?Sized>(path: &Path, data: &T) -> Result<()> {
+    let json = serde_json::to_string_pretty(data)?;
+    atomic_write(path, json.as_bytes())
+}
+
+// ---------------------------------------------------------------------------
+// Advisory file locking for metadata operations
+// ---------------------------------------------------------------------------
+
+/// A guard that holds an exclusive advisory lock on a file.
+///
+/// The lock is released when this guard is dropped.  If the process crashes the
+/// OS releases the lock automatically (`flock` semantics).
+pub struct FileLockGuard {
+    _file: File,
+}
+
+/// Acquire an exclusive advisory lock on the given lock-file path.
+///
+/// Creates the lock file if it doesn't exist.  Blocks until the lock is
+/// acquired.
+pub fn lock_exclusive(lock_path: &Path) -> Result<FileLockGuard> {
+    if let Some(parent) = lock_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let file = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .write(true)
+        .open(lock_path)
+        .with_context(|| format!("failed to open lock file {}", lock_path.display()))?;
+
+    file.lock_exclusive().with_context(|| {
+        format!(
+            "failed to acquire exclusive lock on {}",
+            lock_path.display()
+        )
+    })?;
+
+    Ok(FileLockGuard { _file: file })
+}
+
+// ---------------------------------------------------------------------------
+// Per-session agent lock
+// ---------------------------------------------------------------------------
+
+/// An RAII guard for the per-session agent lock.
+///
+/// While this guard exists, no other process (or the same process) can acquire
+/// the agent lock for the same session.  The lock is released on drop or
+/// process exit.
+pub struct AgentLockGuard {
+    _file: File,
+    path: PathBuf,
+}
+
+impl AgentLockGuard {
+    /// Path of the underlying lock file (useful for diagnostics).
+    #[allow(dead_code)]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for AgentLockGuard {
+    fn drop(&mut self) {
+        // The flock is released when the file descriptor is closed (automatic).
+        // We also try to delete the lock file for cleanliness, but this is
+        // best-effort — the presence of the file alone doesn't indicate a lock.
+        let _ = fs::remove_file(&self.path);
+        debug!("Released agent lock: {}", self.path.display());
+    }
+}
+
+/// Try to acquire the agent lock for a session.
+///
+/// Returns `Ok(Some(guard))` if the lock was acquired, `Ok(None)` if another
+/// process already holds it.  The lock file is located at
+/// `<sessions_dir>/<session_id>.agent.lock`.
+pub fn try_acquire_agent_lock(
+    sessions_dir: &Path,
+    session_id: &str,
+) -> Result<Option<AgentLockGuard>> {
+    let lock_path = sessions_dir.join(format!("{session_id}.agent.lock"));
+
+    fs::create_dir_all(sessions_dir)?;
+
+    let file = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .write(true)
+        .open(&lock_path)
+        .with_context(|| format!("failed to open agent lock file {}", lock_path.display()))?;
+
+    // Non-blocking try-lock
+    match file.try_lock_exclusive() {
+        Ok(()) => {
+            // Write PID for diagnostics
+            let mut f = &file;
+            let _ = f.write_all(format!("{}", std::process::id()).as_bytes());
+            let _ = f.flush();
+            debug!(
+                "Acquired agent lock for session {session_id}: {}",
+                lock_path.display()
+            );
+            Ok(Some(AgentLockGuard {
+                _file: file,
+                path: lock_path,
+            }))
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+            debug!("Agent lock already held for session {session_id}");
+            Ok(None)
+        }
+        Err(e) => {
+            // On some platforms the error kind for "already locked" may differ
+            // from WouldBlock.  Check the raw OS error.
+            #[cfg(unix)]
+            {
+                if let Some(raw) = e.raw_os_error() {
+                    // EAGAIN/EWOULDBLOCK: 11 on Linux, 35 on macOS
+                    if raw == 11 || raw == 35 {
+                        debug!(
+                            "Agent lock already held for session {session_id} (raw errno {raw})"
+                        );
+                        return Ok(None);
+                    }
+                }
+            }
+            Err(anyhow::anyhow!(
+                "failed to try-lock agent lock file {}: {}",
+                lock_path.display(),
+                e
+            ))
+        }
+    }
+}
+
+/// Check whether a session's agent lock is currently held by another process.
+///
+/// Returns `true` if the lock is held (i.e. we cannot acquire it),
+/// `false` if it is free.
+pub fn is_agent_locked(sessions_dir: &Path, session_id: &str) -> bool {
+    let lock_path = sessions_dir.join(format!("{session_id}.agent.lock"));
+
+    let Ok(file) = OpenOptions::new()
+        .create(false)
+        .write(true)
+        .open(&lock_path)
+    else {
+        return false; // File doesn't exist → not locked
+    };
+
+    match file.try_lock_exclusive() {
+        Ok(()) => {
+            // We acquired the lock → it wasn't held.  Release immediately.
+            let _ = file.unlock();
+            false
+        }
+        Err(_) => true, // Cannot acquire → held by another process
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn atomic_write_creates_file() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.json");
+
+        atomic_write(&path, b"hello").unwrap();
+        assert_eq!(fs::read_to_string(&path).unwrap(), "hello");
+    }
+
+    #[test]
+    fn atomic_write_overwrites_existing() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.json");
+
+        fs::write(&path, "old").unwrap();
+        atomic_write(&path, b"new").unwrap();
+        assert_eq!(fs::read_to_string(&path).unwrap(), "new");
+    }
+
+    #[test]
+    fn atomic_write_json_roundtrip() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("data.json");
+
+        let data = vec!["alpha", "beta"];
+        atomic_write_json(&path, &data).unwrap();
+
+        let loaded: Vec<String> =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(loaded, data);
+    }
+
+    #[test]
+    fn lock_exclusive_and_release() {
+        let dir = tempdir().unwrap();
+        let lock_path = dir.path().join("test.lock");
+
+        let guard = lock_exclusive(&lock_path).unwrap();
+        assert!(lock_path.exists());
+        drop(guard);
+    }
+
+    #[test]
+    fn agent_lock_acquire_and_release() {
+        let dir = tempdir().unwrap();
+        let sessions_dir = dir.path().join("sessions");
+
+        // First acquire should succeed
+        let guard = try_acquire_agent_lock(&sessions_dir, "sess1").unwrap();
+        assert!(guard.is_some());
+
+        // Second acquire from same process should fail (already locked)
+        let guard2 = try_acquire_agent_lock(&sessions_dir, "sess1").unwrap();
+        assert!(guard2.is_none());
+
+        // Check is_agent_locked
+        assert!(is_agent_locked(&sessions_dir, "sess1"));
+
+        // Release
+        drop(guard);
+
+        // Now should be free
+        assert!(!is_agent_locked(&sessions_dir, "sess1"));
+    }
+
+    #[test]
+    fn agent_lock_different_sessions_independent() {
+        let dir = tempdir().unwrap();
+        let sessions_dir = dir.path().join("sessions");
+
+        let guard1 = try_acquire_agent_lock(&sessions_dir, "sess1").unwrap();
+        assert!(guard1.is_some());
+
+        let guard2 = try_acquire_agent_lock(&sessions_dir, "sess2").unwrap();
+        assert!(guard2.is_some());
+
+        drop(guard1);
+        drop(guard2);
+    }
+
+    #[test]
+    fn is_agent_locked_returns_false_when_no_file() {
+        let dir = tempdir().unwrap();
+        assert!(!is_agent_locked(dir.path(), "nonexistent"));
+    }
+}

--- a/crates/code_assistant/src/utils/mod.rs
+++ b/crates/code_assistant/src/utils/mod.rs
@@ -1,4 +1,5 @@
 pub mod content;
+pub mod file_utils;
 mod writer;
 
 #[cfg(test)]

--- a/crates/llm/src/anthropic.rs
+++ b/crates/llm/src/anthropic.rs
@@ -939,6 +939,11 @@ impl AnthropicClient {
                                 rate_limits: Some(AnthropicRateLimitInfo::default()),
                             }
                             .into()),
+                            "rate_limit_error" => Err(ApiErrorContext {
+                                error: ApiError::RateLimit(error_msg),
+                                rate_limits: Some(AnthropicRateLimitInfo::default()),
+                            }
+                            .into()),
                             _ => Err(anyhow::anyhow!("Stream error: {error_msg}")),
                         };
                     }


### PR DESCRIPTION
Persistency is now guarded with atomic writes and file locks. One instance of code-assistant is aware when an agent is active in a given session. The session history will update via file watches (complete tool calls and messages only, no streaming).