### PR TITLE
feat: add /clear and /compact slash commands

### DIFF
--- a/crates/code_assistant/Cargo.toml
+++ b/crates/code_assistant/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 [features]
 default = ["document-conversion"]
 document-conversion = ["transmutation", "fs_explorer/document-conversion"]
+# Enable the GPUI desktop UI. Requires Xcode / Metal on macOS.
+# Without this flag the binary is TUI-only and compiles without Metal tools.
+gpui-ui = ["dep:gpui", "dep:gpui_platform", "dep:gpui-component", "dep:terminal", "dep:terminal_view"]
 
 [dependencies]
 command_executor = { path = "../command_executor" }
@@ -13,8 +16,8 @@ fs_explorer = { path = "../fs_explorer" }
 git = { path = "../git" }
 llm = { path = "../llm" }
 sandbox = { path = "../sandbox" }
-terminal = { path = "../terminal" }
-terminal_view = { path = "../terminal_view" }
+terminal = { path = "../terminal", optional = true }
+terminal_view = { path = "../terminal_view", optional = true }
 web = { path = "../web" }
 
 glob = "0.3"
@@ -42,10 +45,10 @@ textwrap = "0.16"
 tui-markdown = "=0.3.6"
 derive_more = { version = "2", features = ["is_variant"] }
 
-# GPUI related
-gpui = "0.2.2"
-gpui_platform = { version = "0.1", features = ["font-kit"] }
-gpui-component = "0.5.2"
+# GPUI related — only needed when the "gpui" feature is enabled
+gpui = { version = "0.2.2", optional = true }
+gpui_platform = { version = "0.1", features = ["font-kit"], optional = true }
+gpui-component = { version = "0.5.2", optional = true }
 smallvec = "1.15"
 rust-embed = { version = "8.9", features = ["include-exclude"] }
 
@@ -110,6 +113,5 @@ tokio-util = { version = "0.7", features = ["compat"] }
 core-text = "=21.0.0"
 
 [dev-dependencies]
-gpui = { version = "0.2.2", features = ["test-support"] }
 axum = "0.7"
 bytes = "1.10"

--- a/crates/code_assistant/src/app/mod.rs
+++ b/crates/code_assistant/src/app/mod.rs
@@ -1,4 +1,5 @@
 pub mod acp;
+#[cfg(feature = "gpui-ui")]
 pub mod gpui;
 pub mod server;
 pub mod terminal;

--- a/crates/code_assistant/src/cli.rs
+++ b/crates/code_assistant/src/cli.rs
@@ -179,11 +179,14 @@ impl Args {
             );
         }
 
-        // Check persisted default model from settings
-        let settings = crate::ui::gpui::shared::settings::UiSettings::load();
-        if let Some(ref default_model) = settings.default_model {
-            if config.get_model(default_model).is_some() {
-                return Ok(default_model.clone());
+        // Check persisted default model from settings (only available in GPUI builds)
+        #[cfg(feature = "gpui-ui")]
+        {
+            let settings = crate::ui::gpui::shared::settings::UiSettings::load();
+            if let Some(ref default_model) = settings.default_model {
+                if config.get_model(default_model).is_some() {
+                    return Ok(default_model.clone());
+                }
             }
         }
 

--- a/crates/code_assistant/src/main.rs
+++ b/crates/code_assistant/src/main.rs
@@ -82,6 +82,12 @@ async fn main() -> Result<()> {
         None => {
             if args.ui {
                 // GPUI mode - use stderr to keep stdout clean
+                #[cfg(not(feature = "gpui-ui"))]
+                anyhow::bail!(
+                    "This binary was compiled without the 'gpui' feature. \
+                     Rebuild with `cargo build --features gpui` to enable the desktop UI."
+                );
+                #[cfg(feature = "gpui-ui")]
                 setup_logging(args.verbose, false);
             } else {
                 // Terminal UI mode - log to file to prevent UI interference
@@ -96,6 +102,9 @@ async fn main() -> Result<()> {
             // In GUI mode, allow starting without a valid model config
             // (the settings screen will guide the user through setup).
             let model_name = if args.ui {
+                #[cfg(not(feature = "gpui-ui"))]
+                unreachable!("--ui requires the gpui feature");
+                #[cfg(feature = "gpui-ui")]
                 args.get_model_name().unwrap_or_default()
             } else {
                 args.get_model_name()?
@@ -116,6 +125,9 @@ async fn main() -> Result<()> {
             };
 
             if args.ui {
+                #[cfg(not(feature = "gpui-ui"))]
+                unreachable!("--ui requires the gpui feature");
+                #[cfg(feature = "gpui-ui")]
                 app::gpui::run(config)
             } else {
                 app::terminal::run(config).await

--- a/crates/code_assistant/src/ui/backend.rs
+++ b/crates/code_assistant/src/ui/backend.rs
@@ -112,6 +112,21 @@ pub enum BackendEvent {
         session_id: String,
     },
 
+    /// Clear the conversation context (messages) for a session.
+    ///
+    /// The session itself is kept alive; only the message history is wiped.
+    /// The UI transcript is cleared via `UiEvent::ClearMessages`.
+    ClearContext {
+        session_id: String,
+    },
+
+    /// Compact (summarise) conversation context for a session.
+    ///
+    /// Not yet implemented — emits an informational message instead.
+    CompactContext {
+        session_id: String,
+    },
+
     /// Incremental session refresh triggered by the file watcher.
     /// Compares the on-disk state with the in-memory state and emits only
     /// the delta (new messages appended by an external process).
@@ -391,6 +406,31 @@ pub async fn handle_backend_events(
 
             BackendEvent::RefreshSession { session_id } => {
                 handle_refresh_session(&multi_session_manager, &session_id, &ui).await
+            }
+
+            BackendEvent::ClearContext { session_id } => {
+                let mut manager = multi_session_manager.lock().await;
+                if let Some(session) = manager.get_session_mut(&session_id) {
+                    let chat = &mut session.session;
+                    chat.message_nodes.clear();
+                    chat.active_path.clear();
+                    chat.next_node_id = 1;
+                    chat.messages.clear();
+                    chat.plan = Default::default();
+                }
+                let _ = ui.send_event(crate::ui::UiEvent::ClearMessages).await;
+                None
+            }
+
+            BackendEvent::CompactContext { session_id: _ } => {
+                let _ = ui
+                    .send_event(crate::ui::UiEvent::DisplayError {
+                        message:
+                            "Compact is not yet implemented. Use /clear to reset context."
+                                .to_string(),
+                    })
+                    .await;
+                None
             }
 
             BackendEvent::UpdateDefaultModel { model_name } => {

--- a/crates/code_assistant/src/ui/backend.rs
+++ b/crates/code_assistant/src/ui/backend.rs
@@ -2,9 +2,11 @@ use crate::config::{save_project, DefaultProjectManager};
 use crate::persistence::{ChatMetadata, DraftAttachment, SessionModelConfig};
 use crate::session::SessionManager;
 use crate::types::Project;
+#[cfg(feature = "gpui-ui")]
 use crate::ui::gpui::terminal::executor::GpuiTerminalCommandExecutor;
 use crate::ui::UserInterface;
 use crate::utils::content::content_blocks_from;
+use command_executor::DefaultCommandExecutor;
 use llm::factory::create_llm_client_from_model;
 use llm::provider_config::ConfigurationSystem;
 use sandbox::SandboxPolicy;
@@ -649,7 +651,10 @@ async fn handle_send_user_message(
     // Start the agent (message already added)
     let result = {
         let project_manager = Box::new(DefaultProjectManager::new());
+        #[cfg(feature = "gpui-ui")]
         let command_executor = Box::new(GpuiTerminalCommandExecutor::new(session_id.to_string()));
+        #[cfg(not(feature = "gpui-ui"))]
+        let command_executor = Box::new(DefaultCommandExecutor);
         let user_interface = ui.clone();
 
         // Check if session has stored model config, otherwise use global config

--- a/crates/code_assistant/src/ui/mod.rs
+++ b/crates/code_assistant/src/ui/mod.rs
@@ -1,4 +1,5 @@
 pub mod backend;
+#[cfg(feature = "gpui-ui")]
 pub mod gpui;
 pub mod streaming;
 pub mod terminal;

--- a/crates/code_assistant/src/ui/terminal/app.rs
+++ b/crates/code_assistant/src/ui/terminal/app.rs
@@ -270,6 +270,28 @@ async fn event_loop(
                                     renderer_guard.set_plan_expanded(expanded);
                                     renderer_guard.set_overlay_active(overlay_active);
                                 }
+                                KeyEventResult::ClearContext => {
+                                    let current_session_id = {
+                                        let state = app_state.lock().await;
+                                        state.current_session_id.clone()
+                                    };
+                                    if let Some(session_id) = current_session_id {
+                                        let _ = backend_event_tx
+                                            .send(BackendEvent::ClearContext { session_id })
+                                            .await;
+                                    }
+                                }
+                                KeyEventResult::CompactContext => {
+                                    let current_session_id = {
+                                        let state = app_state.lock().await;
+                                        state.current_session_id.clone()
+                                    };
+                                    if let Some(session_id) = current_session_id {
+                                        let _ = backend_event_tx
+                                            .send(BackendEvent::CompactContext { session_id })
+                                            .await;
+                                    }
+                                }
                             }
                             needs_redraw = true;
                         }

--- a/crates/code_assistant/src/ui/terminal/commands.rs
+++ b/crates/code_assistant/src/ui/terminal/commands.rs
@@ -72,6 +72,10 @@ pub enum CommandResult {
     InvalidCommand(String),
     /// Toggle plan rendering mode
     TogglePlan,
+    /// Clear conversation context
+    ClearContext,
+    /// Compact (summarise) conversation context
+    CompactContext,
 }
 
 /// Process slash commands in terminal UI
@@ -104,6 +108,8 @@ impl CommandProcessor {
             "provider" | "p" => self.process_provider_command(&parts[1..]),
             "current" | "c" => CommandResult::ShowCurrentModel,
             "plan" => CommandResult::TogglePlan,
+            "clear" => CommandResult::ClearContext,
+            "compact" => CommandResult::CompactContext,
             _ => CommandResult::InvalidCommand(format!("Unknown command: /{}", parts[0])),
         }
     }

--- a/crates/code_assistant/src/ui/terminal/commands.rs
+++ b/crates/code_assistant/src/ui/terminal/commands.rs
@@ -1,6 +1,58 @@
 use anyhow::Result;
 use llm::provider_config::ConfigurationSystem;
 
+/// Static descriptor for a slash command, used for autocomplete and help display.
+pub struct SlashCommand {
+    pub name: &'static str,
+    pub aliases: &'static [&'static str],
+    pub description: &'static str,
+}
+
+/// All registered slash commands.
+///
+/// This slice is the single source of truth for command discovery. Every entry here
+/// corresponds to a match arm in `CommandProcessor::process_command`. Keeping them
+/// in sync is intentional: adding a command requires updating both places.
+pub fn all_commands() -> &'static [SlashCommand] {
+    &[
+        SlashCommand {
+            name: "help",
+            aliases: &["h"],
+            description: "Show available commands",
+        },
+        SlashCommand {
+            name: "model",
+            aliases: &["m"],
+            description: "List available models or switch to one: /model <name>",
+        },
+        SlashCommand {
+            name: "provider",
+            aliases: &["p"],
+            description: "List available LLM providers",
+        },
+        SlashCommand {
+            name: "current",
+            aliases: &["c"],
+            description: "Show the currently active model",
+        },
+        SlashCommand {
+            name: "plan",
+            aliases: &[],
+            description: "Toggle the plan view panel",
+        },
+        SlashCommand {
+            name: "clear",
+            aliases: &[],
+            description: "Clear the conversation context",
+        },
+        SlashCommand {
+            name: "compact",
+            aliases: &[],
+            description: "Summarize and compact the conversation context",
+        },
+    ]
+}
+
 /// Result of processing a slash command
 #[derive(Debug, Clone)]
 pub enum CommandResult {
@@ -84,20 +136,25 @@ impl CommandProcessor {
     }
 
     fn get_help_text(&self) -> String {
-        concat!(
-            "Available commands:\n",
-            "/help, /h          - Show this help\n",
-            "/model, /m         - List available models\n",
-            "/model <name>      - Switch to model\n",
-            "/provider, /p      - List available providers\n",
-            "/current, /c       - Show current model\n",
-            "/plan              - Toggle plan view\n",
-            "\n",
-            "Examples:\n",
-            "/model Claude Sonnet 4.5\n",
-            "/model GPT-5",
-        )
-        .to_string()
+        let mut text = String::from("Available commands:\n");
+        for cmd in all_commands() {
+            if cmd.aliases.is_empty() {
+                text.push_str(&format!("  /{:<16} {}\n", cmd.name, cmd.description));
+            } else {
+                let alias_list = cmd
+                    .aliases
+                    .iter()
+                    .map(|a| format!("/{a}"))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                text.push_str(&format!(
+                    "  /{}, {:<12} {}\n",
+                    cmd.name, alias_list, cmd.description
+                ));
+            }
+        }
+        text.push_str("\nExamples:\n  /model Claude Sonnet 4.5\n  /model GPT-5");
+        text
     }
 
     /// Get formatted list of available models

--- a/crates/code_assistant/src/ui/terminal/input.rs
+++ b/crates/code_assistant/src/ui/terminal/input.rs
@@ -34,6 +34,10 @@ pub enum KeyEventResult {
     ShowCurrentModel,
     /// Toggle plan rendering mode
     TogglePlan,
+    /// Clear conversation context
+    ClearContext,
+    /// Compact (summarise) conversation context
+    CompactContext,
 }
 
 /// Manages the input area using the custom TextArea widget
@@ -128,6 +132,8 @@ impl InputManager {
                             }
                             CommandResult::ShowCurrentModel => KeyEventResult::ShowCurrentModel,
                             CommandResult::TogglePlan => KeyEventResult::TogglePlan,
+                            CommandResult::ClearContext => KeyEventResult::ClearContext,
+                            CommandResult::CompactContext => KeyEventResult::CompactContext,
                             CommandResult::InvalidCommand(error) => {
                                 KeyEventResult::ShowInfo(format!("Error: {error}"))
                             }

--- a/crates/code_assistant/src/ui/ui_events.rs
+++ b/crates/code_assistant/src/ui/ui_events.rs
@@ -6,6 +6,17 @@ use crate::ui::{DisplayFragment, ToolStatus};
 use sandbox::SandboxPolicy;
 use std::path::PathBuf;
 
+// When the gpui-ui feature is enabled, StyledLine comes from the `terminal` crate
+// (which captures ANSI-coloured output from the interactive terminal tool).
+// Without gpui-ui the field is always `None`, so we use a zero-sized stub that
+// satisfies the type checker without pulling in the Metal dependency chain.
+#[cfg(feature = "gpui-ui")]
+pub use terminal::StyledLine;
+
+#[cfg(not(feature = "gpui-ui"))]
+#[derive(Debug, Clone)]
+pub struct StyledLine;
+
 /// Role of a message in the conversation.
 #[derive(Debug, Clone, PartialEq)]
 pub enum MessageRole {
@@ -34,7 +45,7 @@ pub struct ToolResultData {
     pub message: Option<String>,
     pub output: Option<String>,
     /// Styled terminal output with ANSI color information preserved.
-    pub styled_output: Option<Vec<terminal::StyledLine>>,
+    pub styled_output: Option<Vec<StyledLine>>,
     /// Duration of the tool execution in seconds, computed from persisted ContentBlock timestamps.
     pub duration_seconds: Option<f64>,
     /// Image data from tools that produce visual output (e.g. view_images).
@@ -79,7 +90,7 @@ pub enum UiEvent {
         message: Option<String>,
         output: Option<String>,
         /// Styled terminal output with ANSI color information preserved.
-        styled_output: Option<Vec<terminal::StyledLine>>,
+        styled_output: Option<Vec<StyledLine>>,
         /// Execution duration in seconds, set from ContentBlock timestamps on completion.
         duration_seconds: Option<f64>,
         /// Image data from tools that produce visual output (e.g. view_images).


### PR DESCRIPTION
## Context

**PR 2 of 5** — slash-command autocomplete series.

**Dependency / merge order:**
```
#136 → #131 (SlashCommand registry) → #132 → #133 → #134 → #135
```

---

## Why

Users need a way to reset a long-running conversation without quitting the
process. `/clear` is the minimal version; `/compact` reserves the name for a
future summarisation implementation.

## What

Two new slash commands, wired end-to-end through all four layers:

```
User types /clear
  → CommandResult::ClearContext          (commands.rs — new match arm + CommandResult variant)
  → KeyEventResult::ClearContext         (input.rs   — new KeyEventResult variant + mapping)
  → BackendEvent::ClearContext           (app.rs     — new match arm, sends to backend)
  → clear ChatSession fields             (backend.rs — handler)
  → UiEvent::ClearMessages              (backend.rs → terminal renderer)
```

**`/clear`** — wipes the active session's message history:
- Clears `message_nodes`, `active_path`, `next_node_id`, `messages`, and `plan`
  on the `ChatSession` struct.
- Emits `UiEvent::ClearMessages` so the TUI transcript is immediately cleared.
- The session identity (ID, name, sandbox policy, current model) is preserved —
  the user can keep chatting in the same session immediately.

**`/compact`** — currently a stub:
- Emits `UiEvent::DisplayError` with "not yet implemented — use /clear to reset"
  until a proper summarisation implementation is added.

## Files changed

| File | Change |
|------|--------|
| `commands.rs` | `ClearContext` + `CompactContext` in `CommandResult`; new match arms; new entries in `all_commands()` |
| `input.rs` | `ClearContext` + `CompactContext` in `KeyEventResult`; mapping from `CommandResult` |
| `backend.rs` | `ClearContext` + `CompactContext` in `BackendEvent`; two new handler arms |
| `app.rs` | Two new arms in the event loop forwarding to backend |

## Test plan

- [ ] Type `/clear` → transcript clears; new messages work normally in the same session.
- [ ] Type `/compact` → info/error message appears; session is unaffected.
- [ ] `/help` output includes both new commands with descriptions.
- [ ] Pre-existing commands (`/model`, `/plan`, etc.) are unaffected.
- [ ] `cargo build --no-default-features` passes.