### PR TITLE
Make GUI the default launch mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,21 +125,21 @@ See [docs/format-on-save-feature.md](docs/format-on-save-feature.md) for detaile
 ### GUI Mode (Recommended)
 
 ```bash
-# Start with graphical interface
-code-assistant --ui
+# Start with graphical interface (default)
+code-assistant
 
 # Start GUI with initial task
-code-assistant --ui --task "Analyze the authentication system"
+code-assistant --task "Analyze the authentication system"
 ```
 
 ### Terminal Mode
 
 ```bash
-# Basic usage
-code-assistant --task "Explain the purpose of this codebase"
+# Start with terminal interface
+code-assistant --tui --task "Explain the purpose of this codebase"
 
 # With specific model
-code-assistant --task "Add error handling" --model "GPT-5"
+code-assistant --tui --task "Add error handling" --model "GPT-5"
 ```
 
 ### Working Directory Matters
@@ -150,7 +150,7 @@ The directory from which you launch `code-assistant` determines the project cont
 
 ```bash
 cd ~/workspace/my-project
-code-assistant --ui
+code-assistant
 ```
 
 Chats are **grouped by directory**, so starting a new chat from the correct project directory ensures:

--- a/crates/code_assistant/src/cli.rs
+++ b/crates/code_assistant/src/cli.rs
@@ -79,13 +79,13 @@ pub struct Args {
     #[arg(long, default_value = ".")]
     pub path: PathBuf,
 
-    /// Task to perform on the codebase (required in terminal mode, optional with --ui)
+    /// Task to perform on the codebase (required in terminal mode, optional in GUI mode)
     #[arg(short, long)]
     pub task: Option<String>,
 
-    /// Start with GUI interface
+    /// Start with terminal interface instead of GUI
     #[arg(long)]
-    pub ui: bool,
+    pub tui: bool,
 
     /// Continue from previous state
     #[arg(long)]
@@ -274,7 +274,7 @@ mod tests {
 
         assert_eq!(args.path, std::path::PathBuf::from("."));
         assert_eq!(args.verbose, 0);
-        assert!(!args.ui);
+        assert!(!args.tui);
         assert!(!args.continue_task);
         assert!(!args.fast_playback);
         assert!(!args.use_diff_format);

--- a/crates/code_assistant/src/main.rs
+++ b/crates/code_assistant/src/main.rs
@@ -105,7 +105,16 @@ async fn main() -> Result<()> {
             }
         }
         None => {
-            if args.ui {
+            // Determine whether to launch the GPUI frontend. The graphical
+            // interface is the default when compiled in; otherwise we fall
+            // back to the terminal frontend so the binary stays useful in
+            // headless builds (e.g. `--no-default-features`).
+            #[cfg(feature = "gpui-frontend")]
+            let use_gpui = !args.tui;
+            #[cfg(not(feature = "gpui-frontend"))]
+            let use_gpui = false;
+
+            if use_gpui {
                 // GPUI mode - use stderr to keep stdout clean
                 setup_logging(args.verbose, false);
             } else {
@@ -120,7 +129,7 @@ async fn main() -> Result<()> {
 
             // In GUI mode, allow starting without a valid model config
             // (the settings screen will guide the user through setup).
-            let model_name = if args.ui {
+            let model_name = if use_gpui {
                 args.get_model_name().unwrap_or_default()
             } else {
                 args.get_model_name()?
@@ -140,7 +149,7 @@ async fn main() -> Result<()> {
                 sandbox_policy,
             };
 
-            if args.ui {
+            if use_gpui {
                 #[cfg(feature = "gpui-frontend")]
                 {
                     app::gpui::run(config)
@@ -148,10 +157,7 @@ async fn main() -> Result<()> {
                 #[cfg(not(feature = "gpui-frontend"))]
                 {
                     let _ = config;
-                    anyhow::bail!(
-                        "This binary was built without the GPUI frontend \
-                         (feature `gpui-frontend`)"
-                    )
+                    unreachable!("use_gpui is only true when the gpui-frontend feature is enabled")
                 }
             } else {
                 #[cfg(feature = "terminal-frontend")]

--- a/docs/agent-client-protocol/acp-integration-plan.md
+++ b/docs/agent-client-protocol/acp-integration-plan.md
@@ -11,8 +11,8 @@ The Agent Client Protocol standardizes communication between code editors (clien
 ### Current Architecture
 
 code-assistant currently supports three run modes:
-1. **Terminal UI** (`code-assistant --task "..."`) - Interactive terminal interface
-2. **GPUI** (`code-assistant --ui`) - Modern graphical interface
+1. **Terminal UI** (`code-assistant --tui --task "..."`) - Interactive terminal interface
+2. **GPUI** (`code-assistant`) - Modern graphical interface (default)
 3. **MCP Server** (`code-assistant server`) - Model Context Protocol server for Claude Desktop
 
 The architecture has:


### PR DESCRIPTION
## Summary

Make the graphical interface the default when launching `code-assistant` without a subcommand. A new `--tui` flag is added for users who want the terminal interface.

Please review / merge #128 before this PR.

## Motivation

With the macOS `.app` bundle support added in #128, the app needs to launch into GUI mode by default so that double-clicking the application icon works as expected. Previously, users had to pass `--ui` explicitly, which is not practical for a bundled application.

## Changes

- Remove the `--ui` flag
- Add `--tui` flag to opt into terminal mode
- Swap default logic in `main.rs` so GUI is the fallback
- Update README and docs to reflect the new defaults

## Breaking Change

The `--ui` flag no longer exists. Users who had `--ui` in scripts or aliases should simply remove it. Users who relied on the implicit terminal default should add `--tui`.