### PR TITLE
feat: Migrate git backend to gix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,6 +1013,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
+ "regex-automata",
  "serde",
 ]
 
@@ -1364,6 +1365,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code 3.3.2",
+]
+
+[[package]]
+name = "clru"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "197fd99cb113a8d5d9b6376f3aa817f32c1078f2343b714fff7d2ca44fdf67d5"
+dependencies = [
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1854,6 +1864,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2062,6 +2081,20 @@ dependencies = [
  "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -2665,6 +2698,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "faster-hex"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73"
+dependencies = [
+ "heapless 0.8.0",
+ "serde",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3189,7 +3232,7 @@ name = "git"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "git2",
+ "gix",
  "serde",
  "tempfile",
  "tokio",
@@ -3198,16 +3241,870 @@ dependencies = [
 ]
 
 [[package]]
-name = "git2"
-version = "0.20.4"
+name = "gix"
+version = "0.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+checksum = "6ce52001b946a6249d5d0d3011df0a042ac3f8a4d013460db6476577b0b9c567"
+dependencies = [
+ "gix-actor",
+ "gix-archive",
+ "gix-attributes",
+ "gix-blame",
+ "gix-command",
+ "gix-commitgraph",
+ "gix-config",
+ "gix-date",
+ "gix-diff",
+ "gix-dir",
+ "gix-discover",
+ "gix-error",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-ignore",
+ "gix-index",
+ "gix-lock",
+ "gix-merge",
+ "gix-negotiate",
+ "gix-object",
+ "gix-odb",
+ "gix-pack",
+ "gix-path",
+ "gix-pathspec",
+ "gix-protocol",
+ "gix-ref",
+ "gix-refspec",
+ "gix-revision",
+ "gix-revwalk",
+ "gix-sec",
+ "gix-shallow",
+ "gix-status",
+ "gix-submodule",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-traverse",
+ "gix-url",
+ "gix-utils",
+ "gix-validate",
+ "gix-worktree",
+ "gix-worktree-state",
+ "gix-worktree-stream",
+ "nonempty",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-actor"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "272916673b83714734b15d4ef3c8b5f1ccddb15fea8ff548430b97c1ab7b7ed8"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-error",
+]
+
+[[package]]
+name = "gix-archive"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a20ec244b733338d4cb60e5e05eac700dab7fcc689647b1d1daa9396b119342"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-error",
+ "gix-object",
+ "gix-worktree-stream",
+]
+
+[[package]]
+name = "gix-attributes"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe17c5a1c0b6f2ef1476aa1d3222ea50cdff67608016613a58bfc3e078046000"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "kstring",
+ "smallvec",
+ "thiserror 2.0.18",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-bitmap"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ecbfc77ec6852294e341ecc305a490b59f2813e6ca42d79efda5099dcab1894"
+dependencies = [
+ "gix-error",
+]
+
+[[package]]
+name = "gix-blame"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dab9a942ab54a9661ded7397c3bf927274e7afa94494db0d75cfcbde02ca0a"
+dependencies = [
+ "gix-commitgraph",
+ "gix-date",
+ "gix-diff",
+ "gix-error",
+ "gix-hash",
+ "gix-object",
+ "gix-revwalk",
+ "gix-trace",
+ "gix-traverse",
+ "gix-worktree",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-chunk"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edf288be9b60fe7231de03771faa292be1493d84786f68727e33ad1f91764320"
+dependencies = [
+ "gix-error",
+]
+
+[[package]]
+name = "gix-command"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86335306511abe43d75c866d4b1f3d90932fe202edcd43e1314036333e7384d8"
+dependencies = [
+ "bstr",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "shell-words",
+]
+
+[[package]]
+name = "gix-commitgraph"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe3b5aa0f24e19028c261d229aeeedafcaaa52ebd71021cc15184620fc9d32eb"
+dependencies = [
+ "bstr",
+ "gix-chunk",
+ "gix-error",
+ "gix-hash",
+ "memmap2",
+ "nonempty",
+]
+
+[[package]]
+name = "gix-config"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c01848aebd21c67f6ba41f1de8efd46ae96df21f001954a3c9e1517e514d410"
+dependencies = [
+ "bstr",
+ "gix-config-value",
+ "gix-features",
+ "gix-glob",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "smallvec",
+ "thiserror 2.0.18",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-config-value"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b39ed39ee4c10a3b157f9fb94bac8098d9f8e56201f0cf7dee6c187416c4b2"
 dependencies = [
  "bitflags 2.11.1",
+ "bstr",
+ "gix-path",
  "libc",
- "libgit2-sys",
- "log",
- "url",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-date"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94cdae4eb4b0f4136e3d9b3aa2d2cd03cfb5bb9b636b31263aea2df86d41543"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "itoa",
+ "jiff",
+ "smallvec",
+]
+
+[[package]]
+name = "gix-diff"
+version = "0.63.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc08e0fa1a91ff5f24affeab052f198056645e1de004910bde7b82b50ea5982a"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-imara-diff",
+ "gix-object",
+ "gix-path",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-traverse",
+ "gix-worktree",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-dir"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a0fc06e9e1e430cbf0a313666976d90f822f461a6525320427aa9b8af5236c"
+dependencies = [
+ "bstr",
+ "gix-discover",
+ "gix-fs",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-trace",
+ "gix-utils",
+ "gix-worktree",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-discover"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17852e6a501e688a1702b24ebe5b3761d4719455bc869fd29f38b0b859bcad34"
+dependencies = [
+ "bstr",
+ "dunce",
+ "gix-fs",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-error"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e207b971746ab724fccdfced2e4e19e854744611904a0195d3aa8fda8a110613"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
+name = "gix-features"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af375693ad5333d0a2c66b4c5b2cbe9ccc38e34f8e8bf24e4ae42c12307fdc4f"
+dependencies = [
+ "bytes",
+ "crc32fast",
+ "crossbeam-channel",
+ "gix-path",
+ "gix-trace",
+ "gix-utils",
+ "libc",
+ "once_cell",
+ "parking_lot",
+ "prodash",
+ "thiserror 2.0.18",
+ "walkdir",
+ "zlib-rs",
+]
+
+[[package]]
+name = "gix-filter"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac917dbe9653c9b615d248db91907a365bd779750c9e1b457a9d9fdeece3a08"
+dependencies = [
+ "bstr",
+ "encoding_rs",
+ "gix-attributes",
+ "gix-command",
+ "gix-hash",
+ "gix-object",
+ "gix-packetline",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "gix-utils",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-fs"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e1967daac9848757c47c2aef0c57bcadc1a897347f559778249bf286a536c86"
+dependencies = [
+ "bstr",
+ "fastrand 2.4.1",
+ "gix-features",
+ "gix-path",
+ "gix-utils",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-glob"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08bf29249a069bf2507f5964f80997f37b134d320ea348d66527726b9be2c38c"
+dependencies = [
+ "bitflags 2.11.1",
+ "bstr",
+ "gix-features",
+ "gix-path",
+]
+
+[[package]]
+name = "gix-hash"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcf70d1e252337eed16360f8b8ebb71865ece58eab7954b39ce38b420de703d2"
+dependencies = [
+ "faster-hex",
+ "gix-features",
+ "sha1-checked",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-hashtable"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d33b455e07b3c16d3b2eeebc7b38d2dafcbf8a653de1138ef55d4c2a1fd0b08b"
+dependencies = [
+ "gix-hash",
+ "hashbrown 0.16.1",
+ "parking_lot",
+]
+
+[[package]]
+name = "gix-ignore"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb13fbbeeafee943e52b61fcc88dfddf6a452fcaf0c4d0cdc8f218fa25bbec5"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-trace",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-imara-diff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39eb0623e15e4cb83c02ce6a959e48fadd1ae3b715b36b5acc01816e01388c82"
+dependencies = [
+ "bstr",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "gix-index"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54c3ef97ad08121e4327a6226bd63fed6b9e3c6b976d48bddd4356d9d41191db"
+dependencies = [
+ "bitflags 2.11.1",
+ "bstr",
+ "filetime",
+ "fnv",
+ "gix-bitmap",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-traverse",
+ "gix-utils",
+ "gix-validate",
+ "hashbrown 0.16.1",
+ "itoa",
+ "libc",
+ "memmap2",
+ "rustix 1.1.4",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-lock"
+version = "23.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b3bc074e5723027b482dcd9ab99d95804a53742f6de812d0172fbba4a186c1"
+dependencies = [
+ "gix-tempfile",
+ "gix-utils",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-merge"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74bbcdcc52b70a32f0a151b024dff9d0fcf56ee48f00d9503e735af9d99ea881"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-diff",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-imara-diff",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-quote",
+ "gix-revision",
+ "gix-revwalk",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-worktree",
+ "nonempty",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-negotiate"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "103d42bfade1b8a96ca5005933127bdad461ce588d92422b2c2daa3ff20d780c"
+dependencies = [
+ "bitflags 2.11.1",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-object",
+ "gix-revwalk",
+]
+
+[[package]]
+name = "gix-object"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a38075a95d7cc5df8afd38e72c617026c1456952207a4120a7f55a3fbf93b4d7"
+dependencies = [
+ "bstr",
+ "gix-actor",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-utils",
+ "gix-validate",
+ "itoa",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-odb"
+version = "0.80.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeeda12a9663120418735ecdc1250d06eeab0be75700e47b3402a981331716ba"
+dependencies = [
+ "arc-swap",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-pack",
+ "gix-path",
+ "gix-quote",
+ "memmap2",
+ "parking_lot",
+ "tempfile",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-pack"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf02e6f5c8f07a069c9ea5245f40d9b14856ada4086091dc99941b49002b4fa"
+dependencies = [
+ "clru",
+ "gix-chunk",
+ "gix-error",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-path",
+ "memmap2",
+ "smallvec",
+ "thiserror 2.0.18",
+ "uluru",
+]
+
+[[package]]
+name = "gix-packetline"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "362246df440ee691699f0664cbf7006a6ece477db6734222be95e4198e5656e6"
+dependencies = [
+ "bstr",
+ "faster-hex",
+ "gix-trace",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-path"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "671a6059e8a4c1b7f406e24716499cefa3926e060876fb1959ef225efeee346e"
+dependencies = [
+ "bstr",
+ "gix-trace",
+ "gix-validate",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-pathspec"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a84a4f083dd70fb49f4377e13afa6d90df2daaa1c705c49d6ff1331fc7e8855"
+dependencies = [
+ "bitflags 2.11.1",
+ "bstr",
+ "gix-attributes",
+ "gix-config-value",
+ "gix-glob",
+ "gix-path",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-protocol"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4bee82db63ec635996b96efae71cf467c155fa3f34a556184373224a26c4fd"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-ref",
+ "gix-shallow",
+ "gix-transport",
+ "gix-utils",
+ "maybe-async",
+ "nonempty",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-quote"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e97b73791a64bc0fa7dd2c5b3e551136115f97750b876ed1c952c7a7dbaf8be"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "gix-utils",
+]
+
+[[package]]
+name = "gix-ref"
+version = "0.63.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8ba9cc15f558b274c99349b83130f5ec83459660828fde9718bbbb43a726167"
+dependencies = [
+ "gix-actor",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-path",
+ "gix-tempfile",
+ "gix-utils",
+ "gix-validate",
+ "memmap2",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-refspec"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61755b27d57edc8940a1b1593c8c61548ca8e4c02da1ed8d5bfeda9eb2a6b761"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "gix-glob",
+ "gix-hash",
+ "gix-revision",
+ "gix-validate",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-revision"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fb5288fac706d3ea3e4e2ba9ec38b78743b8c02f422e18cb342299cfd6ab7e8"
+dependencies = [
+ "bitflags 2.11.1",
+ "bstr",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-error",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
+ "gix-trace",
+ "nonempty",
+]
+
+[[package]]
+name = "gix-revwalk"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "313813706b073a12ff7f9b2896bf3e6504cdac7cfbc97b1920114724705069f0"
+dependencies = [
+ "gix-commitgraph",
+ "gix-date",
+ "gix-error",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-sec"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3a2d3e504a238136751e646a6c028252286a0ea64ea9974bf0498633407c6"
+dependencies = [
+ "bitflags 2.11.1",
+ "gix-path",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "gix-shallow"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29187305521bfacf4aefd284ab28dbfa9fb74abd39a5e63dd313b1baa5808c27"
+dependencies = [
+ "bstr",
+ "gix-hash",
+ "gix-lock",
+ "nonempty",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-status"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68c6d2a8c521ffa205fe7e268c82e6d1378ba37cd826ca10ab6129fdc29a4b65"
+dependencies = [
+ "bstr",
+ "filetime",
+ "gix-diff",
+ "gix-dir",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-worktree",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-submodule"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fd5fc8692890bd71a596e540fd4c364f8460eaa82c4eaaedebde6e1e3eb4d91"
+dependencies = [
+ "bstr",
+ "gix-config",
+ "gix-path",
+ "gix-pathspec",
+ "gix-refspec",
+ "gix-url",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-tempfile"
+version = "23.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "691ea1e31435c7e7d4d04705ec9d1c0d9482c46b2acf512bc723939d8f0af7fb"
+dependencies = [
+ "dashmap",
+ "gix-fs",
+ "libc",
+ "parking_lot",
+ "tempfile",
+]
+
+[[package]]
+name = "gix-trace"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f23569e55f2ffaf958617353b9734a7d52a7c19c439eeaa5e3efc217fd2270e"
+
+[[package]]
+name = "gix-transport"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd6a5c676b92d4ead5f5a2b2935024415dec69edc997b6090ca9cac010a3018"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-features",
+ "gix-packetline",
+ "gix-quote",
+ "gix-sec",
+ "gix-url",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-traverse"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a14b7052c0786676c03e71fcfde7d7f0f8e8316e642b5cec6bb3998719b2ce5c"
+dependencies = [
+ "bitflags 2.11.1",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-url"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35842d099e813f6f6bba529e88d4670572149c3df79b7a412952259887721ece"
+dependencies = [
+ "bstr",
+ "gix-path",
+ "percent-encoding",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-utils"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e477b4f07a6e8da4ba791c53c858102959703c60d70f199932010d5b94adb2c"
+dependencies = [
+ "bstr",
+ "fastrand 2.4.1",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "gix-validate"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e26ac2602b43eadfdca0560b81d3341944162a3c9f64ccdeef8fc501ad80dad5"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
+name = "gix-worktree"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d69955eb5e2910832f88d041964b809eee01dadd579237e0b55efec58fd406fd"
+dependencies = [
+ "bstr",
+ "gix-attributes",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-validate",
+]
+
+[[package]]
+name = "gix-worktree-state"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a96dccbcf9e8fe0291c55f06e08da93ebb2e691c1311276f541eefcc6d70800"
+dependencies = [
+ "bstr",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-worktree",
+ "io-close",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-worktree-stream"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8444b8ed4662e1a0c97f3eceda29630001a1bbb2632201e50312623e594213"
+dependencies = [
+ "gix-attributes",
+ "gix-error",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-object",
+ "gix-path",
+ "gix-traverse",
+ "parking_lot",
 ]
 
 [[package]]
@@ -3706,6 +4603,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -3731,6 +4634,16 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heapless"
@@ -4379,6 +5292,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-close"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cadcf447f06744f8ce713d2d6239bb5bde2c357a452397a9ed90c625da390bc"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "io-lifetimes"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4473,6 +5396,47 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
 
 [[package]]
 name = "jni-sys"
@@ -4591,6 +5555,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kstring"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
 name = "kurbo"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4666,18 +5639,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libgit2-sys"
-version = "0.18.4+1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b26f66f35e1871b22efcf7191564123d2a446ca0538cde63c23adfefa9b15b7"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "pkg-config",
-]
-
-[[package]]
 name = "libloading"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4700,18 +5661,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -5075,6 +6024,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "maybe-async"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "maybe-rayon"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5390,6 +6350,12 @@ dependencies = [
  "memchr",
  "nom 7.1.3",
 ]
+
+[[package]]
+name = "nonempty"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9737e026353e5cd0736f98eddae28665118eb6f6600902a7f50db585621fecb6"
 
 [[package]]
 name = "noop_proc_macro"
@@ -6445,6 +7411,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prodash"
+version = "31.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "962200e2d7d551451297d9fdce85138374019ada198e30ea9ede38034e27604c"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]
@@ -7768,6 +8743,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1-checked"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
+dependencies = [
+ "digest 0.10.7",
+ "sha1",
+]
+
+[[package]]
 name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8197,7 +9182,7 @@ name = "sum_tree"
 version = "0.1.0"
 source = "git+https://github.com/zed-industries/zed#7f7c21536e080a24861289aabccd99d78808a84e"
 dependencies = [
- "heapless",
+ "heapless 0.9.3",
  "log",
  "rayon",
  "tracing",
@@ -9185,6 +10170,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "uluru"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c8a2469e56e6e5095c82ccd3afb98dad95f7af7929aab6d8ba8d6e0f73657da"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "umya-spreadsheet"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9230,6 +10224,12 @@ name = "unicode-bidi-mirroring"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
+
+[[package]]
+name = "unicode-bom"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217"
 
 [[package]]
 name = "unicode-ccc"

--- a/crates/code_assistant/src/ui/backend.rs
+++ b/crates/code_assistant/src/ui/backend.rs
@@ -1202,7 +1202,7 @@ async fn handle_list_branches_and_worktrees(
 
     let current_branch = repo.current_branch();
 
-    let worktrees = match git::worktree::list_worktrees(&repo.git, repo.workdir()).await {
+    let worktrees = match git::worktree::list_worktrees(&repo).await {
         Ok(w) => w,
         Err(e) => {
             error!("Failed to list worktrees: {}", e);
@@ -1289,7 +1289,7 @@ async fn handle_create_worktree(
     };
 
     // Check if a worktree for this branch already exists
-    match git::worktree::find_worktree_for_branch(&repo.git, repo.workdir(), branch_name).await {
+    match git::worktree::find_worktree_for_branch(&repo, branch_name).await {
         Ok(Some(existing)) => {
             info!(
                 "Reusing existing worktree for branch '{}' at {:?}",

--- a/crates/git/Cargo.toml
+++ b/crates/git/Cargo.toml
@@ -5,11 +5,16 @@ edition = "2024"
 
 [dependencies]
 anyhow = "1.0.95"
-git2 = { version = "0.20.1", default-features = false, features = ["vendored-libgit2"] }
 serde = { version = "1.0.215", features = ["derive"] }
 tokio = { version = "1.40.0", features = ["process"] }
 tracing = "0.1.40"
 which = "7.0"
+
+[dependencies.gix]
+version = "0.83.0"
+default-features = false
+features = ["max-performance", "revision", "sha1", "sha256", "worktree-mutation"]
+
 
 [dev-dependencies]
 tempfile = "3.13.0"

--- a/crates/git/src/binary.rs
+++ b/crates/git/src/binary.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result, bail};
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
+use std::process::Stdio;
 use tokio::process::Command;
 
 /// Wrapper around the system `git` binary.
@@ -23,11 +24,17 @@ impl GitBinary {
     pub fn command(&self, working_dir: &Path) -> Command {
         let mut cmd = Command::new(&self.binary_path);
         cmd.current_dir(working_dir);
-        // Disable fsmonitor for predictable behavior
-        cmd.args(["-c", "core.fsmonitor=false"]);
+        // Prevent git from blocking on password prompts or reading stdin
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        // GIT_OPTIONAL_LOCKS=0: skip advisory locks during read-only operations
+        // GIT_TERMINAL_PROMPT=0: never prompt for credentials
+        cmd.env("GIT_OPTIONAL_LOCKS", "0")
+            .env("GIT_TERMINAL_PROMPT", "0");
+        // Explicitly disable fsmonitor to avoid spawning hook processes
+        cmd.args(["-c", "core.fsmonitor="]);
         cmd.arg("--no-pager");
-        // Prevent git from prompting for input
-        cmd.env("GIT_TERMINAL_PROMPT", "0");
         cmd
     }
 

--- a/crates/git/src/branch.rs
+++ b/crates/git/src/branch.rs
@@ -1,32 +1,35 @@
 use crate::repository::GitRepository;
 use crate::types::Branch;
-use anyhow::Result;
+use anyhow::{Context, Result};
+use gix::refs::Target;
+use gix::refs::transaction::{Change, LogChange, PreviousValue, RefEdit, RefLog};
 
 impl GitRepository {
-    /// List local branches using `git2`.
+    /// List local branches using `gix`.
     ///
-    /// This is fast because it runs in-process via libgit2 with no
+    /// This is fast because it runs in-process via gix with no
     /// subprocess overhead.
     pub fn list_branches(&self) -> Result<Vec<Branch>> {
+        let repo = self.repo.to_thread_local();
         let mut branches = Vec::new();
 
-        let head_name: Option<String> = self
-            .repo
-            .head()
+        let head_name: Option<String> = repo
+            .head_name()
             .ok()
-            .and_then(|h: git2::Reference<'_>| h.shorthand().map(String::from));
+            .flatten()
+            .map(|n| n.shorten().to_string());
 
-        for entry in self.repo.branches(Some(git2::BranchType::Local))? {
-            let (branch, _branch_type): (git2::Branch<'_>, git2::BranchType) = entry?;
-            let name = branch.name()?.unwrap_or("").to_string();
+        for reference in repo.references()?.local_branches()? {
+            let reference = reference.map_err(|e| anyhow::anyhow!("{e}"))?;
+            let name = reference.name().shorten().to_string();
             if name.is_empty() {
                 continue;
             }
 
-            let upstream = branch
-                .upstream()
-                .ok()
-                .and_then(|u: git2::Branch<'_>| u.name().ok().flatten().map(String::from));
+            let upstream = repo
+                .branch_remote_ref_name(reference.name(), gix::remote::Direction::Fetch)
+                .and_then(Result::ok)
+                .map(|r| r.shorten().to_string());
 
             branches.push(Branch {
                 is_head: head_name.as_deref() == Some(&name),
@@ -43,66 +46,81 @@ impl GitRepository {
 
     /// Create a new local branch pointing at `start_point`.
     ///
-    /// Uses the git CLI because libgit2 branch creation doesn't
-    /// trigger hooks and has limited reflog support.
-    pub async fn create_branch(&self, name: &str, start_point: &str) -> Result<()> {
-        self.git
-            .run(self.workdir(), &["branch", name, start_point])
-            .await?;
+    /// Uses gix in-process ref creation.
+    pub fn create_branch(&self, name: &str, start_point: &str) -> Result<()> {
+        let repo = self.repo.to_thread_local();
+        let target_id = repo
+            .rev_parse_single(start_point)
+            .with_context(|| format!("failed to resolve '{start_point}'"))?
+            .detach();
+        let full_name = format!("refs/heads/{name}");
+        repo.edit_reference(RefEdit {
+            change: Change::Update {
+                log: LogChange {
+                    mode: RefLog::AndReference,
+                    force_create_reflog: false,
+                    message: format!("branch: Created from {start_point}").into(),
+                },
+                expected: PreviousValue::MustNotExist,
+                new: Target::Object(target_id),
+            },
+            name: full_name.try_into().context("invalid branch name")?,
+            deref: false,
+        })
+        .with_context(|| format!("failed to create branch '{name}'"))?;
         Ok(())
     }
 
     /// Switch the working directory to the given branch.
+    ///
+    /// Uses the git CLI because checkout updates the worktree and fires the
+    /// post-checkout hook.
     pub async fn checkout_branch(&self, name: &str) -> Result<()> {
         self.git.run(self.workdir(), &["checkout", name]).await?;
         Ok(())
     }
 
     /// Delete a local branch. Set `force` to allow deleting unmerged branches.
-    pub async fn delete_branch(&self, name: &str, force: bool) -> Result<()> {
-        let flag = if force { "-D" } else { "-d" };
-        self.git
-            .run(self.workdir(), &["branch", flag, name])
-            .await?;
+    ///
+    /// Uses gix in-process ref deletion.
+    pub fn delete_branch(&self, name: &str, force: bool) -> Result<()> {
+        let repo = self.repo.to_thread_local();
+        let full_name = format!("refs/heads/{name}");
+
+        let expected = if force {
+            PreviousValue::Any
+        } else {
+            PreviousValue::MustExist
+        };
+
+        repo.edit_reference(RefEdit {
+            change: Change::Delete {
+                expected,
+                log: RefLog::AndReference,
+            },
+            name: full_name.try_into().context("invalid branch name")?,
+            deref: false,
+        })
+        .with_context(|| format!("failed to delete branch '{name}'"))?;
         Ok(())
     }
 
     /// Get the current branch name, or `None` if in detached HEAD state.
     pub fn current_branch(&self) -> Option<String> {
-        self.repo.head().ok().and_then(|head: git2::Reference<'_>| {
-            if head.is_branch() {
-                head.shorthand().map(String::from)
-            } else {
-                None
-            }
-        })
+        self.repo
+            .to_thread_local()
+            .head_name()
+            .ok()
+            .flatten()
+            .map(|name| name.shorten().to_string())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::testutil::init_repo_with_commit;
     use tempfile::TempDir;
-
-    fn init_repo_with_commit(dir: &std::path::Path) -> git2::Repository {
-        let repo = git2::Repository::init(dir).unwrap();
-        {
-            let sig = git2::Signature::now("Test", "test@test.com").unwrap();
-            let tree_id = {
-                let mut index = repo.index().unwrap();
-                // Create a dummy file so we have something to commit
-                let file_path = dir.join("README.md");
-                std::fs::write(&file_path, "# Test\n").unwrap();
-                index.add_path(std::path::Path::new("README.md")).unwrap();
-                index.write().unwrap();
-                index.write_tree().unwrap()
-            };
-            let tree = repo.find_tree(tree_id).unwrap();
-            repo.commit(Some("HEAD"), &sig, &sig, "Initial commit", &tree, &[])
-                .unwrap();
-        }
-        repo
-    }
 
     #[test]
     fn list_branches_on_new_repo() {
@@ -127,18 +145,33 @@ mod tests {
         assert!(branch.is_some());
     }
 
-    #[tokio::test]
-    async fn create_and_list_branch() {
+    #[test]
+    fn create_and_list_branch() {
         let dir = TempDir::new().unwrap();
         init_repo_with_commit(dir.path());
 
         let repo = GitRepository::open(dir.path()).unwrap();
-        repo.create_branch("feature-x", "HEAD").await.unwrap();
+        repo.create_branch("feature-x", "HEAD").unwrap();
 
         let branches = repo.list_branches().unwrap();
         assert_eq!(branches.len(), 2);
 
         let feature = branches.iter().find(|b| b.name == "feature-x").unwrap();
         assert!(!feature.is_head);
+    }
+
+    #[test]
+    fn delete_branch() {
+        let dir = TempDir::new().unwrap();
+        init_repo_with_commit(dir.path());
+
+        let repo = GitRepository::open(dir.path()).unwrap();
+        repo.create_branch("to-delete", "HEAD").unwrap();
+        assert_eq!(repo.list_branches().unwrap().len(), 2);
+
+        repo.delete_branch("to-delete", false).unwrap();
+        let branches = repo.list_branches().unwrap();
+        assert_eq!(branches.len(), 1);
+        assert!(branches.iter().all(|b| b.name != "to-delete"));
     }
 }

--- a/crates/git/src/lib.rs
+++ b/crates/git/src/lib.rs
@@ -7,3 +7,61 @@ pub mod worktree;
 pub use binary::GitBinary;
 pub use repository::GitRepository;
 pub use types::*;
+
+#[cfg(test)]
+pub(crate) mod testutil {
+    use std::path::Path;
+
+    fn git_config(dir: &Path, key: &str, value: &str) {
+        std::process::Command::new("git")
+            .args(["config", "--local", key, value])
+            .current_dir(dir)
+            .status()
+            .unwrap_or_else(|e| panic!("git config {key}: {e}"));
+    }
+
+    fn init_with_config(dir: &Path) -> gix::Repository {
+        let mut repo = gix::init(dir).expect("failed to init repo");
+
+        const CONFIGS: &[(&str, &str)] = &[
+            // Set identity so commits work without global git config interference
+            ("user.email", "test@test.com"),
+            ("user.name", "Test"),
+            // Ensure git commands are durable during I/O-contentious tests
+            ("core.fsync", "all"),
+            // Avoid signing
+            ("commit.gpgsign", "false"),
+            ("tag.gpgsign", "false"),
+            // Set well-known default branch name
+            ("init.defaultBranch", "main"),
+            // Disable maintanance tasks
+            ("maintenance.auto", "false"),
+            ("gc.auto", "0"),
+        ];
+
+        for (key, value) in CONFIGS {
+            git_config(dir, key, value);
+        }
+        repo.reload().expect("reload after config write");
+        repo
+    }
+
+    /// Init a repo with identity + fsync config, then create an initial empty-tree commit.
+    pub fn init_repo_with_commit(dir: &Path) -> gix::Repository {
+        let repo = init_with_config(dir);
+        let empty_tree = gix::ObjectId::empty_tree(repo.object_hash());
+        repo.commit(
+            "HEAD",
+            "Initial commit",
+            empty_tree,
+            [] as [gix::ObjectId; 0],
+        )
+        .expect("failed to create initial commit");
+        repo
+    }
+
+    /// Like `init_repo_with_commit` but without the commit.
+    pub fn init_repo(dir: &Path) -> gix::Repository {
+        init_with_config(dir)
+    }
+}

--- a/crates/git/src/lib.rs
+++ b/crates/git/src/lib.rs
@@ -32,8 +32,6 @@ pub(crate) mod testutil {
             // Avoid signing
             ("commit.gpgsign", "false"),
             ("tag.gpgsign", "false"),
-            // Set well-known default branch name
-            ("init.defaultBranch", "main"),
             // Disable maintanance tasks
             ("maintenance.auto", "false"),
             ("gc.auto", "0"),

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -1,17 +1,18 @@
 use crate::binary::GitBinary;
-use crate::types::RepoInfo;
+use crate::types::{RepoInfo, Worktree};
 use anyhow::{Context, Result};
+use gix::ThreadSafeRepository;
+use gix::sec::trust::DefaultForLevel;
 use std::path::{Path, PathBuf};
 
 /// A handle to a git repository.
 ///
-/// Uses `git2` (libgit2) for fast in-process reads and the system `git`
-/// binary for write operations, worktree management, and anything that
-/// may need hooks or credential helpers.
+/// Uses `gix` for fast in-process operations and the system `git` binary
+/// for operations that need hooks (checkout).
 pub struct GitRepository {
-    /// In-process libgit2 handle for fast reads.
-    pub(crate) repo: git2::Repository,
-    /// System git binary for CLI operations.
+    /// In-process gix handle for fast reads and branch mutations.
+    pub(crate) repo: ThreadSafeRepository,
+    /// System git binary for checkout and worktree operations.
     pub git: GitBinary,
     /// Cached working directory path.
     workdir: PathBuf,
@@ -24,9 +25,17 @@ impl GitRepository {
     /// The repository is discovered by walking up the directory tree.
     pub fn open(path: impl AsRef<Path>) -> Result<Self> {
         let path = path.as_ref();
-        let repo = git2::Repository::discover(path)
-            .with_context(|| format!("No git repository found at {}", path.display()))?;
+        let shared_repo = ThreadSafeRepository::discover_with_environment_overrides_opts(
+            path,
+            gix::discover::upwards::Options {
+                match_ceiling_dir_or_error: false,
+                ..Default::default()
+            },
+            Default::default(),
+        )
+        .with_context(|| format!("No git repository found at {}", path.display()))?;
 
+        let repo = shared_repo.to_thread_local();
         let workdir = repo
             .workdir()
             .context("Bare repositories are not supported")?
@@ -34,29 +43,33 @@ impl GitRepository {
 
         let git = GitBinary::new()?;
 
-        Ok(Self { repo, git, workdir })
+        Ok(Self {
+            repo: shared_repo,
+            git,
+            workdir,
+        })
     }
 
     /// Check whether a path is inside a git repository.
     pub fn is_repo(path: impl AsRef<Path>) -> bool {
-        git2::Repository::discover(path.as_ref()).is_ok()
+        ThreadSafeRepository::discover(path.as_ref()).is_ok()
     }
 
     /// Get summary information about this repository.
     pub fn info(&self) -> Result<RepoInfo> {
-        let head_branch = self.repo.head().ok().and_then(|head| {
-            if head.is_branch() {
-                head.shorthand().map(String::from)
-            } else {
-                None
-            }
-        });
+        let repo = self.repo.to_thread_local();
 
-        let has_origin = self.repo.find_remote("origin").is_ok();
+        let head_branch = repo
+            .head_name()
+            .ok()
+            .flatten()
+            .map(|name| name.shorten().to_string());
+
+        let has_origin = repo.remote_names().iter().any(|n| n.as_ref() == b"origin");
 
         Ok(RepoInfo {
             workdir: self.workdir.clone(),
-            git_dir: self.repo.path().to_path_buf(),
+            git_dir: repo.path().to_path_buf(),
             head_branch,
             has_origin,
         })
@@ -72,26 +85,25 @@ impl GitRepository {
     /// For the main worktree this is the same as `git_dir`.
     /// For linked worktrees this points to the main repo's `.git` directory.
     pub fn commondir(&self) -> PathBuf {
-        self.repo.commondir().to_path_buf()
+        self.repo.to_thread_local().common_dir().to_path_buf()
     }
 
-    /// Provide read access to the underlying `git2::Repository`.
+    /// List all worktrees for this repository using gix (no subprocess).
     ///
-    /// Useful for callers that need direct libgit2 access
-    /// (e.g. for computing in-memory diffs).
-    pub fn libgit2(&self) -> &git2::Repository {
-        &self.repo
+    /// The main worktree is always first. Linked worktrees follow, sorted by
+    /// their git dir path. Worktrees whose checkout path cannot be resolved
+    /// are silently skipped.
+    pub fn list_worktrees(&self) -> Result<Vec<Worktree>> {
+        let repo = self.repo.to_thread_local();
+        crate::worktree::list_worktrees_sync(&repo)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::testutil::{init_repo, init_repo_with_commit};
     use tempfile::TempDir;
-
-    fn init_repo(dir: &Path) -> git2::Repository {
-        git2::Repository::init(dir).expect("failed to init repo")
-    }
 
     #[test]
     fn open_existing_repo() {
@@ -101,7 +113,8 @@ mod tests {
         let repo = GitRepository::open(dir.path()).unwrap();
         // Use canonicalize to handle macOS /var -> /private/var symlink
         let expected = dir.path().canonicalize().unwrap();
-        assert_eq!(repo.workdir(), expected);
+        let actual = repo.workdir().canonicalize().unwrap();
+        assert_eq!(actual, expected);
     }
 
     #[test]
@@ -114,7 +127,8 @@ mod tests {
 
         let repo = GitRepository::open(&sub).unwrap();
         let expected = dir.path().canonicalize().unwrap();
-        assert_eq!(repo.workdir(), expected);
+        let actual = repo.workdir().canonicalize().unwrap();
+        assert_eq!(actual, expected);
     }
 
     #[test]
@@ -135,12 +149,12 @@ mod tests {
     #[test]
     fn info_on_empty_repo() {
         let dir = TempDir::new().unwrap();
-        init_repo(dir.path());
+        init_repo_with_commit(dir.path());
 
         let repo = GitRepository::open(dir.path()).unwrap();
         let info = repo.info().unwrap();
-        // HEAD is unborn on an empty repo
-        assert_eq!(info.head_branch, None);
+        // gix resolves the unborn branch name from config (e.g. "main"), unlike git2
+        assert!(info.head_branch.is_some());
         assert!(!info.has_origin);
     }
 }

--- a/crates/git/src/worktree.rs
+++ b/crates/git/src/worktree.rs
@@ -1,21 +1,68 @@
 use crate::binary::GitBinary;
+use crate::repository::GitRepository;
 use crate::types::Worktree;
 use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 
-/// List all worktrees for a repository.
+/// List all worktrees for a repository using gix (no subprocess).
 ///
-/// Parses `git worktree list --porcelain` output. Always includes
-/// the main worktree as the first entry.
-pub async fn list_worktrees(git: &GitBinary, workdir: &Path) -> Result<Vec<Worktree>> {
-    let output = git
-        .run(
-            workdir,
-            &["--no-optional-locks", "worktree", "list", "--porcelain"],
-        )
-        .await?;
+/// Always returns the main worktree first. Worktrees with an unborn HEAD
+/// (no commits yet) or inaccessible checkout paths are silently skipped.
+pub async fn list_worktrees(repo: &GitRepository) -> Result<Vec<Worktree>> {
+    let shared = repo.repo.clone();
+    tokio::task::spawn_blocking(move || {
+        let local = shared.to_thread_local();
+        list_worktrees_sync(&local)
+    })
+    .await
+    .context("list_worktrees task panicked")?
+}
 
-    Ok(parse_worktrees(&output))
+pub(crate) fn list_worktrees_sync(repo: &gix::Repository) -> Result<Vec<Worktree>> {
+    let proxies = repo
+        .worktrees()
+        .context("Failed to enumerate linked worktrees")?;
+
+    let linked: Result<Vec<_>> = proxies
+        .into_iter()
+        .filter_map(|proxy| {
+            proxy
+                .into_repo_with_possibly_inaccessible_worktree()
+                .ok()
+                .map(|r| build_worktree_entry(&r, false))
+        })
+        .collect();
+
+    let mut worktrees = Vec::new();
+    worktrees.extend(build_worktree_entry(repo, true)?);
+    worktrees.extend(linked?.into_iter().flatten());
+
+    Ok(worktrees)
+}
+
+fn build_worktree_entry(repo: &gix::Repository, is_main: bool) -> Result<Option<Worktree>> {
+    let path = match repo.workdir() {
+        Some(p) => p.to_path_buf(),
+        None => return Ok(None),
+    };
+
+    let head_sha = match repo.head_id() {
+        Ok(id) => id.to_hex().to_string(),
+        Err(_) => return Ok(None),
+    };
+
+    let branch = repo
+        .head_name()
+        .ok()
+        .flatten()
+        .map(|name| name.as_bstr().to_string());
+
+    Ok(Some(Worktree {
+        path,
+        branch,
+        head_sha,
+        is_main,
+    }))
 }
 
 /// Create a new worktree with a new branch.
@@ -116,13 +163,12 @@ pub async fn remove_worktree(
 
 /// Find the worktree that has the given branch checked out, if any.
 pub async fn find_worktree_for_branch(
-    git: &GitBinary,
-    workdir: &Path,
+    repo: &GitRepository,
     branch_name: &str,
 ) -> Result<Option<Worktree>> {
-    let worktrees = list_worktrees(git, workdir).await?;
     let full_ref = format!("refs/heads/{branch_name}");
-    Ok(worktrees
+    Ok(list_worktrees(repo)
+        .await?
         .into_iter()
         .find(|wt| wt.branch.as_deref() == Some(&full_ref)))
 }
@@ -146,160 +192,18 @@ pub fn suggest_worktree_path(workdir: &Path, branch_name: &str) -> PathBuf {
         .join(sanitized_branch)
 }
 
-/// Parse `git worktree list --porcelain` output into structured data.
-///
-/// The porcelain format emits entries separated by blank lines:
-/// ```text
-/// worktree /path/to/main
-/// HEAD abc123...
-/// branch refs/heads/main
-///
-/// worktree /path/to/feature
-/// HEAD def456...
-/// branch refs/heads/feature
-/// ```
-fn parse_worktrees(output: &str) -> Vec<Worktree> {
-    let mut worktrees = Vec::new();
-    let normalized = output.replace("\r\n", "\n");
-
-    for (idx, entry) in normalized.split("\n\n").enumerate() {
-        let entry = entry.trim();
-        if entry.is_empty() {
-            continue;
-        }
-
-        let mut path = None;
-        let mut head_sha = None;
-        let mut branch = None;
-        let mut is_bare = false;
-
-        for line in entry.lines() {
-            let line = line.trim();
-            if line.is_empty() {
-                continue;
-            }
-            if let Some(rest) = line.strip_prefix("worktree ") {
-                path = Some(PathBuf::from(rest));
-            } else if let Some(rest) = line.strip_prefix("HEAD ") {
-                head_sha = Some(rest.to_string());
-            } else if let Some(rest) = line.strip_prefix("branch ") {
-                branch = Some(rest.to_string());
-            } else if line == "bare" {
-                is_bare = true;
-            }
-        }
-
-        if is_bare {
-            continue;
-        }
-
-        if let (Some(path), Some(head_sha)) = (path, head_sha) {
-            worktrees.push(Worktree {
-                path,
-                branch,
-                head_sha,
-                is_main: idx == 0,
-            });
-        }
-    }
-
-    worktrees
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::GitRepository;
-
-    #[test]
-    fn parse_single_main_worktree() {
-        let input = "\
-worktree /home/user/project
-HEAD abc123def456
-branch refs/heads/main
-";
-        let wts = parse_worktrees(input);
-        assert_eq!(wts.len(), 1);
-        assert_eq!(wts[0].path, PathBuf::from("/home/user/project"));
-        assert_eq!(wts[0].head_sha, "abc123def456");
-        assert_eq!(wts[0].branch.as_deref(), Some("refs/heads/main"));
-        assert_eq!(wts[0].branch_name(), Some("main"));
-        assert!(wts[0].is_main);
-    }
-
-    #[test]
-    fn parse_multiple_worktrees() {
-        let input = "\
-worktree /home/user/project
-HEAD abc123
-branch refs/heads/main
-
-worktree /home/user/.worktrees/project/feature-x
-HEAD def456
-branch refs/heads/feature/x
-";
-        let wts = parse_worktrees(input);
-        assert_eq!(wts.len(), 2);
-
-        assert!(wts[0].is_main);
-        assert_eq!(wts[0].branch_name(), Some("main"));
-
-        assert!(!wts[1].is_main);
-        assert_eq!(wts[1].branch_name(), Some("feature/x"));
-        assert_eq!(
-            wts[1].path,
-            PathBuf::from("/home/user/.worktrees/project/feature-x")
-        );
-    }
-
-    #[test]
-    fn parse_detached_head() {
-        let input = "\
-worktree /home/user/project
-HEAD abc123
-branch refs/heads/main
-
-worktree /tmp/detached
-HEAD 789abc
-detached
-";
-        let wts = parse_worktrees(input);
-        assert_eq!(wts.len(), 2);
-        assert!(wts[1].branch.is_none());
-        assert_eq!(wts[1].branch_name(), None);
-    }
-
-    #[test]
-    fn parse_bare_repo_skipped() {
-        let input = "\
-worktree /home/user/project.git
-HEAD abc123
-bare
-";
-        let wts = parse_worktrees(input);
-        assert_eq!(wts.len(), 0);
-    }
-
-    #[test]
-    fn parse_empty_input() {
-        let wts = parse_worktrees("");
-        assert!(wts.is_empty());
-    }
-
-    #[test]
-    fn parse_crlf_line_endings() {
-        let input = "worktree /home/user/project\r\nHEAD abc123\r\nbranch refs/heads/main\r\n";
-        let wts = parse_worktrees(input);
-        assert_eq!(wts.len(), 1);
-        assert_eq!(wts[0].branch_name(), Some("main"));
-    }
+    use crate::testutil::init_repo_with_commit;
 
     #[test]
     fn test_suggest_worktree_path() {
         let dir = tempfile::TempDir::new().unwrap();
         let repo_dir = dir.path().join("my-project");
         std::fs::create_dir_all(&repo_dir).unwrap();
-        git2::Repository::init(&repo_dir).unwrap();
+        gix::init(&repo_dir).unwrap();
 
         let repo = GitRepository::open(&repo_dir).unwrap();
         let suggested = suggest_worktree_path(repo.workdir(), "feature/login");
@@ -313,7 +217,11 @@ bare
             .join("my-project")
             .join("feature-login");
 
-        assert_eq!(suggested, expected);
+        // Use canonicalize on the root tmpdir to resolve macOS /var -> /private/var symlink,
+        // then re-append the relative suffix that suggest_worktree_path would produce
+        let root = dir.path().canonicalize().unwrap();
+        let suffix = suggested.strip_prefix(dir.path()).unwrap();
+        assert_eq!(root.join(suffix), expected);
     }
 
     // Integration tests that require git binary
@@ -325,23 +233,7 @@ bare
         std::fs::create_dir_all(&repo_dir).unwrap();
 
         // Need a commit before we can create worktrees
-        let git_repo = git2::Repository::init(&repo_dir).unwrap();
-        {
-            let sig = git2::Signature::now("Test", "test@test.com").unwrap();
-            let tree_id = {
-                let mut index = git_repo.index().unwrap();
-                let file_path = repo_dir.join("README.md");
-                std::fs::write(&file_path, "# Test\n").unwrap();
-                index.add_path(std::path::Path::new("README.md")).unwrap();
-                index.write().unwrap();
-                index.write_tree().unwrap()
-            };
-            let tree = git_repo.find_tree(tree_id).unwrap();
-            git_repo
-                .commit(Some("HEAD"), &sig, &sig, "Initial", &tree, &[])
-                .unwrap();
-        }
-        drop(git_repo);
+        init_repo_with_commit(&repo_dir);
 
         let repo = GitRepository::open(&repo_dir).unwrap();
 
@@ -354,20 +246,20 @@ bare
         assert!(wt_path.exists());
 
         // List worktrees
-        let worktrees = list_worktrees(&repo.git, repo.workdir()).await.unwrap();
+        let worktrees = list_worktrees(&repo).await.unwrap();
         assert_eq!(worktrees.len(), 2);
         assert!(worktrees[0].is_main);
         assert!(!worktrees[1].is_main);
         assert_eq!(worktrees[1].branch_name(), Some("feature-branch"));
 
         // Find worktree for branch
-        let found = find_worktree_for_branch(&repo.git, repo.workdir(), "feature-branch")
+        let found = find_worktree_for_branch(&repo, "feature-branch")
             .await
             .unwrap();
         assert!(found.is_some());
         assert_eq!(found.unwrap().branch_name(), Some("feature-branch"));
 
-        let not_found = find_worktree_for_branch(&repo.git, repo.workdir(), "nonexistent")
+        let not_found = find_worktree_for_branch(&repo, "nonexistent")
             .await
             .unwrap();
         assert!(not_found.is_none());
@@ -379,23 +271,7 @@ bare
         let repo_dir = dir.path().join("main-repo");
         std::fs::create_dir_all(&repo_dir).unwrap();
 
-        let git_repo = git2::Repository::init(&repo_dir).unwrap();
-        {
-            let sig = git2::Signature::now("Test", "test@test.com").unwrap();
-            let tree_id = {
-                let mut index = git_repo.index().unwrap();
-                let file_path = repo_dir.join("README.md");
-                std::fs::write(&file_path, "# Test\n").unwrap();
-                index.add_path(std::path::Path::new("README.md")).unwrap();
-                index.write().unwrap();
-                index.write_tree().unwrap()
-            };
-            let tree = git_repo.find_tree(tree_id).unwrap();
-            git_repo
-                .commit(Some("HEAD"), &sig, &sig, "Initial", &tree, &[])
-                .unwrap();
-        }
-        drop(git_repo);
+        init_repo_with_commit(&repo_dir);
 
         let repo = GitRepository::open(&repo_dir).unwrap();
 
@@ -410,7 +286,7 @@ bare
             .unwrap();
         assert!(!wt_path.exists());
 
-        let worktrees = list_worktrees(&repo.git, repo.workdir()).await.unwrap();
+        let worktrees = list_worktrees(&repo).await.unwrap();
         assert_eq!(worktrees.len(), 1); // only main remains
     }
 
@@ -420,25 +296,19 @@ bare
         let repo_dir = dir.path().join("main-repo");
         std::fs::create_dir_all(&repo_dir).unwrap();
 
-        let git_repo = git2::Repository::init(&repo_dir).unwrap();
-        {
-            let sig = git2::Signature::now("Test", "test@test.com").unwrap();
-            let tree_id = {
-                let mut index = git_repo.index().unwrap();
-                let file_path = repo_dir.join("README.md");
-                std::fs::write(&file_path, "# Test\n").unwrap();
-                index.add_path(std::path::Path::new("README.md")).unwrap();
-                index.write().unwrap();
-                index.write_tree().unwrap()
-            };
-            let tree = git_repo.find_tree(tree_id).unwrap();
-            let commit = git_repo
-                .commit(Some("HEAD"), &sig, &sig, "Initial", &tree, &[])
-                .unwrap();
-            let commit = git_repo.find_commit(commit).unwrap();
-            git_repo.branch("existing-branch", &commit, false).unwrap();
-        }
-        drop(git_repo);
+        let repo_gix = init_repo_with_commit(&repo_dir);
+
+        // Create an extra branch using gix
+        let head_id = repo_gix.head_id().unwrap();
+        repo_gix
+            .reference(
+                "refs/heads/existing-branch",
+                head_id,
+                gix::refs::transaction::PreviousValue::MustNotExist,
+                "branch: Created from HEAD",
+            )
+            .unwrap();
+        drop(repo_gix);
 
         let repo = GitRepository::open(&repo_dir).unwrap();
 
@@ -448,7 +318,7 @@ bare
             .unwrap();
         assert!(wt_path.exists());
 
-        let worktrees = list_worktrees(&repo.git, repo.workdir()).await.unwrap();
+        let worktrees = list_worktrees(&repo).await.unwrap();
         assert_eq!(worktrees.len(), 2);
         assert_eq!(worktrees[1].branch_name(), Some("existing-branch"));
     }


### PR DESCRIPTION
This PR replaces `git2` with rust-native `gix`.

Authored via CC as this project not fully working on my system, and as such mostly tested via the unit test setup.

Possible regressions: `gix` does not yet fully support reftable, sparse indices and sha256 repos, thought some of these are also lacking in libgit2 iirc.

Also optimised `GitBinary::command` with `GIT_OPTIONAL_LOCKS ` a bit. By the way I would argue disabling `core.fsmonitor` is less useful If you are still executing git hooks.
