### PR TITLE
feat: slash-command system with stacked popups

### DIFF
--- a/crates/code_assistant_core/src/backend.rs
+++ b/crates/code_assistant_core/src/backend.rs
@@ -118,6 +118,21 @@ pub enum BackendEvent {
         session_id: String,
     },
 
+    /// Clear the conversation context (messages) for a session.
+    ///
+    /// The session itself is kept alive; only the message history is wiped.
+    /// The UI transcript is cleared via `UiEvent::ClearMessages`.
+    ClearContext {
+        session_id: String,
+    },
+
+    /// Compact (summarise) conversation context for a session.
+    ///
+    /// Not yet implemented — emits an informational message instead.
+    CompactContext {
+        session_id: String,
+    },
+
     /// Incremental session refresh triggered by the file watcher.
     /// Compares the on-disk state with the in-memory state and emits only
     /// the delta (new messages appended by an external process).
@@ -414,6 +429,30 @@ pub async fn handle_backend_events(
 
             BackendEvent::RefreshSession { session_id } => {
                 handle_refresh_session(&multi_session_manager, &session_id, &ui).await
+            }
+
+            BackendEvent::ClearContext { session_id } => {
+                let mut manager = multi_session_manager.lock().await;
+                if let Some(session) = manager.get_session_mut(&session_id) {
+                    let chat = &mut session.session;
+                    chat.message_nodes.clear();
+                    chat.active_path.clear();
+                    chat.next_node_id = 1;
+                    chat.messages.clear();
+                    chat.plan = Default::default();
+                }
+                let _ = ui.send_event(crate::ui::UiEvent::ClearMessages).await;
+                None
+            }
+
+            BackendEvent::CompactContext { session_id: _ } => {
+                let _ = ui
+                    .send_event(crate::ui::UiEvent::DisplayError {
+                        message: "Compact is not yet implemented. Use /clear to reset context."
+                            .to_string(),
+                    })
+                    .await;
+                None
             }
 
             BackendEvent::UpdateDefaultModel { model_name } => {

--- a/crates/ui_terminal/src/app.rs
+++ b/crates/ui_terminal/src/app.rs
@@ -1,4 +1,5 @@
 use crate::{
+    commands::all_commands,
     input::{InputManager, KeyEventResult},
     renderer::ProductionTerminalRenderer,
     state::AppState,
@@ -292,6 +293,92 @@ async fn event_loop(
                                             .await;
                                     }
                                 }
+                                KeyEventResult::UpdateAutocomplete { query } => {
+                                    match query {
+                                        None => {
+                                            // Current line no longer starts with '/'; close popup.
+                                            let mut state = app_state.lock().await;
+                                            state.close_autocomplete();
+                                            input_manager.autocomplete_active = false;
+                                        }
+                                        Some(q) => {
+                                            let filtered: Vec<_> = all_commands()
+                                                .iter()
+                                                .filter(|cmd| {
+                                                    cmd.name.starts_with(q.as_str())
+                                                        || cmd.aliases.iter().any(|a| a.starts_with(q.as_str()))
+                                                })
+                                                .collect();
+                                            let mut state = app_state.lock().await;
+                                            if filtered.is_empty() {
+                                                state.close_autocomplete();
+                                                input_manager.autocomplete_active = false;
+                                            } else {
+                                                // Clamp selected index to new list length.
+                                                let selected = state
+                                                    .autocomplete_selected
+                                                    .min(filtered.len().saturating_sub(1));
+                                                state.open_autocomplete(q);
+                                                state.autocomplete_selected = selected;
+                                                input_manager.autocomplete_active = true;
+                                            }
+                                        }
+                                    }
+                                }
+                                KeyEventResult::MoveAutocomplete(delta) => {
+                                    let item_count = {
+                                        let state = app_state.lock().await;
+                                        let q = &state.autocomplete_query.clone();
+                                        all_commands()
+                                            .iter()
+                                            .filter(|cmd| {
+                                                cmd.name.starts_with(q.as_str())
+                                                    || cmd.aliases.iter().any(|a| a.starts_with(q.as_str()))
+                                            })
+                                            .count()
+                                    };
+                                    let mut state = app_state.lock().await;
+                                    state.move_autocomplete_selection(delta, item_count);
+                                }
+                                KeyEventResult::SelectAutocomplete => {
+                                    // Find the selected command and expand its name into the textarea.
+                                    let (selected_name, query) = {
+                                        let state = app_state.lock().await;
+                                        let q = state.autocomplete_query.clone();
+                                        let filtered: Vec<_> = all_commands()
+                                            .iter()
+                                            .filter(|cmd| {
+                                                cmd.name.starts_with(q.as_str())
+                                                    || cmd.aliases.iter().any(|a| a.starts_with(q.as_str()))
+                                            })
+                                            .collect();
+                                        let name = filtered
+                                            .get(state.autocomplete_selected)
+                                            .map(|cmd| cmd.name.to_string());
+                                        (name, q)
+                                    };
+
+                                    if let Some(name) = selected_name {
+                                        // Replace "/<query>" on the current line with "/<name> ".
+                                        // Compute the byte range: from start-of-line up to cursor.
+                                        let cursor = input_manager.textarea.cursor();
+                                        let text = input_manager.textarea.text().to_string();
+                                        let line_start = text[..cursor]
+                                            .rfind('\n')
+                                            .map(|i| i + 1)
+                                            .unwrap_or(0);
+                                        // Replace exactly the portion "/<query>" the user typed.
+                                        let typed_end = line_start + 1 + query.len(); // '/' + query
+                                        let replace_end = typed_end.min(cursor);
+                                        input_manager.textarea.replace_range(
+                                            line_start..replace_end,
+                                            &format!("/{name} "),
+                                        );
+                                        let mut state = app_state.lock().await;
+                                        state.close_autocomplete();
+                                        input_manager.autocomplete_active = false;
+                                    }
+                                }
                             }
                             needs_redraw = true;
                         }
@@ -300,6 +387,28 @@ async fn event_loop(
                             // normalize before processing.
                             let pasted = pasted.replace('\r', "\n");
                             input_manager.handle_paste(pasted);
+                            // Update autocomplete: pasting may introduce or clear a slash prefix.
+                            match input_manager.slash_prefix() {
+                                None => {
+                                    let mut state = app_state.lock().await;
+                                    state.close_autocomplete();
+                                    input_manager.autocomplete_active = false;
+                                }
+                                Some(q) => {
+                                    let has_matches = all_commands().iter().any(|cmd| {
+                                        cmd.name.starts_with(q.as_str())
+                                            || cmd.aliases.iter().any(|a| a.starts_with(q.as_str()))
+                                    });
+                                    let mut state = app_state.lock().await;
+                                    if has_matches {
+                                        state.open_autocomplete(q);
+                                        input_manager.autocomplete_active = true;
+                                    } else {
+                                        state.close_autocomplete();
+                                        input_manager.autocomplete_active = false;
+                                    }
+                                }
+                            }
                             needs_redraw = true;
                         }
                         Event::Resize(_, _) => {

--- a/crates/ui_terminal/src/app.rs
+++ b/crates/ui_terminal/src/app.rs
@@ -270,6 +270,28 @@ async fn event_loop(
                                     renderer_guard.set_plan_expanded(expanded);
                                     renderer_guard.set_overlay_active(overlay_active);
                                 }
+                                KeyEventResult::ClearContext => {
+                                    let current_session_id = {
+                                        let state = app_state.lock().await;
+                                        state.current_session_id.clone()
+                                    };
+                                    if let Some(session_id) = current_session_id {
+                                        let _ = backend_event_tx
+                                            .send(BackendEvent::ClearContext { session_id })
+                                            .await;
+                                    }
+                                }
+                                KeyEventResult::CompactContext => {
+                                    let current_session_id = {
+                                        let state = app_state.lock().await;
+                                        state.current_session_id.clone()
+                                    };
+                                    if let Some(session_id) = current_session_id {
+                                        let _ = backend_event_tx
+                                            .send(BackendEvent::CompactContext { session_id })
+                                            .await;
+                                    }
+                                }
                             }
                             needs_redraw = true;
                         }

--- a/crates/ui_terminal/src/app.rs
+++ b/crates/ui_terminal/src/app.rs
@@ -490,6 +490,22 @@ async fn event_loop(
                                     )
                                     .await;
                                 }
+                                KeyEventResult::PopupQueryChanged(text) => {
+                                    let mut state = app_state.lock().await;
+                                    // For the root popup the user typed "/cl",
+                                    // so the query is the part after the leading "/".
+                                    // For sub-popups the composer is the query verbatim.
+                                    let query: String = if state.popup_stack.depth() == 1
+                                        && text.starts_with('/')
+                                    {
+                                        text[1..].to_string()
+                                    } else {
+                                        text
+                                    };
+                                    state.popup_stack.set_query(&query);
+                                    input_manager.popup_active =
+                                        state.popup_stack.is_active();
+                                }
                                 KeyEventResult::PopupKey(key) => {
                                     let outcome = {
                                         let mut state = app_state.lock().await;
@@ -500,17 +516,41 @@ async fn event_loop(
                                             key.code,
                                             crossterm::event::KeyCode::Esc
                                         ) && state.popup_stack.depth() == 1;
+                                        let depth_before = state.popup_stack.depth();
                                         let result = state.popup_stack.handle_key(key);
+                                        let depth_after = state.popup_stack.depth();
                                         let still_active = state.popup_stack.is_active();
-                                        (result, was_root_esc, still_active)
+                                        (
+                                            result,
+                                            was_root_esc,
+                                            still_active,
+                                            depth_before,
+                                            depth_after,
+                                        )
                                     };
-                                    let (committed, was_root_esc, still_active) = outcome;
+                                    let (
+                                        committed,
+                                        was_root_esc,
+                                        still_active,
+                                        depth_before,
+                                        depth_after,
+                                    ) = outcome;
                                     input_manager.popup_active = still_active;
 
                                     if was_root_esc && !still_active {
                                         // Drop a leading "/" from the current composer line so
                                         // the popup does not re-open on the next keystroke.
                                         delete_leading_slash(&mut input_manager.textarea);
+                                    }
+
+                                    // If a sub-popup was just pushed, clear the composer so
+                                    // the user can type a fresh query for the new popup
+                                    // (e.g. "/mo<Enter>" -> empty composer that filters models).
+                                    if depth_after > depth_before {
+                                        input_manager.clear();
+                                        // Reset the new popup's query to empty.
+                                        let mut state = app_state.lock().await;
+                                        state.popup_stack.set_query("");
                                     }
 
                                     if let Some(cmd) = committed {

--- a/crates/ui_terminal/src/app.rs
+++ b/crates/ui_terminal/src/app.rs
@@ -300,6 +300,8 @@ async fn event_loop(
                                             let mut state = app_state.lock().await;
                                             state.close_autocomplete();
                                             input_manager.autocomplete_active = false;
+                                            drop(state);
+                                            renderer.lock().await.clear_autocomplete();
                                         }
                                         Some(q) => {
                                             let filtered: Vec<_> = all_commands()
@@ -313,6 +315,8 @@ async fn event_loop(
                                             if filtered.is_empty() {
                                                 state.close_autocomplete();
                                                 input_manager.autocomplete_active = false;
+                                                drop(state);
+                                                renderer.lock().await.clear_autocomplete();
                                             } else {
                                                 // Clamp selected index to new list length.
                                                 let selected = state
@@ -321,24 +325,40 @@ async fn event_loop(
                                                 state.open_autocomplete(q);
                                                 state.autocomplete_selected = selected;
                                                 input_manager.autocomplete_active = true;
+                                                drop(state);
+                                                let items: Vec<_> = filtered
+                                                    .iter()
+                                                    .map(|cmd| (cmd.name, cmd.description))
+                                                    .collect();
+                                                renderer.lock().await.set_autocomplete(items, selected);
                                             }
                                         }
                                     }
                                 }
                                 KeyEventResult::MoveAutocomplete(delta) => {
-                                    let item_count = {
+                                    let (item_count, items) = {
                                         let state = app_state.lock().await;
-                                        let q = &state.autocomplete_query.clone();
-                                        all_commands()
+                                        let q = state.autocomplete_query.clone();
+                                        let filtered: Vec<_> = all_commands()
                                             .iter()
                                             .filter(|cmd| {
                                                 cmd.name.starts_with(q.as_str())
                                                     || cmd.aliases.iter().any(|a| a.starts_with(q.as_str()))
                                             })
-                                            .count()
+                                            .collect();
+                                        let count = filtered.len();
+                                        let items: Vec<_> = filtered
+                                            .iter()
+                                            .map(|cmd| (cmd.name, cmd.description))
+                                            .collect();
+                                        (count, items)
                                     };
-                                    let mut state = app_state.lock().await;
-                                    state.move_autocomplete_selection(delta, item_count);
+                                    let selected = {
+                                        let mut state = app_state.lock().await;
+                                        state.move_autocomplete_selection(delta, item_count);
+                                        state.autocomplete_selected
+                                    };
+                                    renderer.lock().await.set_autocomplete(items, selected);
                                 }
                                 KeyEventResult::SelectAutocomplete => {
                                     // Find the selected command and expand its name into the textarea.
@@ -377,6 +397,8 @@ async fn event_loop(
                                         let mut state = app_state.lock().await;
                                         state.close_autocomplete();
                                         input_manager.autocomplete_active = false;
+                                        drop(state);
+                                        renderer.lock().await.clear_autocomplete();
                                     }
                                 }
                             }
@@ -393,19 +415,36 @@ async fn event_loop(
                                     let mut state = app_state.lock().await;
                                     state.close_autocomplete();
                                     input_manager.autocomplete_active = false;
+                                    drop(state);
+                                    renderer.lock().await.clear_autocomplete();
                                 }
                                 Some(q) => {
-                                    let has_matches = all_commands().iter().any(|cmd| {
-                                        cmd.name.starts_with(q.as_str())
-                                            || cmd.aliases.iter().any(|a| a.starts_with(q.as_str()))
-                                    });
+                                    let filtered: Vec<_> = all_commands()
+                                        .iter()
+                                        .filter(|cmd| {
+                                            cmd.name.starts_with(q.as_str())
+                                                || cmd.aliases.iter().any(|a| a.starts_with(q.as_str()))
+                                        })
+                                        .collect();
                                     let mut state = app_state.lock().await;
-                                    if has_matches {
-                                        state.open_autocomplete(q);
-                                        input_manager.autocomplete_active = true;
-                                    } else {
+                                    if filtered.is_empty() {
                                         state.close_autocomplete();
                                         input_manager.autocomplete_active = false;
+                                        drop(state);
+                                        renderer.lock().await.clear_autocomplete();
+                                    } else {
+                                        let selected = state
+                                            .autocomplete_selected
+                                            .min(filtered.len().saturating_sub(1));
+                                        state.open_autocomplete(q);
+                                        state.autocomplete_selected = selected;
+                                        input_manager.autocomplete_active = true;
+                                        drop(state);
+                                        let items: Vec<_> = filtered
+                                            .iter()
+                                            .map(|cmd| (cmd.name, cmd.description))
+                                            .collect();
+                                        renderer.lock().await.set_autocomplete(items, selected);
                                     }
                                 }
                             }

--- a/crates/ui_terminal/src/app.rs
+++ b/crates/ui_terminal/src/app.rs
@@ -1,8 +1,10 @@
 use crate::{
-    commands::all_commands,
+    commands::CommandProcessor,
     input::{InputManager, KeyEventResult},
     renderer::ProductionTerminalRenderer,
+    slash_popup::CommandListPopup,
     state::AppState,
+    textarea::TextArea,
     tui,
     ui::TerminalUI,
 };
@@ -27,6 +29,174 @@ use std::sync::{
 use tokio::sync::Mutex;
 use tokio::time::Duration;
 use tracing::debug;
+
+/// Update the popup stack to reflect a new slash-prefix on the current input line.
+///
+/// - `query == None` → user just deleted the leading `/`; close the popup.
+/// - `query == Some(q)` → ensure a [`CommandListPopup`] is on the stack and
+///   forward the query so the visible rows are filtered.
+async fn handle_slash_prefix_changed(
+    query: Option<String>,
+    app_state: &Arc<Mutex<AppState>>,
+    input_manager: &mut InputManager,
+) {
+    let mut state = app_state.lock().await;
+    match query {
+        None => {
+            state.popup_stack.clear();
+        }
+        Some(q) => {
+            // If the stack is empty (or the top is not the root command list),
+            // open the root command list popup. Sub-popups remain on the stack
+            // and ignore the prefix change (the top-of-stack popup decides).
+            if state.popup_stack.depth() == 0 {
+                state.popup_stack.push(Box::new(CommandListPopup::new()));
+            }
+            state.popup_stack.set_query(&q);
+        }
+    }
+    input_manager.popup_active = state.popup_stack.is_active();
+}
+
+/// Delete a leading `/` from the current line of `textarea`, if any. Used
+/// when the user dismisses the root popup with Esc so the next keystroke
+/// does not immediately reopen it.
+fn delete_leading_slash(textarea: &mut TextArea) {
+    let cursor = textarea.cursor();
+    let text = textarea.text().to_string();
+    let line_start = text[..cursor].rfind('\n').map(|i| i + 1).unwrap_or(0);
+    if text[line_start..].starts_with('/') {
+        textarea.replace_range(line_start..line_start + 1, "");
+    }
+}
+
+/// When a popup commits a final command, the leading "/word" the user typed
+/// is no longer needed in the composer (it has been consumed). Remove the
+/// "/" plus everything up to the next whitespace.
+fn clear_slash_command_word(textarea: &mut TextArea) {
+    let cursor = textarea.cursor();
+    let text = textarea.text().to_string();
+    let line_start = text[..cursor].rfind('\n').map(|i| i + 1).unwrap_or(0);
+    if !text[line_start..].starts_with('/') {
+        return;
+    }
+    // Find end of the slash-word: first whitespace or end of line.
+    let mut end = line_start + 1;
+    for (idx, ch) in text[line_start + 1..].char_indices() {
+        let abs = line_start + 1 + idx;
+        if ch.is_whitespace() {
+            end = abs;
+            break;
+        }
+        end = abs + ch.len_utf8();
+    }
+    textarea.replace_range(line_start..end, "");
+}
+
+/// Run the side-effects for a [`CommandResult`] produced by either an inline
+/// `/cmd<Enter>` submission or a popup commit. Returns an optional
+/// [`BackendEvent`] the caller should send.
+async fn handle_command_result(
+    cmd: crate::commands::CommandResult,
+    app_state: &Arc<Mutex<AppState>>,
+    renderer: &Arc<Mutex<ProductionTerminalRenderer>>,
+    backend_event_tx: &async_channel::Sender<BackendEvent>,
+) -> Option<BackendEvent> {
+    use crate::commands::CommandResult;
+    match cmd {
+        CommandResult::Continue => None,
+        CommandResult::Help(_) => {
+            let processor = CommandProcessor::new().ok();
+            let text = processor
+                .map(|p| match p.process_command("/help") {
+                    CommandResult::Help(t) => t,
+                    _ => String::new(),
+                })
+                .unwrap_or_default();
+            app_state.lock().await.set_info_message(Some(text));
+            None
+        }
+        CommandResult::ListModels => {
+            if let Ok(p) = CommandProcessor::new() {
+                app_state
+                    .lock()
+                    .await
+                    .set_info_message(Some(p.get_models_list()));
+            }
+            None
+        }
+        CommandResult::ListProviders => {
+            if let Ok(p) = CommandProcessor::new() {
+                app_state
+                    .lock()
+                    .await
+                    .set_info_message(Some(p.get_providers_list()));
+            }
+            None
+        }
+        CommandResult::SwitchModel(model_name) => {
+            let session_id = {
+                let state = app_state.lock().await;
+                state.current_session_id.clone()
+            };
+            if let Some(session_id) = session_id {
+                let mut state = app_state.lock().await;
+                state.update_current_model(Some(model_name.clone()));
+                state.set_info_message(Some(format!("Switched to model: {model_name}")));
+                Some(BackendEvent::SwitchModel {
+                    session_id,
+                    model_name,
+                })
+            } else {
+                app_state
+                    .lock()
+                    .await
+                    .set_info_message(Some("No active session to switch model".to_string()));
+                None
+            }
+        }
+        CommandResult::ShowCurrentModel => {
+            let current_model = app_state.lock().await.current_model.clone();
+            let message = match current_model {
+                Some(model) => format!("Current model: {model}"),
+                None => "No model selected".to_string(),
+            };
+            app_state.lock().await.set_info_message(Some(message));
+            None
+        }
+        CommandResult::TogglePlan => {
+            let (plan_state, expanded, overlay_active) = {
+                let mut state = app_state.lock().await;
+                let expanded = state.toggle_plan_expanded();
+                (state.plan.clone(), expanded, state.is_overlay_active())
+            };
+            let mut renderer_guard = renderer.lock().await;
+            if let Some(plan_state) = plan_state {
+                renderer_guard.set_plan_state(Some(plan_state));
+            }
+            renderer_guard.set_plan_expanded(expanded);
+            renderer_guard.set_overlay_active(overlay_active);
+            None
+        }
+        CommandResult::ClearContext => {
+            let session_id = app_state.lock().await.current_session_id.clone();
+            session_id.map(|session_id| BackendEvent::ClearContext { session_id })
+        }
+        CommandResult::CompactContext => {
+            let session_id = app_state.lock().await.current_session_id.clone();
+            session_id.map(|session_id| BackendEvent::CompactContext { session_id })
+        }
+        CommandResult::InvalidCommand(error) => {
+            app_state
+                .lock()
+                .await
+                .set_info_message(Some(format!("Error: {error}")));
+            // Suppress unused warning in this branch.
+            let _ = backend_event_tx;
+            None
+        }
+    }
+}
 
 /// Main event loop for handling terminal events
 async fn event_loop(
@@ -61,6 +231,25 @@ async fn event_loop(
                 }
                 renderer_guard.set_plan_expanded(state.plan_expanded);
                 renderer_guard.set_overlay_active(state.is_overlay_active());
+
+                // Sync popup snapshot from the popup stack.
+                let snap = if state.popup_stack.is_active() {
+                    let top = state.popup_stack.top().unwrap();
+                    Some(crate::renderer::PopupSnapshot {
+                        breadcrumb: state
+                            .popup_stack
+                            .breadcrumb()
+                            .iter()
+                            .map(|s| s.to_string())
+                            .collect(),
+                        rows: top.rows().to_vec(),
+                        selected: top.selected(),
+                        stack_depth: state.popup_stack.depth(),
+                    })
+                } else {
+                    None
+                };
+                renderer_guard.set_popup_snapshot(snap);
 
                 drop(state); // Release the lock before rendering
 
@@ -293,112 +482,53 @@ async fn event_loop(
                                             .await;
                                     }
                                 }
-                                KeyEventResult::UpdateAutocomplete { query } => {
-                                    match query {
-                                        None => {
-                                            // Current line no longer starts with '/'; close popup.
-                                            let mut state = app_state.lock().await;
-                                            state.close_autocomplete();
-                                            input_manager.autocomplete_active = false;
-                                            drop(state);
-                                            renderer.lock().await.clear_autocomplete();
-                                        }
-                                        Some(q) => {
-                                            let filtered: Vec<_> = all_commands()
-                                                .iter()
-                                                .filter(|cmd| {
-                                                    cmd.name.starts_with(q.as_str())
-                                                        || cmd.aliases.iter().any(|a| a.starts_with(q.as_str()))
-                                                })
-                                                .collect();
-                                            let mut state = app_state.lock().await;
-                                            if filtered.is_empty() {
-                                                state.close_autocomplete();
-                                                input_manager.autocomplete_active = false;
-                                                drop(state);
-                                                renderer.lock().await.clear_autocomplete();
-                                            } else {
-                                                // Clamp selected index to new list length.
-                                                let selected = state
-                                                    .autocomplete_selected
-                                                    .min(filtered.len().saturating_sub(1));
-                                                state.open_autocomplete(q);
-                                                state.autocomplete_selected = selected;
-                                                input_manager.autocomplete_active = true;
-                                                drop(state);
-                                                let items: Vec<_> = filtered
-                                                    .iter()
-                                                    .map(|cmd| (cmd.name, cmd.description))
-                                                    .collect();
-                                                renderer.lock().await.set_autocomplete(items, selected);
-                                            }
-                                        }
-                                    }
+                                KeyEventResult::SlashPrefixChanged(query) => {
+                                    handle_slash_prefix_changed(
+                                        query,
+                                        &app_state,
+                                        &mut input_manager,
+                                    )
+                                    .await;
                                 }
-                                KeyEventResult::MoveAutocomplete(delta) => {
-                                    let (item_count, items) = {
-                                        let state = app_state.lock().await;
-                                        let q = state.autocomplete_query.clone();
-                                        let filtered: Vec<_> = all_commands()
-                                            .iter()
-                                            .filter(|cmd| {
-                                                cmd.name.starts_with(q.as_str())
-                                                    || cmd.aliases.iter().any(|a| a.starts_with(q.as_str()))
-                                            })
-                                            .collect();
-                                        let count = filtered.len();
-                                        let items: Vec<_> = filtered
-                                            .iter()
-                                            .map(|cmd| (cmd.name, cmd.description))
-                                            .collect();
-                                        (count, items)
-                                    };
-                                    let selected = {
+                                KeyEventResult::PopupKey(key) => {
+                                    let outcome = {
                                         let mut state = app_state.lock().await;
-                                        state.move_autocomplete_selection(delta, item_count);
-                                        state.autocomplete_selected
+                                        // Capture root-Esc *before* dispatch so we can also
+                                        // delete the leading "/" from the composer when the
+                                        // user dismisses the root popup.
+                                        let was_root_esc = matches!(
+                                            key.code,
+                                            crossterm::event::KeyCode::Esc
+                                        ) && state.popup_stack.depth() == 1;
+                                        let result = state.popup_stack.handle_key(key);
+                                        let still_active = state.popup_stack.is_active();
+                                        (result, was_root_esc, still_active)
                                     };
-                                    renderer.lock().await.set_autocomplete(items, selected);
-                                }
-                                KeyEventResult::SelectAutocomplete => {
-                                    // Find the selected command and expand its name into the textarea.
-                                    let (selected_name, query) = {
-                                        let state = app_state.lock().await;
-                                        let q = state.autocomplete_query.clone();
-                                        let filtered: Vec<_> = all_commands()
-                                            .iter()
-                                            .filter(|cmd| {
-                                                cmd.name.starts_with(q.as_str())
-                                                    || cmd.aliases.iter().any(|a| a.starts_with(q.as_str()))
-                                            })
-                                            .collect();
-                                        let name = filtered
-                                            .get(state.autocomplete_selected)
-                                            .map(|cmd| cmd.name.to_string());
-                                        (name, q)
-                                    };
+                                    let (committed, was_root_esc, still_active) = outcome;
+                                    input_manager.popup_active = still_active;
 
-                                    if let Some(name) = selected_name {
-                                        // Replace "/<query>" on the current line with "/<name> ".
-                                        // Compute the byte range: from start-of-line up to cursor.
-                                        let cursor = input_manager.textarea.cursor();
-                                        let text = input_manager.textarea.text().to_string();
-                                        let line_start = text[..cursor]
-                                            .rfind('\n')
-                                            .map(|i| i + 1)
-                                            .unwrap_or(0);
-                                        // Replace exactly the portion "/<query>" the user typed.
-                                        let typed_end = line_start + 1 + query.len(); // '/' + query
-                                        let replace_end = typed_end.min(cursor);
-                                        input_manager.textarea.replace_range(
-                                            line_start..replace_end,
-                                            &format!("/{name} "),
-                                        );
-                                        let mut state = app_state.lock().await;
-                                        state.close_autocomplete();
-                                        input_manager.autocomplete_active = false;
-                                        drop(state);
-                                        renderer.lock().await.clear_autocomplete();
+                                    if was_root_esc && !still_active {
+                                        // Drop a leading "/" from the current composer line so
+                                        // the popup does not re-open on the next keystroke.
+                                        delete_leading_slash(&mut input_manager.textarea);
+                                    }
+
+                                    if let Some(cmd) = committed {
+                                        // The popup committed a final command; clear the
+                                        // composer line (the slash word) and dispatch the
+                                        // command via the same path as inline /commands.
+                                        clear_slash_command_word(&mut input_manager.textarea);
+                                        if let Some(next_event) = handle_command_result(
+                                            cmd,
+                                            &app_state,
+                                            &renderer,
+                                            &backend_event_tx,
+                                        )
+                                        .await
+                                        {
+                                            // Forward any backend event the command produced.
+                                            let _ = backend_event_tx.send(next_event).await;
+                                        }
                                     }
                                 }
                             }
@@ -410,44 +540,9 @@ async fn event_loop(
                             let pasted = pasted.replace('\r', "\n");
                             input_manager.handle_paste(pasted);
                             // Update autocomplete: pasting may introduce or clear a slash prefix.
-                            match input_manager.slash_prefix() {
-                                None => {
-                                    let mut state = app_state.lock().await;
-                                    state.close_autocomplete();
-                                    input_manager.autocomplete_active = false;
-                                    drop(state);
-                                    renderer.lock().await.clear_autocomplete();
-                                }
-                                Some(q) => {
-                                    let filtered: Vec<_> = all_commands()
-                                        .iter()
-                                        .filter(|cmd| {
-                                            cmd.name.starts_with(q.as_str())
-                                                || cmd.aliases.iter().any(|a| a.starts_with(q.as_str()))
-                                        })
-                                        .collect();
-                                    let mut state = app_state.lock().await;
-                                    if filtered.is_empty() {
-                                        state.close_autocomplete();
-                                        input_manager.autocomplete_active = false;
-                                        drop(state);
-                                        renderer.lock().await.clear_autocomplete();
-                                    } else {
-                                        let selected = state
-                                            .autocomplete_selected
-                                            .min(filtered.len().saturating_sub(1));
-                                        state.open_autocomplete(q);
-                                        state.autocomplete_selected = selected;
-                                        input_manager.autocomplete_active = true;
-                                        drop(state);
-                                        let items: Vec<_> = filtered
-                                            .iter()
-                                            .map(|cmd| (cmd.name, cmd.description))
-                                            .collect();
-                                        renderer.lock().await.set_autocomplete(items, selected);
-                                    }
-                                }
-                            }
+                            let prefix = input_manager.slash_prefix();
+                            handle_slash_prefix_changed(prefix, &app_state, &mut input_manager)
+                                .await;
                             needs_redraw = true;
                         }
                         Event::Resize(_, _) => {

--- a/crates/ui_terminal/src/commands.rs
+++ b/crates/ui_terminal/src/commands.rs
@@ -72,6 +72,10 @@ pub enum CommandResult {
     InvalidCommand(String),
     /// Toggle plan rendering mode
     TogglePlan,
+    /// Clear conversation context
+    ClearContext,
+    /// Compact (summarise) conversation context
+    CompactContext,
 }
 
 /// Process slash commands in terminal UI
@@ -104,6 +108,8 @@ impl CommandProcessor {
             "provider" | "p" => self.process_provider_command(&parts[1..]),
             "current" | "c" => CommandResult::ShowCurrentModel,
             "plan" => CommandResult::TogglePlan,
+            "clear" => CommandResult::ClearContext,
+            "compact" => CommandResult::CompactContext,
             _ => CommandResult::InvalidCommand(format!("Unknown command: /{}", parts[0])),
         }
     }

--- a/crates/ui_terminal/src/commands.rs
+++ b/crates/ui_terminal/src/commands.rs
@@ -1,6 +1,58 @@
 use anyhow::Result;
 use llm::provider_config::ConfigurationSystem;
 
+/// Static descriptor for a slash command, used for autocomplete and help display.
+pub struct SlashCommand {
+    pub name: &'static str,
+    pub aliases: &'static [&'static str],
+    pub description: &'static str,
+}
+
+/// All registered slash commands.
+///
+/// This slice is the single source of truth for command discovery. Every entry here
+/// corresponds to a match arm in `CommandProcessor::process_command`. Keeping them
+/// in sync is intentional: adding a command requires updating both places.
+pub fn all_commands() -> &'static [SlashCommand] {
+    &[
+        SlashCommand {
+            name: "help",
+            aliases: &["h"],
+            description: "Show available commands",
+        },
+        SlashCommand {
+            name: "model",
+            aliases: &["m"],
+            description: "List available models or switch to one: /model <name>",
+        },
+        SlashCommand {
+            name: "provider",
+            aliases: &["p"],
+            description: "List available LLM providers",
+        },
+        SlashCommand {
+            name: "current",
+            aliases: &["c"],
+            description: "Show the currently active model",
+        },
+        SlashCommand {
+            name: "plan",
+            aliases: &[],
+            description: "Toggle the plan view panel",
+        },
+        SlashCommand {
+            name: "clear",
+            aliases: &[],
+            description: "Clear the conversation context",
+        },
+        SlashCommand {
+            name: "compact",
+            aliases: &[],
+            description: "Summarize and compact the conversation context",
+        },
+    ]
+}
+
 /// Result of processing a slash command
 #[derive(Debug, Clone)]
 pub enum CommandResult {
@@ -84,20 +136,25 @@ impl CommandProcessor {
     }
 
     fn get_help_text(&self) -> String {
-        concat!(
-            "Available commands:\n",
-            "/help, /h          - Show this help\n",
-            "/model, /m         - List available models\n",
-            "/model <name>      - Switch to model\n",
-            "/provider, /p      - List available providers\n",
-            "/current, /c       - Show current model\n",
-            "/plan              - Toggle plan view\n",
-            "\n",
-            "Examples:\n",
-            "/model Claude Sonnet 4.5\n",
-            "/model GPT-5",
-        )
-        .to_string()
+        let mut text = String::from("Available commands:\n");
+        for cmd in all_commands() {
+            if cmd.aliases.is_empty() {
+                text.push_str(&format!("  /{:<16} {}\n", cmd.name, cmd.description));
+            } else {
+                let alias_list = cmd
+                    .aliases
+                    .iter()
+                    .map(|a| format!("/{a}"))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                text.push_str(&format!(
+                    "  /{}, {:<12} {}\n",
+                    cmd.name, alias_list, cmd.description
+                ));
+            }
+        }
+        text.push_str("\nExamples:\n  /model Claude Sonnet 4.5\n  /model GPT-5");
+        text
     }
 
     /// Get formatted list of available models

--- a/crates/ui_terminal/src/input.rs
+++ b/crates/ui_terminal/src/input.rs
@@ -34,6 +34,10 @@ pub enum KeyEventResult {
     ShowCurrentModel,
     /// Toggle plan rendering mode
     TogglePlan,
+    /// Clear conversation context
+    ClearContext,
+    /// Compact (summarise) conversation context
+    CompactContext,
 }
 
 /// Manages the input area using the custom TextArea widget
@@ -128,6 +132,8 @@ impl InputManager {
                             }
                             CommandResult::ShowCurrentModel => KeyEventResult::ShowCurrentModel,
                             CommandResult::TogglePlan => KeyEventResult::TogglePlan,
+                            CommandResult::ClearContext => KeyEventResult::ClearContext,
+                            CommandResult::CompactContext => KeyEventResult::CompactContext,
                             CommandResult::InvalidCommand(error) => {
                                 KeyEventResult::ShowInfo(format!("Error: {error}"))
                             }

--- a/crates/ui_terminal/src/input.rs
+++ b/crates/ui_terminal/src/input.rs
@@ -38,6 +38,15 @@ pub enum KeyEventResult {
     ClearContext,
     /// Compact (summarise) conversation context
     CompactContext,
+    /// Update (or close) the autocomplete popup.
+    ///
+    /// `query` contains the text after `/` on the current input line.
+    /// `None` means the current line no longer starts with `/` — close the popup.
+    UpdateAutocomplete { query: Option<String> },
+    /// Move the autocomplete selection up (-1) or down (+1).
+    MoveAutocomplete(i32),
+    /// Accept the currently highlighted autocomplete entry.
+    SelectAutocomplete,
 }
 
 /// Manages the input area using the custom TextArea widget
@@ -52,6 +61,11 @@ pub struct InputManager {
     pending_pastes: Vec<(String, String)>,
     /// Counters for generating unique large-paste placeholders (keyed by char_count).
     large_paste_counters: HashMap<usize, usize>,
+    /// Whether the autocomplete popup is currently visible.
+    ///
+    /// When `true`, Up/Down arrows navigate the popup instead of moving the
+    /// textarea cursor, and Tab/Enter accept the highlighted suggestion.
+    pub autocomplete_active: bool,
 }
 
 impl InputManager {
@@ -64,6 +78,7 @@ impl InputManager {
             image_counter: 0,
             pending_pastes: Vec::new(),
             large_paste_counters: HashMap::new(),
+            autocomplete_active: false,
         }
     }
 
@@ -88,18 +103,45 @@ impl InputManager {
                 }
                 KeyEventResult::Continue
             }
+            // Escape: close autocomplete popup if open, otherwise bubble up.
             KeyEvent {
                 code: KeyCode::Esc,
                 modifiers: KeyModifiers::NONE,
                 ..
-            } => KeyEventResult::Escape,
+            } => {
+                if self.autocomplete_active {
+                    KeyEventResult::UpdateAutocomplete { query: None }
+                } else {
+                    KeyEventResult::Escape
+                }
+            }
+            // Up/Down: navigate the autocomplete list when the popup is open.
+            KeyEvent {
+                code: KeyCode::Up,
+                modifiers: KeyModifiers::NONE,
+                ..
+            } if self.autocomplete_active => KeyEventResult::MoveAutocomplete(-1),
+            KeyEvent {
+                code: KeyCode::Down,
+                modifiers: KeyModifiers::NONE,
+                ..
+            } if self.autocomplete_active => KeyEventResult::MoveAutocomplete(1),
+            // Tab: accept the highlighted autocomplete suggestion.
+            KeyEvent {
+                code: KeyCode::Tab,
+                modifiers: KeyModifiers::NONE,
+                ..
+            } if self.autocomplete_active => KeyEventResult::SelectAutocomplete,
             KeyEvent {
                 code: KeyCode::Enter,
                 modifiers: KeyModifiers::SHIFT,
                 ..
             } => {
                 self.textarea.insert_str("\n");
-                KeyEventResult::Continue
+                // A newline on the current line means no slash-command on this line anymore.
+                KeyEventResult::UpdateAutocomplete {
+                    query: self.slash_prefix(),
+                }
             }
             KeyEvent {
                 code: KeyCode::Enter,
@@ -150,10 +192,27 @@ impl InputManager {
                 }
             }
             _ => {
-                // Forward the key event directly to our custom TextArea
+                // Forward the key event directly to our custom TextArea, then check
+                // whether the current line now starts with a slash command.
                 self.textarea.input(key_event);
-                KeyEventResult::Continue
+                KeyEventResult::UpdateAutocomplete {
+                    query: self.slash_prefix(),
+                }
             }
+        }
+    }
+
+    /// Returns `Some(query)` when the current input line starts with `/`, where
+    /// `query` is the text after the `/`.  Returns `None` otherwise.
+    ///
+    /// Used after every keystroke to decide whether to show/update/hide the
+    /// autocomplete popup.
+    pub fn slash_prefix(&self) -> Option<String> {
+        let line = self.textarea.current_line();
+        if line.starts_with('/') {
+            Some(line[1..].to_string())
+        } else {
+            None
         }
     }
 
@@ -284,14 +343,20 @@ mod tests {
         // Test initial state
         assert_eq!(input_manager.textarea.text(), "");
 
-        // Test character input
+        // Test character input: normal text returns UpdateAutocomplete with no query.
         let result = input_manager
             .handle_key_event(create_key_event(KeyCode::Char('h'), KeyModifiers::NONE));
-        assert!(matches!(result, KeyEventResult::Continue));
+        assert!(matches!(
+            result,
+            KeyEventResult::UpdateAutocomplete { query: None }
+        ));
 
         let result = input_manager
             .handle_key_event(create_key_event(KeyCode::Char('i'), KeyModifiers::NONE));
-        assert!(matches!(result, KeyEventResult::Continue));
+        assert!(matches!(
+            result,
+            KeyEventResult::UpdateAutocomplete { query: None }
+        ));
 
         // Content should contain the typed characters
         let content = input_manager.textarea.text();
@@ -341,10 +406,10 @@ mod tests {
         input_manager.handle_key_event(create_key_event(KeyCode::Char('h'), KeyModifiers::NONE));
         input_manager.handle_key_event(create_key_event(KeyCode::Char('i'), KeyModifiers::NONE));
 
-        // Shift+Enter should add newline without submitting
+        // Shift+Enter should add newline without submitting; returns UpdateAutocomplete.
         let result =
             input_manager.handle_key_event(create_key_event(KeyCode::Enter, KeyModifiers::SHIFT));
-        assert!(matches!(result, KeyEventResult::Continue));
+        assert!(matches!(result, KeyEventResult::UpdateAutocomplete { .. }));
 
         // Add more text
         input_manager.handle_key_event(create_key_event(KeyCode::Char('b'), KeyModifiers::NONE));
@@ -431,5 +496,83 @@ mod tests {
         assert!(input_manager.pending_pastes.is_empty());
         assert!(input_manager.attachments.is_empty());
         assert_eq!(input_manager.image_counter, 0);
+    }
+
+    #[test]
+    fn test_slash_prefix_detected() {
+        let mut input_manager = InputManager::new();
+
+        // Typing '/' should emit UpdateAutocomplete with an empty query string.
+        let result = input_manager
+            .handle_key_event(create_key_event(KeyCode::Char('/'), KeyModifiers::NONE));
+        assert!(
+            matches!(result, KeyEventResult::UpdateAutocomplete { query: Some(ref q) } if q.is_empty()),
+            "Expected UpdateAutocomplete with empty query, got {result:?}"
+        );
+
+        // Typing 'm' after '/' should emit query "m".
+        let result = input_manager
+            .handle_key_event(create_key_event(KeyCode::Char('m'), KeyModifiers::NONE));
+        assert!(
+            matches!(result, KeyEventResult::UpdateAutocomplete { query: Some(ref q) } if q == "m"),
+            "Expected query 'm', got {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_slash_prefix_absent_for_normal_text() {
+        let mut input_manager = InputManager::new();
+        let result = input_manager
+            .handle_key_event(create_key_event(KeyCode::Char('h'), KeyModifiers::NONE));
+        assert!(
+            matches!(result, KeyEventResult::UpdateAutocomplete { query: None }),
+            "Expected no autocomplete for normal text, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_escape_closes_autocomplete_when_active() {
+        let mut input_manager = InputManager::new();
+        input_manager.autocomplete_active = true;
+
+        let result =
+            input_manager.handle_key_event(create_key_event(KeyCode::Esc, KeyModifiers::NONE));
+        // When popup is open, Escape should close it, not propagate as Escape.
+        assert!(
+            matches!(result, KeyEventResult::UpdateAutocomplete { query: None }),
+            "Expected autocomplete close on Escape, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_arrow_keys_navigate_autocomplete_when_active() {
+        let mut input_manager = InputManager::new();
+        input_manager.autocomplete_active = true;
+
+        let down =
+            input_manager.handle_key_event(create_key_event(KeyCode::Down, KeyModifiers::NONE));
+        assert!(
+            matches!(down, KeyEventResult::MoveAutocomplete(1)),
+            "Expected MoveAutocomplete(1), got {down:?}"
+        );
+
+        let up = input_manager.handle_key_event(create_key_event(KeyCode::Up, KeyModifiers::NONE));
+        assert!(
+            matches!(up, KeyEventResult::MoveAutocomplete(-1)),
+            "Expected MoveAutocomplete(-1), got {up:?}"
+        );
+    }
+
+    #[test]
+    fn test_tab_selects_autocomplete_when_active() {
+        let mut input_manager = InputManager::new();
+        input_manager.autocomplete_active = true;
+
+        let result =
+            input_manager.handle_key_event(create_key_event(KeyCode::Tab, KeyModifiers::NONE));
+        assert!(
+            matches!(result, KeyEventResult::SelectAutocomplete),
+            "Expected SelectAutocomplete on Tab, got {result:?}"
+        );
     }
 }

--- a/crates/ui_terminal/src/input.rs
+++ b/crates/ui_terminal/src/input.rs
@@ -45,6 +45,10 @@ pub enum KeyEventResult {
     /// `None` means the current line no longer starts with `/` (close the
     /// popup if it was open).
     SlashPrefixChanged(Option<String>),
+    /// The user typed (or backspaced) while a popup was already open.
+    /// The string is the entire current composer line, used as the query
+    /// for the top-of-stack popup (no leading slash strip).
+    PopupQueryChanged(String),
     /// A key event that should be routed to the active popup (Up / Down /
     /// Enter / Tab / Esc while the popup is open).
     PopupKey(KeyEvent),
@@ -200,10 +204,17 @@ impl InputManager {
                 }
             }
             _ => {
-                // Forward the key event directly to our custom TextArea, then check
-                // whether the current line now starts with a slash command.
+                // Forward the key event directly to our custom TextArea.
                 self.textarea.input(key_event);
-                KeyEventResult::SlashPrefixChanged(self.slash_prefix())
+                if self.popup_active {
+                    // While a popup is open, the entire composer line acts as
+                    // the popup query (the leading slash, if any, is stripped
+                    // for root popups by the app event loop).
+                    KeyEventResult::PopupQueryChanged(self.textarea.text().to_string())
+                } else {
+                    // No popup open: detect the start of a slash command.
+                    KeyEventResult::SlashPrefixChanged(self.slash_prefix())
+                }
             }
         }
     }
@@ -628,6 +639,56 @@ mod tests {
                 })
             ),
             "Expected PopupKey(Enter) while popup active, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_typing_while_popup_active_emits_popup_query_changed() {
+        let mut input_manager = InputManager::new();
+        input_manager.popup_active = true;
+
+        // Composer is empty (e.g. just after a sub-popup was pushed).
+        // Typing 'c' should NOT close the popup — it should report the
+        // composer's current text as a query update.
+        let result = input_manager
+            .handle_key_event(create_key_event(KeyCode::Char('c'), KeyModifiers::NONE));
+        assert!(
+            matches!(result, KeyEventResult::PopupQueryChanged(ref q) if q == "c"),
+            "Expected PopupQueryChanged(\"c\") while popup active, got {result:?}"
+        );
+
+        let result = input_manager
+            .handle_key_event(create_key_event(KeyCode::Char('l'), KeyModifiers::NONE));
+        assert!(
+            matches!(result, KeyEventResult::PopupQueryChanged(ref q) if q == "cl"),
+            "Expected PopupQueryChanged(\"cl\"), got {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_backspace_while_popup_active_emits_popup_query_changed() {
+        let mut input_manager = InputManager::new();
+        input_manager.textarea.insert_str("cl");
+        input_manager.popup_active = true;
+
+        let result = input_manager
+            .handle_key_event(create_key_event(KeyCode::Backspace, KeyModifiers::NONE));
+        assert!(
+            matches!(result, KeyEventResult::PopupQueryChanged(ref q) if q == "c"),
+            "Expected PopupQueryChanged(\"c\") after Backspace, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_typing_while_popup_inactive_still_emits_slash_prefix_changed() {
+        // Regression: popup_active=false must keep the existing slash-prefix
+        // detection behaviour (used by the root popup trigger via "/").
+        let mut input_manager = InputManager::new();
+        let result = input_manager
+            .handle_key_event(create_key_event(KeyCode::Char('h'), KeyModifiers::NONE));
+        assert!(
+            matches!(result, KeyEventResult::SlashPrefixChanged(None)),
+            "Expected SlashPrefixChanged(None) when popup inactive, got {result:?}"
         );
     }
 }

--- a/crates/ui_terminal/src/input.rs
+++ b/crates/ui_terminal/src/input.rs
@@ -38,15 +38,16 @@ pub enum KeyEventResult {
     ClearContext,
     /// Compact (summarise) conversation context
     CompactContext,
-    /// Update (or close) the autocomplete popup.
+    /// The slash-prefix on the current input line changed.
     ///
-    /// `query` contains the text after `/` on the current input line.
-    /// `None` means the current line no longer starts with `/` — close the popup.
-    UpdateAutocomplete { query: Option<String> },
-    /// Move the autocomplete selection up (-1) or down (+1).
-    MoveAutocomplete(i32),
-    /// Accept the currently highlighted autocomplete entry.
-    SelectAutocomplete,
+    /// `Some("")` means the user just typed `/` (open the popup at root).
+    /// `Some("cl")` means the line is `/cl…` (filter root popup by "cl").
+    /// `None` means the current line no longer starts with `/` (close the
+    /// popup if it was open).
+    SlashPrefixChanged(Option<String>),
+    /// A key event that should be routed to the active popup (Up / Down /
+    /// Enter / Tab / Esc while the popup is open).
+    PopupKey(KeyEvent),
 }
 
 /// Manages the input area using the custom TextArea widget
@@ -61,11 +62,12 @@ pub struct InputManager {
     pending_pastes: Vec<(String, String)>,
     /// Counters for generating unique large-paste placeholders (keyed by char_count).
     large_paste_counters: HashMap<usize, usize>,
-    /// Whether the autocomplete popup is currently visible.
+    /// Whether a slash-command popup is currently visible.
     ///
-    /// When `true`, Up/Down arrows navigate the popup instead of moving the
-    /// textarea cursor, and Tab/Enter accept the highlighted suggestion.
-    pub autocomplete_active: bool,
+    /// When `true`, Up / Down / Enter / Tab / Esc are intercepted and routed
+    /// to the popup stack as [`KeyEventResult::PopupKey`] events. The flag is
+    /// set/cleared by the app event loop based on the popup-stack depth.
+    pub popup_active: bool,
 }
 
 impl InputManager {
@@ -78,7 +80,7 @@ impl InputManager {
             image_counter: 0,
             pending_pastes: Vec::new(),
             large_paste_counters: HashMap::new(),
-            autocomplete_active: false,
+            popup_active: false,
         }
     }
 
@@ -103,35 +105,35 @@ impl InputManager {
                 }
                 KeyEventResult::Continue
             }
-            // Escape: close autocomplete popup if open, otherwise bubble up.
+            // Escape: close popup if open, otherwise bubble up.
             KeyEvent {
                 code: KeyCode::Esc,
                 modifiers: KeyModifiers::NONE,
                 ..
             } => {
-                if self.autocomplete_active {
-                    KeyEventResult::UpdateAutocomplete { query: None }
+                if self.popup_active {
+                    KeyEventResult::PopupKey(key_event)
                 } else {
                     KeyEventResult::Escape
                 }
             }
-            // Up/Down: navigate the autocomplete list when the popup is open.
+            // Up/Down: navigate the popup when it is open.
             KeyEvent {
                 code: KeyCode::Up,
                 modifiers: KeyModifiers::NONE,
                 ..
-            } if self.autocomplete_active => KeyEventResult::MoveAutocomplete(-1),
+            } if self.popup_active => KeyEventResult::PopupKey(key_event),
             KeyEvent {
                 code: KeyCode::Down,
                 modifiers: KeyModifiers::NONE,
                 ..
-            } if self.autocomplete_active => KeyEventResult::MoveAutocomplete(1),
-            // Tab: accept the highlighted autocomplete suggestion.
+            } if self.popup_active => KeyEventResult::PopupKey(key_event),
+            // Tab: route to popup (e.g. accept root suggestion).
             KeyEvent {
                 code: KeyCode::Tab,
                 modifiers: KeyModifiers::NONE,
                 ..
-            } if self.autocomplete_active => KeyEventResult::SelectAutocomplete,
+            } if self.popup_active => KeyEventResult::PopupKey(key_event),
             KeyEvent {
                 code: KeyCode::Enter,
                 modifiers: KeyModifiers::SHIFT,
@@ -139,10 +141,16 @@ impl InputManager {
             } => {
                 self.textarea.insert_str("\n");
                 // A newline on the current line means no slash-command on this line anymore.
-                KeyEventResult::UpdateAutocomplete {
-                    query: self.slash_prefix(),
-                }
+                KeyEventResult::SlashPrefixChanged(self.slash_prefix())
             }
+            // Plain Enter while popup is open: route to popup so the highlighted
+            // row can be activated. The popup stack decides whether this commits
+            // a command, pushes a sub-popup, or is a no-op.
+            KeyEvent {
+                code: KeyCode::Enter,
+                modifiers: KeyModifiers::NONE,
+                ..
+            } if self.popup_active => KeyEventResult::PopupKey(key_event),
             KeyEvent {
                 code: KeyCode::Enter,
                 modifiers: KeyModifiers::NONE,
@@ -195,9 +203,7 @@ impl InputManager {
                 // Forward the key event directly to our custom TextArea, then check
                 // whether the current line now starts with a slash command.
                 self.textarea.input(key_event);
-                KeyEventResult::UpdateAutocomplete {
-                    query: self.slash_prefix(),
-                }
+                KeyEventResult::SlashPrefixChanged(self.slash_prefix())
             }
         }
     }
@@ -343,20 +349,14 @@ mod tests {
         // Test initial state
         assert_eq!(input_manager.textarea.text(), "");
 
-        // Test character input: normal text returns UpdateAutocomplete with no query.
+        // Test character input: normal text returns SlashPrefixChanged(None).
         let result = input_manager
             .handle_key_event(create_key_event(KeyCode::Char('h'), KeyModifiers::NONE));
-        assert!(matches!(
-            result,
-            KeyEventResult::UpdateAutocomplete { query: None }
-        ));
+        assert!(matches!(result, KeyEventResult::SlashPrefixChanged(None)));
 
         let result = input_manager
             .handle_key_event(create_key_event(KeyCode::Char('i'), KeyModifiers::NONE));
-        assert!(matches!(
-            result,
-            KeyEventResult::UpdateAutocomplete { query: None }
-        ));
+        assert!(matches!(result, KeyEventResult::SlashPrefixChanged(None)));
 
         // Content should contain the typed characters
         let content = input_manager.textarea.text();
@@ -406,10 +406,10 @@ mod tests {
         input_manager.handle_key_event(create_key_event(KeyCode::Char('h'), KeyModifiers::NONE));
         input_manager.handle_key_event(create_key_event(KeyCode::Char('i'), KeyModifiers::NONE));
 
-        // Shift+Enter should add newline without submitting; returns UpdateAutocomplete.
+        // Shift+Enter should add newline without submitting; returns SlashPrefixChanged.
         let result =
             input_manager.handle_key_event(create_key_event(KeyCode::Enter, KeyModifiers::SHIFT));
-        assert!(matches!(result, KeyEventResult::UpdateAutocomplete { .. }));
+        assert!(matches!(result, KeyEventResult::SlashPrefixChanged(_)));
 
         // Add more text
         input_manager.handle_key_event(create_key_event(KeyCode::Char('b'), KeyModifiers::NONE));
@@ -502,19 +502,19 @@ mod tests {
     fn test_slash_prefix_detected() {
         let mut input_manager = InputManager::new();
 
-        // Typing '/' should emit UpdateAutocomplete with an empty query string.
+        // Typing '/' should emit SlashPrefixChanged with an empty query string.
         let result = input_manager
             .handle_key_event(create_key_event(KeyCode::Char('/'), KeyModifiers::NONE));
         assert!(
-            matches!(result, KeyEventResult::UpdateAutocomplete { query: Some(ref q) } if q.is_empty()),
-            "Expected UpdateAutocomplete with empty query, got {result:?}"
+            matches!(result, KeyEventResult::SlashPrefixChanged(Some(ref q)) if q.is_empty()),
+            "Expected SlashPrefixChanged with empty query, got {result:?}"
         );
 
         // Typing 'm' after '/' should emit query "m".
         let result = input_manager
             .handle_key_event(create_key_event(KeyCode::Char('m'), KeyModifiers::NONE));
         assert!(
-            matches!(result, KeyEventResult::UpdateAutocomplete { query: Some(ref q) } if q == "m"),
+            matches!(result, KeyEventResult::SlashPrefixChanged(Some(ref q)) if q == "m"),
             "Expected query 'm', got {result:?}"
         );
     }
@@ -525,54 +525,109 @@ mod tests {
         let result = input_manager
             .handle_key_event(create_key_event(KeyCode::Char('h'), KeyModifiers::NONE));
         assert!(
-            matches!(result, KeyEventResult::UpdateAutocomplete { query: None }),
-            "Expected no autocomplete for normal text, got {result:?}"
+            matches!(result, KeyEventResult::SlashPrefixChanged(None)),
+            "Expected no slash prefix for normal text, got {result:?}"
         );
     }
 
     #[test]
-    fn test_escape_closes_autocomplete_when_active() {
+    fn test_escape_routes_to_popup_when_active() {
         let mut input_manager = InputManager::new();
-        input_manager.autocomplete_active = true;
+        input_manager.popup_active = true;
 
         let result =
             input_manager.handle_key_event(create_key_event(KeyCode::Esc, KeyModifiers::NONE));
-        // When popup is open, Escape should close it, not propagate as Escape.
+        // When popup is open, Escape becomes a PopupKey so the stack can decide
+        // whether to pop one level or close entirely.
         assert!(
-            matches!(result, KeyEventResult::UpdateAutocomplete { query: None }),
-            "Expected autocomplete close on Escape, got {result:?}"
+            matches!(
+                result,
+                KeyEventResult::PopupKey(KeyEvent {
+                    code: KeyCode::Esc,
+                    ..
+                })
+            ),
+            "Expected PopupKey(Esc) when popup is open, got {result:?}"
         );
     }
 
     #[test]
-    fn test_arrow_keys_navigate_autocomplete_when_active() {
+    fn test_escape_propagates_when_popup_inactive() {
         let mut input_manager = InputManager::new();
-        input_manager.autocomplete_active = true;
+        let result =
+            input_manager.handle_key_event(create_key_event(KeyCode::Esc, KeyModifiers::NONE));
+        assert!(
+            matches!(result, KeyEventResult::Escape),
+            "Expected Escape when popup is closed, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_arrow_keys_route_to_popup_when_active() {
+        let mut input_manager = InputManager::new();
+        input_manager.popup_active = true;
 
         let down =
             input_manager.handle_key_event(create_key_event(KeyCode::Down, KeyModifiers::NONE));
         assert!(
-            matches!(down, KeyEventResult::MoveAutocomplete(1)),
-            "Expected MoveAutocomplete(1), got {down:?}"
+            matches!(
+                down,
+                KeyEventResult::PopupKey(KeyEvent {
+                    code: KeyCode::Down,
+                    ..
+                })
+            ),
+            "Expected PopupKey(Down), got {down:?}"
         );
 
         let up = input_manager.handle_key_event(create_key_event(KeyCode::Up, KeyModifiers::NONE));
         assert!(
-            matches!(up, KeyEventResult::MoveAutocomplete(-1)),
-            "Expected MoveAutocomplete(-1), got {up:?}"
+            matches!(
+                up,
+                KeyEventResult::PopupKey(KeyEvent {
+                    code: KeyCode::Up,
+                    ..
+                })
+            ),
+            "Expected PopupKey(Up), got {up:?}"
         );
     }
 
     #[test]
-    fn test_tab_selects_autocomplete_when_active() {
+    fn test_tab_routes_to_popup_when_active() {
         let mut input_manager = InputManager::new();
-        input_manager.autocomplete_active = true;
+        input_manager.popup_active = true;
 
         let result =
             input_manager.handle_key_event(create_key_event(KeyCode::Tab, KeyModifiers::NONE));
         assert!(
-            matches!(result, KeyEventResult::SelectAutocomplete),
-            "Expected SelectAutocomplete on Tab, got {result:?}"
+            matches!(
+                result,
+                KeyEventResult::PopupKey(KeyEvent {
+                    code: KeyCode::Tab,
+                    ..
+                })
+            ),
+            "Expected PopupKey(Tab), got {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_enter_routes_to_popup_when_active() {
+        let mut input_manager = InputManager::new();
+        input_manager.popup_active = true;
+
+        let result =
+            input_manager.handle_key_event(create_key_event(KeyCode::Enter, KeyModifiers::NONE));
+        assert!(
+            matches!(
+                result,
+                KeyEventResult::PopupKey(KeyEvent {
+                    code: KeyCode::Enter,
+                    ..
+                })
+            ),
+            "Expected PopupKey(Enter) while popup active, got {result:?}"
         );
     }
 }

--- a/crates/ui_terminal/src/lib.rs
+++ b/crates/ui_terminal/src/lib.rs
@@ -6,6 +6,7 @@ pub mod history_insert;
 pub mod input;
 pub mod message;
 pub mod renderer;
+pub mod slash_popup;
 pub mod state;
 pub mod streaming;
 pub mod terminal_color;

--- a/crates/ui_terminal/src/renderer.rs
+++ b/crates/ui_terminal/src/renderer.rs
@@ -111,11 +111,23 @@ pub struct TerminalRenderer {
     needs_paragraph_break_after_hidden_tool: bool,
     /// Last known terminal width (updated in prepare(), used for history rendering).
     last_known_width: u16,
-    /// Filtered list of (name, description) pairs to show in the autocomplete popup.
-    /// Empty when the popup is hidden.
-    autocomplete_items: Vec<(&'static str, &'static str)>,
-    /// Index of the highlighted row in `autocomplete_items`.
-    autocomplete_selected: usize,
+    /// Snapshot of the active slash-command popup, or `None` when the stack
+    /// is empty. Set by the app event loop right before each draw via
+    /// [`Self::set_popup_snapshot`].
+    popup: Option<PopupSnapshot>,
+}
+
+/// Snapshot of a [`SlashPopup`] taken at draw time.
+#[derive(Debug, Clone)]
+pub struct PopupSnapshot {
+    /// Breadcrumb of titles, root first, top last (e.g. `["Slash commands", "Choose model"]`).
+    pub breadcrumb: Vec<String>,
+    /// Rows of the top-of-stack popup, already filtered.
+    pub rows: Vec<crate::slash_popup::PopupRow>,
+    /// Highlighted row index in `rows`.
+    pub selected: usize,
+    /// Depth of the stack. `> 1` enables the "Esc/← back" hint in the footer.
+    pub stack_depth: usize,
 }
 
 /// Tracks the last block type for paragraph breaks after hidden tools
@@ -149,8 +161,7 @@ impl TerminalRenderer {
             last_block_type_for_hidden_tool: None,
             needs_paragraph_break_after_hidden_tool: false,
             last_known_width: 80,
-            autocomplete_items: Vec::new(),
-            autocomplete_selected: 0,
+            popup: None,
         })
     }
 
@@ -305,19 +316,10 @@ impl TerminalRenderer {
         self.overlay_active = active;
     }
 
-    /// Update the autocomplete popup contents.
-    ///
-    /// `items` is the pre-filtered list of (name, description) pairs to display.
-    /// `selected` is the index of the highlighted row.
-    pub fn set_autocomplete(&mut self, items: Vec<(&'static str, &'static str)>, selected: usize) {
-        self.autocomplete_items = items;
-        self.autocomplete_selected = selected;
-    }
-
-    /// Hide the autocomplete popup.
-    pub fn clear_autocomplete(&mut self) {
-        self.autocomplete_items.clear();
-        self.autocomplete_selected = 0;
+    /// Set or clear the popup snapshot. Called by the app event loop right
+    /// before each draw to mirror the current state of the popup stack.
+    pub fn set_popup_snapshot(&mut self, snapshot: Option<PopupSnapshot>) {
+        self.popup = snapshot;
     }
 
     /// Append text to the last block in the current message
@@ -743,13 +745,18 @@ impl TerminalRenderer {
         content_height.saturating_add(input_height)
     }
 
-    /// Height reserved for the autocomplete popup (0 when inactive).
+    /// Height reserved for the slash-command popup (0 when no popup is active).
     fn measure_autocomplete_height(&self) -> u16 {
         const MAX_POPUP_ROWS: u16 = 8;
-        if self.autocomplete_items.is_empty() {
-            0
-        } else {
-            (self.autocomplete_items.len() as u16).min(MAX_POPUP_ROWS)
+        const HEADER_ROWS: u16 = 1; // breadcrumb header
+        const FOOTER_ROWS: u16 = 1; // hint footer
+        const GAP_ROWS: u16 = 1; // visual gap between scrollback and popup
+        match &self.popup {
+            None => 0,
+            Some(snap) => {
+                let row_count = (snap.rows.len() as u16).clamp(1, MAX_POPUP_ROWS);
+                HEADER_ROWS + row_count + FOOTER_ROWS + GAP_ROWS
+            }
         }
     }
 
@@ -972,16 +979,11 @@ impl TerminalRenderer {
         // Render input area (block + textarea)
         self.composer.render(f, input_area, textarea);
 
-        // Render autocomplete popup in its dedicated layout slice (just above
-        // the input area). The slice has zero height when no items are active.
-        if !self.autocomplete_items.is_empty() && popup_area.height > 0 {
-            Self::render_autocomplete_popup(
-                f,
-                popup_area,
-                input_area,
-                &self.autocomplete_items,
-                self.autocomplete_selected,
-            );
+        // Render slash-command popup (above the composer) when a snapshot is set.
+        if let Some(snap) = self.popup.clone() {
+            if popup_area.height > 0 {
+                Self::render_popup(f, popup_area, input_area, &snap);
+            }
         }
     }
 
@@ -1250,93 +1252,170 @@ impl TerminalRenderer {
     /// anchored to the top-left of `input_area` and extends upward (i.e. it
     /// sits between the scroll-back content and the composer).  If `input_area`
     /// is not tall enough to fit the popup it is clamped to the available space.
-    fn render_autocomplete_popup(
+    fn render_popup(
         f: &mut custom_terminal::Frame,
         popup_area: Rect,
         input_area: Rect,
-        items: &[(&'static str, &'static str)],
-        selected: usize,
+        snap: &PopupSnapshot,
     ) {
         const MAX_POPUP_ROWS: u16 = 8;
 
-        if items.is_empty() || popup_area.height == 0 {
+        if popup_area.height == 0 {
             return;
         }
 
-        // Width: prefer fitting the longest "  /name  —  description  " row,
-        // but never exceed the popup slice width.
-        let max_text_width = items
+        // Compute the textual width budget. Reserve room for the longest item
+        // and for header / footer text.
+        let header_text = format_breadcrumb(&snap.breadcrumb);
+        let footer_text = format_footer(snap.stack_depth);
+        let longest_row = snap
+            .rows
             .iter()
-            .map(|(name, desc)| {
-                // "  /name  —  description  "
-                2 + 1 + name.len() + 2 + 3 + 2 + desc.len() + 2
-            })
+            .map(|r| 2 + r.label.chars().count() + 4 + r.description.chars().count() + 2)
             .max()
-            .unwrap_or(20) as u16;
-        let popup_width = max_text_width.max(20).min(popup_area.width);
+            .unwrap_or(20);
+        let min_width = longest_row
+            .max(header_text.chars().count() + 4)
+            .max(footer_text.chars().count() + 4) as u16;
+        let popup_width = min_width.max(24).min(popup_area.width);
 
-        // Horizontally align the popup with the "› " prefix of the composer
-        // (two columns indent), but clamp to the popup slice bounds.
+        // Horizontal indent under the "› " composer prefix.
         let popup_x = (input_area.x + 2)
             .max(popup_area.x)
             .min(popup_area.x + popup_area.width.saturating_sub(popup_width));
-        let popup_height = popup_area.height.min(MAX_POPUP_ROWS);
 
-        let popup_area = Rect {
+        // Layout inside the slice: 1 row gap, 1 row header, n rows list, 1 row footer.
+        let total_height = popup_area.height;
+        if total_height < 3 {
+            return;
+        }
+        let rows_height = total_height.saturating_sub(3); // gap + header + footer
+        let rows_height = rows_height.min(MAX_POPUP_ROWS);
+
+        let header_y = popup_area.y + 1; // skip the gap row
+        let list_y = header_y + 1;
+        let footer_y = list_y + rows_height;
+
+        // Background fill: header + list + footer rows.
+        let bg = Color::Reset;
+        for y in [header_y]
+            .into_iter()
+            .chain((0..rows_height).map(|i| list_y + i))
+            .chain([footer_y])
+        {
+            let area = Rect {
+                x: popup_x,
+                y,
+                width: popup_width,
+                height: 1,
+            };
+            f.render_widget(
+                Paragraph::new(Line::raw(" ".repeat(popup_width as usize)))
+                    .style(Style::default().bg(bg)),
+                area,
+            );
+        }
+
+        // Header: " ▍ /model > Choose model "  (cyan accent + breadcrumb)
+        let header_area = Rect {
             x: popup_x,
-            y: popup_area.y,
+            y: header_y,
             width: popup_width,
-            height: popup_height,
+            height: 1,
         };
+        let header = Line::from(vec![
+            Span::styled(
+                " ▍ ",
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                header_text.clone(),
+                Style::default()
+                    .fg(Color::White)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ]);
+        f.render_widget(Paragraph::new(header), header_area);
 
-        // Determine which items are visible (top `MAX_POPUP_ROWS` items starting
-        // from the window that keeps `selected` in view).
-        let window_start = if selected >= MAX_POPUP_ROWS as usize {
-            selected + 1 - MAX_POPUP_ROWS as usize
+        // List rows. Keep selection in view with a sliding window.
+        let selected = snap.selected.min(snap.rows.len().saturating_sub(1));
+        let window_start = if rows_height == 0 {
+            0
+        } else if selected >= rows_height as usize {
+            selected + 1 - rows_height as usize
         } else {
             0
         };
-        let visible: Vec<_> = items
-            .iter()
+        for (row_idx, item_idx) in (window_start..)
+            .take(rows_height as usize)
             .enumerate()
-            .skip(window_start)
-            .take(MAX_POPUP_ROWS as usize)
-            .collect();
-
-        for (row_idx, (item_idx, (name, desc))) in visible.iter().enumerate() {
-            let row_y = popup_area.y + row_idx as u16;
-            // Defensive: never render past the popup slice.
-            if row_y >= popup_area.y + popup_area.height {
-                break;
-            }
+            .filter(|(_, i)| *i < snap.rows.len())
+        {
+            let row = &snap.rows[item_idx];
+            let row_y = list_y + row_idx as u16;
             let row_area = Rect {
-                x: popup_area.x,
+                x: popup_x,
                 y: row_y,
-                width: popup_area.width,
+                width: popup_width,
                 height: 1,
             };
 
-            let is_selected = *item_idx == selected;
-            let (bg, fg, name_fg) = if is_selected {
-                (Color::DarkGray, Color::White, Color::Cyan)
+            let is_selected = item_idx == selected;
+            let (row_bg, label_fg, desc_fg) = if is_selected {
+                (Color::DarkGray, Color::Cyan, Color::White)
             } else {
-                (Color::Reset, Color::DarkGray, Color::Gray)
+                (Color::Reset, Color::Gray, Color::DarkGray)
             };
+            let bg_style = Style::default().bg(row_bg);
+            f.render_widget(
+                Paragraph::new(Line::raw(" ".repeat(popup_width as usize))).style(bg_style),
+                row_area,
+            );
 
-            // Fill the whole row background first.
-            let bg_style = Style::default().bg(bg);
-            let fill = Line::raw(" ".repeat(popup_area.width as usize));
-            f.render_widget(Paragraph::new(fill).style(bg_style), row_area);
-
-            // Render "  /name  —  description" over the background.
-            let line = Line::from(vec![
-                Span::styled("  ", Style::default().bg(bg)),
-                Span::styled(format!("/{name}"), Style::default().fg(name_fg).bg(bg)),
-                Span::styled("  —  ", Style::default().fg(fg).bg(bg)),
-                Span::styled(*desc, Style::default().fg(fg).bg(bg)),
-            ]);
-            f.render_widget(Paragraph::new(line), row_area);
+            let mut spans: Vec<Span> = Vec::with_capacity(6);
+            spans.push(Span::styled("  ", Style::default().bg(row_bg)));
+            spans.push(Span::styled(
+                row.label.clone(),
+                Style::default().fg(label_fg).bg(row_bg),
+            ));
+            if !row.description.is_empty() {
+                spans.push(Span::styled(
+                    "  —  ",
+                    Style::default().fg(desc_fg).bg(row_bg),
+                ));
+                spans.push(Span::styled(
+                    row.description.clone(),
+                    Style::default().fg(desc_fg).bg(row_bg),
+                ));
+            }
+            if row.has_submenu {
+                spans.push(Span::styled(
+                    "  ›",
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .bg(row_bg)
+                        .add_modifier(Modifier::BOLD),
+                ));
+            }
+            f.render_widget(Paragraph::new(Line::from(spans)), row_area);
         }
+
+        // Footer hint.
+        let footer_area = Rect {
+            x: popup_x,
+            y: footer_y,
+            width: popup_width,
+            height: 1,
+        };
+        let footer = Line::from(vec![Span::styled(
+            footer_text,
+            Style::default()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::DIM),
+        )]);
+        f.render_widget(Paragraph::new(footer), footer_area);
     }
 
     /// Set an error message to display
@@ -1385,6 +1464,21 @@ impl TerminalRenderer {
 }
 
 /// Apply Yellow+Italic style to thinking lines while preserving per-span markdown styling.
+/// Format the breadcrumb of a popup stack as `"Slash commands › Choose model"`.
+fn format_breadcrumb(crumbs: &[String]) -> String {
+    crumbs.join(" › ")
+}
+
+/// Footer hint shown beneath the popup. The hint changes based on stack depth:
+/// at the root level the user can dismiss with Esc, deeper levels offer "back".
+fn format_footer(stack_depth: usize) -> String {
+    if stack_depth > 1 {
+        "  ↵ select   ←/Esc back".to_string()
+    } else {
+        "  ↵ select   Tab complete   Esc dismiss".to_string()
+    }
+}
+
 fn style_thinking_lines(thinking: Vec<Line<'static>>) -> Vec<Line<'static>> {
     thinking
         .into_iter()

--- a/crates/ui_terminal/src/renderer.rs
+++ b/crates/ui_terminal/src/renderer.rs
@@ -733,11 +733,24 @@ impl TerminalRenderer {
         // Status/error height
         content_height = content_height.saturating_add(self.measure_status_height(screen_width));
 
+        // Autocomplete popup height (rendered just above the composer).
+        content_height = content_height.saturating_add(self.measure_autocomplete_height());
+
         // Always reserve at least 1 row so there's a visible gap between
         // scrollback and the composer when no live content is displayed.
         content_height = content_height.max(1);
 
         content_height.saturating_add(input_height)
+    }
+
+    /// Height reserved for the autocomplete popup (0 when inactive).
+    fn measure_autocomplete_height(&self) -> u16 {
+        const MAX_POPUP_ROWS: u16 = 8;
+        if self.autocomplete_items.is_empty() {
+            0
+        } else {
+            (self.autocomplete_items.len() as u16).min(MAX_POPUP_ROWS)
+        }
     }
 
     fn measure_status_height(&self, width: u16) -> u16 {
@@ -903,9 +916,12 @@ impl TerminalRenderer {
         // Composed content occupies rows [cursor_y .. scratch_height)
         let total_height = scratch_height.saturating_sub(cursor_y);
 
-        let [content_area, status_area, input_area] = Layout::vertical([
+        let popup_height = self.measure_autocomplete_height();
+
+        let [content_area, status_area, popup_area, input_area] = Layout::vertical([
             Constraint::Min(0),
             Constraint::Length(status_height),
+            Constraint::Length(popup_height),
             Constraint::Length(input_height),
         ])
         .areas(full);
@@ -956,10 +972,12 @@ impl TerminalRenderer {
         // Render input area (block + textarea)
         self.composer.render(f, input_area, textarea);
 
-        // Render autocomplete popup on top of the input area if items are present.
-        if !self.autocomplete_items.is_empty() {
+        // Render autocomplete popup in its dedicated layout slice (just above
+        // the input area). The slice has zero height when no items are active.
+        if !self.autocomplete_items.is_empty() && popup_area.height > 0 {
             Self::render_autocomplete_popup(
                 f,
+                popup_area,
                 input_area,
                 &self.autocomplete_items,
                 self.autocomplete_selected,
@@ -1234,18 +1252,19 @@ impl TerminalRenderer {
     /// is not tall enough to fit the popup it is clamped to the available space.
     fn render_autocomplete_popup(
         f: &mut custom_terminal::Frame,
+        popup_area: Rect,
         input_area: Rect,
         items: &[(&'static str, &'static str)],
         selected: usize,
     ) {
         const MAX_POPUP_ROWS: u16 = 8;
-        const H_PADDING: u16 = 1; // spaces on each side of the text
 
-        if items.is_empty() || input_area.height == 0 {
+        if items.is_empty() || popup_area.height == 0 {
             return;
         }
 
-        // How wide should each row be?
+        // Width: prefer fitting the longest "  /name  —  description  " row,
+        // but never exceed the popup slice width.
         let max_text_width = items
             .iter()
             .map(|(name, desc)| {
@@ -1254,23 +1273,18 @@ impl TerminalRenderer {
             })
             .max()
             .unwrap_or(20) as u16;
-        let popup_width = max_text_width
-            .max(20)
-            .min(input_area.width.saturating_sub(H_PADDING * 2));
+        let popup_width = max_text_width.max(20).min(popup_area.width);
 
-        let popup_height = (items.len() as u16).min(MAX_POPUP_ROWS);
-
-        // Position the popup directly above the input area, left-aligned with
-        // a small horizontal indent so it visually aligns with the "› " prefix.
-        let popup_x = input_area.x + 2; // indent under the "› " prefix
-        let popup_y = input_area.y.saturating_sub(popup_height);
-
-        // Clamp to screen bounds.
-        let popup_x = popup_x.min(f.area().width.saturating_sub(popup_width));
+        // Horizontally align the popup with the "› " prefix of the composer
+        // (two columns indent), but clamp to the popup slice bounds.
+        let popup_x = (input_area.x + 2)
+            .max(popup_area.x)
+            .min(popup_area.x + popup_area.width.saturating_sub(popup_width));
+        let popup_height = popup_area.height.min(MAX_POPUP_ROWS);
 
         let popup_area = Rect {
             x: popup_x,
-            y: popup_y,
+            y: popup_area.y,
             width: popup_width,
             height: popup_height,
         };
@@ -1290,9 +1304,14 @@ impl TerminalRenderer {
             .collect();
 
         for (row_idx, (item_idx, (name, desc))) in visible.iter().enumerate() {
+            let row_y = popup_area.y + row_idx as u16;
+            // Defensive: never render past the popup slice.
+            if row_y >= popup_area.y + popup_area.height {
+                break;
+            }
             let row_area = Rect {
                 x: popup_area.x,
-                y: popup_area.y + row_idx as u16,
+                y: row_y,
                 width: popup_area.width,
                 height: 1,
             };

--- a/crates/ui_terminal/src/renderer.rs
+++ b/crates/ui_terminal/src/renderer.rs
@@ -111,6 +111,11 @@ pub struct TerminalRenderer {
     needs_paragraph_break_after_hidden_tool: bool,
     /// Last known terminal width (updated in prepare(), used for history rendering).
     last_known_width: u16,
+    /// Filtered list of (name, description) pairs to show in the autocomplete popup.
+    /// Empty when the popup is hidden.
+    autocomplete_items: Vec<(&'static str, &'static str)>,
+    /// Index of the highlighted row in `autocomplete_items`.
+    autocomplete_selected: usize,
 }
 
 /// Tracks the last block type for paragraph breaks after hidden tools
@@ -144,6 +149,8 @@ impl TerminalRenderer {
             last_block_type_for_hidden_tool: None,
             needs_paragraph_break_after_hidden_tool: false,
             last_known_width: 80,
+            autocomplete_items: Vec::new(),
+            autocomplete_selected: 0,
         })
     }
 
@@ -296,6 +303,21 @@ impl TerminalRenderer {
     /// Toggle whether an overlay is active (drives deferred history behavior).
     pub fn set_overlay_active(&mut self, active: bool) {
         self.overlay_active = active;
+    }
+
+    /// Update the autocomplete popup contents.
+    ///
+    /// `items` is the pre-filtered list of (name, description) pairs to display.
+    /// `selected` is the index of the highlighted row.
+    pub fn set_autocomplete(&mut self, items: Vec<(&'static str, &'static str)>, selected: usize) {
+        self.autocomplete_items = items;
+        self.autocomplete_selected = selected;
+    }
+
+    /// Hide the autocomplete popup.
+    pub fn clear_autocomplete(&mut self) {
+        self.autocomplete_items.clear();
+        self.autocomplete_selected = 0;
     }
 
     /// Append text to the last block in the current message
@@ -933,6 +955,16 @@ impl TerminalRenderer {
 
         // Render input area (block + textarea)
         self.composer.render(f, input_area, textarea);
+
+        // Render autocomplete popup on top of the input area if items are present.
+        if !self.autocomplete_items.is_empty() {
+            Self::render_autocomplete_popup(
+                f,
+                input_area,
+                &self.autocomplete_items,
+                self.autocomplete_selected,
+            );
+        }
     }
 
     /// Render a message to the scratch buffer, updating cursor_y
@@ -1188,6 +1220,104 @@ impl TerminalRenderer {
 
     fn format_error_message(message: &str) -> String {
         format!("Error: {message} (Press Esc to dismiss)")
+    }
+
+    /// Render the slash-command autocomplete popup above the input area.
+    ///
+    /// The popup is a borderless list drawn over `input_area`.  Each row shows
+    /// `  /name  —  description  `; the highlighted row is drawn with a dark
+    /// background so it stands out without being distracting.
+    ///
+    /// Layout: the popup height is `min(items.len(), MAX_POPUP_ROWS)`.  It is
+    /// anchored to the top-left of `input_area` and extends upward (i.e. it
+    /// sits between the scroll-back content and the composer).  If `input_area`
+    /// is not tall enough to fit the popup it is clamped to the available space.
+    fn render_autocomplete_popup(
+        f: &mut custom_terminal::Frame,
+        input_area: Rect,
+        items: &[(&'static str, &'static str)],
+        selected: usize,
+    ) {
+        const MAX_POPUP_ROWS: u16 = 8;
+        const H_PADDING: u16 = 1; // spaces on each side of the text
+
+        if items.is_empty() || input_area.height == 0 {
+            return;
+        }
+
+        // How wide should each row be?
+        let max_text_width = items
+            .iter()
+            .map(|(name, desc)| {
+                // "  /name  —  description  "
+                2 + 1 + name.len() + 2 + 3 + 2 + desc.len() + 2
+            })
+            .max()
+            .unwrap_or(20) as u16;
+        let popup_width = max_text_width
+            .max(20)
+            .min(input_area.width.saturating_sub(H_PADDING * 2));
+
+        let popup_height = (items.len() as u16).min(MAX_POPUP_ROWS);
+
+        // Position the popup directly above the input area, left-aligned with
+        // a small horizontal indent so it visually aligns with the "› " prefix.
+        let popup_x = input_area.x + 2; // indent under the "› " prefix
+        let popup_y = input_area.y.saturating_sub(popup_height);
+
+        // Clamp to screen bounds.
+        let popup_x = popup_x.min(f.area().width.saturating_sub(popup_width));
+
+        let popup_area = Rect {
+            x: popup_x,
+            y: popup_y,
+            width: popup_width,
+            height: popup_height,
+        };
+
+        // Determine which items are visible (top `MAX_POPUP_ROWS` items starting
+        // from the window that keeps `selected` in view).
+        let window_start = if selected >= MAX_POPUP_ROWS as usize {
+            selected + 1 - MAX_POPUP_ROWS as usize
+        } else {
+            0
+        };
+        let visible: Vec<_> = items
+            .iter()
+            .enumerate()
+            .skip(window_start)
+            .take(MAX_POPUP_ROWS as usize)
+            .collect();
+
+        for (row_idx, (item_idx, (name, desc))) in visible.iter().enumerate() {
+            let row_area = Rect {
+                x: popup_area.x,
+                y: popup_area.y + row_idx as u16,
+                width: popup_area.width,
+                height: 1,
+            };
+
+            let is_selected = *item_idx == selected;
+            let (bg, fg, name_fg) = if is_selected {
+                (Color::DarkGray, Color::White, Color::Cyan)
+            } else {
+                (Color::Reset, Color::DarkGray, Color::Gray)
+            };
+
+            // Fill the whole row background first.
+            let bg_style = Style::default().bg(bg);
+            let fill = Line::raw(" ".repeat(popup_area.width as usize));
+            f.render_widget(Paragraph::new(fill).style(bg_style), row_area);
+
+            // Render "  /name  —  description" over the background.
+            let line = Line::from(vec![
+                Span::styled("  ", Style::default().bg(bg)),
+                Span::styled(format!("/{name}"), Style::default().fg(name_fg).bg(bg)),
+                Span::styled("  —  ", Style::default().fg(fg).bg(bg)),
+                Span::styled(*desc, Style::default().fg(fg).bg(bg)),
+            ]);
+            f.render_widget(Paragraph::new(line), row_area);
+        }
     }
 
     /// Set an error message to display

--- a/crates/ui_terminal/src/slash_popup/command_list.rs
+++ b/crates/ui_terminal/src/slash_popup/command_list.rs
@@ -1,0 +1,224 @@
+//! Root popup that lists all known slash commands.
+
+use crate::commands::{all_commands, CommandResult};
+use crate::slash_popup::{PopupAction, PopupRow, SlashPopup};
+
+pub struct CommandListPopup {
+    /// All rows the popup knows about, before filtering.
+    all_rows: Vec<PopupRow>,
+    /// All command names (parallel to `all_rows`); used to dispatch on activate.
+    all_names: Vec<&'static str>,
+    /// Currently visible rows after filtering.
+    visible_rows: Vec<PopupRow>,
+    /// Indices into `all_rows`/`all_names` for the currently visible rows.
+    visible_indices: Vec<usize>,
+    /// Highlighted row inside `visible_rows`.
+    selected: usize,
+}
+
+impl Default for CommandListPopup {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CommandListPopup {
+    pub fn new() -> Self {
+        let mut all_rows = Vec::new();
+        let mut all_names = Vec::new();
+        for cmd in all_commands() {
+            all_rows.push(PopupRow {
+                label: format!("/{}", cmd.name),
+                description: cmd.description.to_string(),
+                has_submenu: command_has_submenu(cmd.name),
+            });
+            all_names.push(cmd.name);
+        }
+        let visible_indices = (0..all_rows.len()).collect::<Vec<_>>();
+        let visible_rows = all_rows.clone();
+        Self {
+            all_rows,
+            all_names,
+            visible_rows,
+            visible_indices,
+            selected: 0,
+        }
+    }
+
+    /// Return the command name for the currently selected visible row.
+    fn selected_name(&self) -> Option<&'static str> {
+        let idx = *self.visible_indices.get(self.selected)?;
+        self.all_names.get(idx).copied()
+    }
+}
+
+/// Returns true if the command should open a sub-popup when activated without
+/// arguments (instead of running immediately).
+fn command_has_submenu(name: &str) -> bool {
+    matches!(name, "model")
+}
+
+/// Build the [`PopupAction`] for activating a slash command by name.
+/// Pure function so we can unit-test the dispatch table without instantiating
+/// the popup.
+pub(crate) fn dispatch_command(name: &str) -> PopupAction {
+    match name {
+        "model" => PopupAction::Push(Box::new(super::model_picker::ModelPickerPopup::new())),
+        "help" => PopupAction::Commit(CommandResult::Help(String::new())),
+        "provider" => PopupAction::Commit(CommandResult::ListProviders),
+        "current" => PopupAction::Commit(CommandResult::ShowCurrentModel),
+        "plan" => PopupAction::Commit(CommandResult::TogglePlan),
+        "clear" => PopupAction::Commit(CommandResult::ClearContext),
+        "compact" => PopupAction::Commit(CommandResult::CompactContext),
+        other => PopupAction::Commit(CommandResult::InvalidCommand(format!(
+            "Unknown command: /{other}"
+        ))),
+    }
+}
+
+impl SlashPopup for CommandListPopup {
+    fn title(&self) -> &str {
+        "Slash commands"
+    }
+
+    fn set_query(&mut self, query: &str) {
+        // Filter rows by prefix-match on the command name (case-insensitive).
+        // `query` is the text after the leading "/", so for "/cl" we receive "cl".
+        let q = query.to_lowercase();
+        self.visible_rows.clear();
+        self.visible_indices.clear();
+        for (i, name) in self.all_names.iter().enumerate() {
+            if name.to_lowercase().starts_with(&q) {
+                self.visible_rows.push(self.all_rows[i].clone());
+                self.visible_indices.push(i);
+            }
+        }
+        // Clamp selection.
+        if self.visible_rows.is_empty() {
+            self.selected = 0;
+        } else if self.selected >= self.visible_rows.len() {
+            self.selected = self.visible_rows.len() - 1;
+        }
+    }
+
+    fn rows(&self) -> &[PopupRow] {
+        &self.visible_rows
+    }
+
+    fn selected(&self) -> usize {
+        self.selected
+    }
+
+    fn move_selection(&mut self, delta: i32) {
+        let len = self.visible_rows.len() as i32;
+        if len == 0 {
+            return;
+        }
+        self.selected = (self.selected as i32 + delta).rem_euclid(len) as usize;
+    }
+
+    fn activate(&self) -> PopupAction {
+        match self.selected_name() {
+            Some(name) => dispatch_command(name),
+            None => PopupAction::Continue,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::slash_popup::PopupStack;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn lists_all_commands_initially() {
+        let popup = CommandListPopup::new();
+        let labels: Vec<&str> = popup.rows().iter().map(|r| r.label.as_str()).collect();
+        assert!(labels.contains(&"/help"));
+        assert!(labels.contains(&"/model"));
+        assert!(labels.contains(&"/clear"));
+        assert!(labels.contains(&"/compact"));
+        assert_eq!(popup.rows().len(), all_commands().len());
+    }
+
+    #[test]
+    fn filter_by_prefix() {
+        let mut popup = CommandListPopup::new();
+        popup.set_query("c");
+        let labels: Vec<&str> = popup.rows().iter().map(|r| r.label.as_str()).collect();
+        // "current", "clear", "compact" all start with c
+        assert_eq!(labels, vec!["/current", "/clear", "/compact"]);
+    }
+
+    #[test]
+    fn filter_narrowing_keeps_selection_in_range() {
+        let mut popup = CommandListPopup::new();
+        popup.set_query("c"); // 3 rows
+        popup.move_selection(2); // selected = 2 (last)
+        popup.set_query("cl"); // 1 row
+        assert_eq!(popup.selected(), 0);
+        assert_eq!(popup.rows().len(), 1);
+        assert_eq!(popup.rows()[0].label, "/clear");
+    }
+
+    #[test]
+    fn empty_filter_result_does_not_panic() {
+        let mut popup = CommandListPopup::new();
+        popup.set_query("zzzzz");
+        assert!(popup.rows().is_empty());
+        // Activating an empty filter is a no-op (Continue), not a panic.
+        let action = popup.activate();
+        assert!(matches!(action, PopupAction::Continue));
+    }
+
+    #[test]
+    fn model_command_opens_submenu_with_marker() {
+        let popup = CommandListPopup::new();
+        let model_row = popup.rows().iter().find(|r| r.label == "/model").unwrap();
+        assert!(
+            model_row.has_submenu,
+            "model row should be marked as having a sub-menu"
+        );
+    }
+
+    #[test]
+    fn non_submenu_commands_are_not_marked() {
+        let popup = CommandListPopup::new();
+        for row in popup.rows() {
+            if row.label != "/model" {
+                assert!(
+                    !row.has_submenu,
+                    "{} should not be marked as having a sub-menu",
+                    row.label
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn enter_on_clear_commits_clear_context() {
+        let mut stack = PopupStack::new();
+        stack.push(Box::new(CommandListPopup::new()));
+        stack.set_query("cl"); // narrow to /clear
+        let result = stack.handle_key(key(KeyCode::Enter));
+        assert!(matches!(result, Some(CommandResult::ClearContext)));
+        assert!(!stack.is_active());
+    }
+
+    #[test]
+    fn enter_on_model_pushes_submenu() {
+        let mut stack = PopupStack::new();
+        stack.push(Box::new(CommandListPopup::new()));
+        stack.set_query("mo"); // /model
+        let result = stack.handle_key(key(KeyCode::Enter));
+        // No final command — sub-popup is now on top.
+        assert!(result.is_none());
+        assert_eq!(stack.depth(), 2);
+        assert_eq!(stack.breadcrumb()[0], "Slash commands");
+    }
+}

--- a/crates/ui_terminal/src/slash_popup/mod.rs
+++ b/crates/ui_terminal/src/slash_popup/mod.rs
@@ -1,0 +1,383 @@
+//! Slash-command popup system.
+//!
+//! Popups follow a "stack of modal pickers" pattern, similar to how a CLI
+//! command tree works. The root popup (`CommandListPopup`) lists all known
+//! slash commands. Activating a row may either:
+//!
+//! - immediately run a [`CommandResult`] (most commands), or
+//! - push a sub-popup onto the stack (e.g. `/model` opens a model picker).
+//!
+//! The popup stack is owned by [`crate::state::AppState`] and rendered by
+//! the composer just above the input area, growing the inline viewport
+//! dynamically (see [`crate::renderer::desired_viewport_height`]).
+//!
+//! While the stack is non-empty, the input layer routes Up / Down / Enter /
+//! Esc / Backspace / Left to the top-of-stack popup via [`SlashPopup::handle_key`]
+//! and reflects the resulting [`PopupAction`] on the stack.
+
+pub mod command_list;
+pub mod model_picker;
+
+pub use command_list::CommandListPopup;
+pub use model_picker::ModelPickerPopup;
+
+use crate::commands::CommandResult;
+use crossterm::event::{KeyCode, KeyEvent};
+
+/// One row inside a popup list.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PopupRow {
+    /// Primary text shown in the row (e.g. `/help` or a model name).
+    pub label: String,
+    /// Secondary, dimmer description.
+    pub description: String,
+    /// When true, the row opens a sub-popup; rendered with a "›" trailing hint.
+    pub has_submenu: bool,
+}
+
+/// Result of activating or navigating a popup.
+pub enum PopupAction {
+    /// Selection moved or query updated — just redraw, no stack change.
+    Continue,
+    /// Push a new popup onto the stack as a sub-popup.
+    Push(Box<dyn SlashPopup>),
+    /// Close the top-of-stack popup. Empty stack closes the popup system entirely
+    /// (and, by convention, deletes the leading "/" from the composer line).
+    Pop,
+    /// Close the entire stack and execute a final command.
+    Commit(CommandResult),
+    /// Close the entire stack without running anything (e.g. user hit Esc at root).
+    Dismiss,
+}
+
+/// A modal picker shown above the composer.
+pub trait SlashPopup: Send {
+    /// Header title (e.g. `"Slash commands"` for the root, `"Choose model"`
+    /// for a model picker).
+    fn title(&self) -> &str;
+
+    /// Update the filter query (the text the user has typed after `/`).
+    /// Sub-popups are free to ignore this and present an unfiltered list.
+    fn set_query(&mut self, query: &str);
+
+    /// Currently visible rows (already filtered by `set_query`).
+    fn rows(&self) -> &[PopupRow];
+
+    /// Currently highlighted row index. May be 0 even if `rows()` is empty;
+    /// renderers should bounds-check.
+    fn selected(&self) -> usize;
+
+    /// Handle a key event. Returns the action to apply to the stack.
+    /// The default impl handles Up / Down / Enter / Esc and delegates row
+    /// activation to [`Self::activate`].
+    fn handle_key(&mut self, key: KeyEvent) -> PopupAction {
+        match key.code {
+            KeyCode::Up => {
+                self.move_selection(-1);
+                PopupAction::Continue
+            }
+            KeyCode::Down => {
+                self.move_selection(1);
+                PopupAction::Continue
+            }
+            KeyCode::Enter | KeyCode::Tab => self.activate(),
+            KeyCode::Esc => PopupAction::Pop,
+            _ => PopupAction::Continue,
+        }
+    }
+
+    /// Move the selection by `delta` rows, wrapping with rem_euclid.
+    fn move_selection(&mut self, delta: i32);
+
+    /// Activate the currently highlighted row.
+    fn activate(&self) -> PopupAction;
+}
+
+/// Stack of nested popups. Empty stack ↔ no popup visible.
+#[derive(Default)]
+pub struct PopupStack {
+    stack: Vec<Box<dyn SlashPopup>>,
+}
+
+impl std::fmt::Debug for PopupStack {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PopupStack")
+            .field("depth", &self.stack.len())
+            .field(
+                "titles",
+                &self.stack.iter().map(|p| p.title()).collect::<Vec<_>>(),
+            )
+            .finish()
+    }
+}
+
+impl PopupStack {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn is_active(&self) -> bool {
+        !self.stack.is_empty()
+    }
+
+    pub fn depth(&self) -> usize {
+        self.stack.len()
+    }
+
+    /// Push a new popup as the active one.
+    pub fn push(&mut self, popup: Box<dyn SlashPopup>) {
+        self.stack.push(popup);
+    }
+
+    /// Close all popups.
+    pub fn clear(&mut self) {
+        self.stack.clear();
+    }
+
+    /// Mutable access to the top-of-stack popup, if any.
+    pub fn top_mut(&mut self) -> Option<&mut (dyn SlashPopup + 'static)> {
+        match self.stack.last_mut() {
+            Some(p) => Some(&mut **p),
+            None => None,
+        }
+    }
+
+    /// Read-only access to the top-of-stack popup, if any.
+    pub fn top(&self) -> Option<&(dyn SlashPopup + 'static)> {
+        match self.stack.last() {
+            Some(p) => Some(&**p),
+            None => None,
+        }
+    }
+
+    /// Breadcrumb of titles, root first, top last.
+    pub fn breadcrumb(&self) -> Vec<&str> {
+        self.stack.iter().map(|p| p.title()).collect()
+    }
+
+    /// Forward a key to the top-of-stack popup and apply the resulting action
+    /// to the stack. Returns the (possibly) terminal outcome:
+    ///
+    /// - `None` — popup is still open (or just closed cleanly with nothing to
+    ///   commit).
+    /// - `Some(CommandResult)` — caller should run this command.
+    pub fn handle_key(&mut self, key: KeyEvent) -> Option<CommandResult> {
+        let action = match self.top_mut() {
+            Some(top) => top.handle_key(key),
+            None => return None,
+        };
+        self.apply(action)
+    }
+
+    /// Apply a [`PopupAction`] to the stack.
+    pub fn apply(&mut self, action: PopupAction) -> Option<CommandResult> {
+        match action {
+            PopupAction::Continue => None,
+            PopupAction::Push(p) => {
+                self.stack.push(p);
+                None
+            }
+            PopupAction::Pop => {
+                self.stack.pop();
+                None
+            }
+            PopupAction::Dismiss => {
+                self.stack.clear();
+                None
+            }
+            PopupAction::Commit(cmd) => {
+                self.stack.clear();
+                Some(cmd)
+            }
+        }
+    }
+
+    /// Forward `set_query` to the top-of-stack popup. Used by the input layer
+    /// when the user types more characters after `/`.
+    pub fn set_query(&mut self, query: &str) {
+        if let Some(top) = self.top_mut() {
+            top.set_query(query);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    /// Minimal popup used to test stack mechanics.
+    struct FakePopup {
+        title: &'static str,
+        rows: Vec<PopupRow>,
+        selected: usize,
+        on_activate: Box<dyn Fn(usize) -> PopupAction + Send>,
+        last_query: String,
+    }
+
+    impl FakePopup {
+        fn new(
+            title: &'static str,
+            row_labels: &[&str],
+            on_activate: impl Fn(usize) -> PopupAction + Send + 'static,
+        ) -> Box<Self> {
+            Box::new(Self {
+                title,
+                rows: row_labels
+                    .iter()
+                    .map(|l| PopupRow {
+                        label: l.to_string(),
+                        description: String::new(),
+                        has_submenu: false,
+                    })
+                    .collect(),
+                selected: 0,
+                on_activate: Box::new(on_activate),
+                last_query: String::new(),
+            })
+        }
+    }
+
+    impl SlashPopup for FakePopup {
+        fn title(&self) -> &str {
+            self.title
+        }
+        fn set_query(&mut self, query: &str) {
+            self.last_query = query.to_string();
+        }
+        fn rows(&self) -> &[PopupRow] {
+            &self.rows
+        }
+        fn selected(&self) -> usize {
+            self.selected
+        }
+        fn move_selection(&mut self, delta: i32) {
+            let len = self.rows.len() as i32;
+            if len == 0 {
+                return;
+            }
+            let new = (self.selected as i32 + delta).rem_euclid(len);
+            self.selected = new as usize;
+        }
+        fn activate(&self) -> PopupAction {
+            (self.on_activate)(self.selected)
+        }
+    }
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn empty_stack_is_inactive() {
+        let stack = PopupStack::new();
+        assert!(!stack.is_active());
+        assert_eq!(stack.depth(), 0);
+        assert!(stack.top().is_none());
+        assert!(stack.breadcrumb().is_empty());
+    }
+
+    #[test]
+    fn push_makes_stack_active() {
+        let mut stack = PopupStack::new();
+        stack.push(FakePopup::new("Root", &["a", "b"], |_| PopupAction::Pop));
+        assert!(stack.is_active());
+        assert_eq!(stack.depth(), 1);
+        assert_eq!(stack.breadcrumb(), vec!["Root"]);
+    }
+
+    #[test]
+    fn arrow_keys_move_selection_with_wrap() {
+        let mut stack = PopupStack::new();
+        stack.push(FakePopup::new("Root", &["a", "b", "c"], |_| {
+            PopupAction::Pop
+        }));
+        // Down twice: 0 -> 1 -> 2
+        stack.handle_key(key(KeyCode::Down));
+        stack.handle_key(key(KeyCode::Down));
+        assert_eq!(stack.top().unwrap().selected(), 2);
+        // Down again wraps to 0
+        stack.handle_key(key(KeyCode::Down));
+        assert_eq!(stack.top().unwrap().selected(), 0);
+        // Up wraps to last
+        stack.handle_key(key(KeyCode::Up));
+        assert_eq!(stack.top().unwrap().selected(), 2);
+    }
+
+    #[test]
+    fn enter_commits_command_and_clears_stack() {
+        let mut stack = PopupStack::new();
+        stack.push(FakePopup::new("Root", &["help"], |_| {
+            PopupAction::Commit(CommandResult::Help("text".into()))
+        }));
+        let result = stack.handle_key(key(KeyCode::Enter));
+        assert!(matches!(result, Some(CommandResult::Help(_))));
+        assert!(!stack.is_active());
+    }
+
+    #[test]
+    fn enter_can_push_sub_popup() {
+        let mut stack = PopupStack::new();
+        stack.push(FakePopup::new("Root", &["model"], |_| {
+            PopupAction::Push(FakePopup::new("Choose model", &["sonnet", "gpt"], |_| {
+                PopupAction::Commit(CommandResult::SwitchModel("sonnet".into()))
+            }))
+        }));
+        // Enter on root pushes sub-popup
+        let result = stack.handle_key(key(KeyCode::Enter));
+        assert!(result.is_none());
+        assert_eq!(stack.depth(), 2);
+        assert_eq!(stack.breadcrumb(), vec!["Root", "Choose model"]);
+        // Enter on sub commits and clears
+        let result = stack.handle_key(key(KeyCode::Enter));
+        assert!(matches!(result, Some(CommandResult::SwitchModel(s)) if s == "sonnet"));
+        assert!(!stack.is_active());
+    }
+
+    #[test]
+    fn esc_pops_one_level_and_can_close() {
+        let mut stack = PopupStack::new();
+        stack.push(FakePopup::new("Root", &["x"], |_| PopupAction::Pop));
+        stack.push(FakePopup::new("Sub", &["y"], |_| PopupAction::Pop));
+        // First Esc: back to root
+        stack.handle_key(key(KeyCode::Esc));
+        assert_eq!(stack.depth(), 1);
+        assert_eq!(stack.breadcrumb(), vec!["Root"]);
+        // Second Esc: stack empty
+        stack.handle_key(key(KeyCode::Esc));
+        assert!(!stack.is_active());
+    }
+
+    #[test]
+    fn dismiss_clears_entire_stack() {
+        let mut stack = PopupStack::new();
+        stack.push(FakePopup::new("Root", &["x"], |_| PopupAction::Pop));
+        stack.push(FakePopup::new("Sub", &["y"], |_| PopupAction::Pop));
+        stack.apply(PopupAction::Dismiss);
+        assert!(!stack.is_active());
+    }
+
+    #[test]
+    fn set_query_forwards_to_top_only() {
+        let mut stack = PopupStack::new();
+        stack.push(FakePopup::new("Root", &["x"], |_| PopupAction::Pop));
+        stack.push(FakePopup::new("Sub", &["y"], |_| PopupAction::Pop));
+        stack.set_query("hello");
+
+        // Top-of-stack got the query.
+        let top = stack.top().unwrap();
+        assert_eq!(top.title(), "Sub");
+        // We can't read FakePopup.last_query through the trait, but we know
+        // only the top should ever be queried; this is enforced by api shape.
+        // Assertion-by-construction: just verify nothing panicked.
+        assert_eq!(stack.depth(), 2);
+    }
+
+    #[test]
+    fn handle_key_on_empty_stack_is_noop() {
+        let mut stack = PopupStack::new();
+        let result = stack.handle_key(key(KeyCode::Enter));
+        assert!(result.is_none());
+        assert!(!stack.is_active());
+    }
+}

--- a/crates/ui_terminal/src/slash_popup/model_picker.rs
+++ b/crates/ui_terminal/src/slash_popup/model_picker.rs
@@ -1,0 +1,179 @@
+//! Sub-popup that lets the user pick a model by name.
+//!
+//! Pushed by [`super::command_list::CommandListPopup`] when `/model` is
+//! activated without an inline argument. Models are read from the
+//! shared [`ConfigurationSystem`] at popup-construction time.
+
+use crate::commands::CommandResult;
+use crate::slash_popup::{PopupAction, PopupRow, SlashPopup};
+use llm::provider_config::ConfigurationSystem;
+
+pub struct ModelPickerPopup {
+    /// All model rows, before any future filtering.
+    all_rows: Vec<PopupRow>,
+    /// Currently visible rows.
+    visible_rows: Vec<PopupRow>,
+    /// Highlighted row in `visible_rows`.
+    selected: usize,
+}
+
+impl ModelPickerPopup {
+    pub fn new() -> Self {
+        let rows = build_rows_from_config();
+        Self::from_rows(rows)
+    }
+
+    /// Construction helper used by tests.
+    fn from_rows(rows: Vec<PopupRow>) -> Self {
+        Self {
+            all_rows: rows.clone(),
+            visible_rows: rows,
+            selected: 0,
+        }
+    }
+}
+
+impl Default for ModelPickerPopup {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn build_rows_from_config() -> Vec<PopupRow> {
+    let Ok(config) = ConfigurationSystem::load() else {
+        return Vec::new();
+    };
+    let mut names: Vec<String> = config.models.keys().cloned().collect();
+    names.sort();
+    names
+        .into_iter()
+        .map(|name| {
+            let description = config
+                .get_model_with_provider(&name)
+                .map(|(_, prov)| prov.label.clone())
+                .unwrap_or_default();
+            PopupRow {
+                label: name,
+                description,
+                has_submenu: false,
+            }
+        })
+        .collect()
+}
+
+impl SlashPopup for ModelPickerPopup {
+    fn title(&self) -> &str {
+        "Choose model"
+    }
+
+    fn set_query(&mut self, query: &str) {
+        // Sub-popups currently ignore composer-line query: the user navigates
+        // with arrow keys. We still honour the contract by re-applying a
+        // (case-insensitive) substring filter when a query is supplied via the
+        // future "type-to-filter inside popup" feature.
+        if query.is_empty() {
+            self.visible_rows = self.all_rows.clone();
+        } else {
+            let q = query.to_lowercase();
+            self.visible_rows = self
+                .all_rows
+                .iter()
+                .filter(|r| r.label.to_lowercase().contains(&q))
+                .cloned()
+                .collect();
+        }
+        if self.visible_rows.is_empty() {
+            self.selected = 0;
+        } else if self.selected >= self.visible_rows.len() {
+            self.selected = self.visible_rows.len() - 1;
+        }
+    }
+
+    fn rows(&self) -> &[PopupRow] {
+        &self.visible_rows
+    }
+
+    fn selected(&self) -> usize {
+        self.selected
+    }
+
+    fn move_selection(&mut self, delta: i32) {
+        let len = self.visible_rows.len() as i32;
+        if len == 0 {
+            return;
+        }
+        self.selected = (self.selected as i32 + delta).rem_euclid(len) as usize;
+    }
+
+    fn activate(&self) -> PopupAction {
+        match self.visible_rows.get(self.selected) {
+            Some(row) => PopupAction::Commit(CommandResult::SwitchModel(row.label.clone())),
+            None => PopupAction::Continue,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::slash_popup::PopupStack;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn fake_popup_with_models(models: &[&str]) -> ModelPickerPopup {
+        let rows = models
+            .iter()
+            .map(|m| PopupRow {
+                label: (*m).to_string(),
+                description: "fake provider".to_string(),
+                has_submenu: false,
+            })
+            .collect();
+        ModelPickerPopup::from_rows(rows)
+    }
+
+    #[test]
+    fn enter_commits_switch_model_with_selected_label() {
+        let mut stack = PopupStack::new();
+        stack.push(Box::new(fake_popup_with_models(&[
+            "Claude Sonnet 4.5",
+            "GPT-5",
+        ])));
+        stack.handle_key(key(KeyCode::Down)); // move to GPT-5
+        let result = stack.handle_key(key(KeyCode::Enter));
+        assert!(matches!(
+            result,
+            Some(CommandResult::SwitchModel(ref s)) if s == "GPT-5"
+        ));
+        assert!(!stack.is_active());
+    }
+
+    #[test]
+    fn esc_pops_one_level_back_to_root() {
+        let mut stack = PopupStack::new();
+        stack.push(Box::new(super::super::command_list::CommandListPopup::new()));
+        stack.push(Box::new(fake_popup_with_models(&["Claude Sonnet 4.5"])));
+        assert_eq!(stack.depth(), 2);
+        stack.handle_key(key(KeyCode::Esc));
+        assert_eq!(stack.depth(), 1);
+        assert_eq!(stack.top().unwrap().title(), "Slash commands");
+    }
+
+    #[test]
+    fn empty_model_list_does_not_panic_on_activate() {
+        let popup = fake_popup_with_models(&[]);
+        let action = popup.activate();
+        assert!(matches!(action, PopupAction::Continue));
+    }
+
+    #[test]
+    fn substring_filter_narrows_visible_rows() {
+        let mut popup = fake_popup_with_models(&["Claude Sonnet 4.5", "GPT-5", "Claude Haiku"]);
+        popup.set_query("claude");
+        let labels: Vec<&str> = popup.rows().iter().map(|r| r.label.as_str()).collect();
+        assert_eq!(labels, vec!["Claude Sonnet 4.5", "Claude Haiku"]);
+    }
+}

--- a/crates/ui_terminal/src/slash_popup/model_picker.rs
+++ b/crates/ui_terminal/src/slash_popup/model_picker.rs
@@ -67,10 +67,9 @@ impl SlashPopup for ModelPickerPopup {
     }
 
     fn set_query(&mut self, query: &str) {
-        // Sub-popups currently ignore composer-line query: the user navigates
-        // with arrow keys. We still honour the contract by re-applying a
-        // (case-insensitive) substring filter when a query is supplied via the
-        // future "type-to-filter inside popup" feature.
+        // While the popup is open the composer text becomes the popup query.
+        // Substring match (case-insensitive) so partial mid-string typos still
+        // surface results (e.g. "sonnet" finds "Claude Sonnet 4.5").
         if query.is_empty() {
             self.visible_rows = self.all_rows.clone();
         } else {
@@ -175,5 +174,22 @@ mod tests {
         popup.set_query("claude");
         let labels: Vec<&str> = popup.rows().iter().map(|r| r.label.as_str()).collect();
         assert_eq!(labels, vec!["Claude Sonnet 4.5", "Claude Haiku"]);
+    }
+
+    #[test]
+    fn substring_filter_is_case_insensitive() {
+        let mut popup = fake_popup_with_models(&["Claude Sonnet 4.5", "GPT-5"]);
+        popup.set_query("CLA");
+        let labels: Vec<&str> = popup.rows().iter().map(|r| r.label.as_str()).collect();
+        assert_eq!(labels, vec!["Claude Sonnet 4.5"]);
+    }
+
+    #[test]
+    fn substring_filter_matches_mid_string() {
+        // "sonnet" appears mid-string in "Claude Sonnet 4.5" — should still match.
+        let mut popup = fake_popup_with_models(&["Claude Sonnet 4.5", "GPT-5"]);
+        popup.set_query("sonnet");
+        let labels: Vec<&str> = popup.rows().iter().map(|r| r.label.as_str()).collect();
+        assert_eq!(labels, vec!["Claude Sonnet 4.5"]);
     }
 }

--- a/crates/ui_terminal/src/state.rs
+++ b/crates/ui_terminal/src/state.rs
@@ -1,3 +1,4 @@
+use crate::slash_popup::PopupStack;
 use code_assistant_core::persistence::ChatMetadata;
 use code_assistant_core::session::instance::SessionActivityState;
 use code_assistant_core::types::PlanState;
@@ -24,12 +25,8 @@ pub struct AppState {
     pub current_model: Option<String>,
     pub info_message: Option<String>,
     pub current_sandbox_policy: Option<SandboxPolicy>,
-    /// Whether the slash-command autocomplete popup is currently visible.
-    pub autocomplete_active: bool,
-    /// The text the user has typed after the leading `/` on the current line.
-    pub autocomplete_query: String,
-    /// Index of the currently highlighted entry in the filtered command list.
-    pub autocomplete_selected: usize,
+    /// Slash-command popup stack. Empty stack ↔ no popup visible.
+    pub popup_stack: PopupStack,
 }
 
 impl AppState {
@@ -48,9 +45,7 @@ impl AppState {
             current_model: None,
             info_message: None,
             current_sandbox_policy: None,
-            autocomplete_active: false,
-            autocomplete_query: String::new(),
-            autocomplete_selected: 0,
+            popup_stack: PopupStack::new(),
         }
     }
 
@@ -113,35 +108,5 @@ impl AppState {
 
     pub fn is_overlay_active(&self) -> bool {
         !matches!(self.overlay_state, OverlayState::None)
-    }
-
-    /// Open (or update) the autocomplete popup with a new query string.
-    ///
-    /// `query` is the text after the leading `/` on the current input line.
-    /// Calling this resets the selection to the first item.
-    pub fn open_autocomplete(&mut self, query: String) {
-        self.autocomplete_active = true;
-        self.autocomplete_query = query;
-        self.autocomplete_selected = 0;
-    }
-
-    /// Close the autocomplete popup and reset all related state.
-    pub fn close_autocomplete(&mut self) {
-        self.autocomplete_active = false;
-        self.autocomplete_query.clear();
-        self.autocomplete_selected = 0;
-    }
-
-    /// Move the selection by `delta` rows (positive = down, negative = up),
-    /// wrapping around within `[0, item_count)`.
-    ///
-    /// Does nothing when `item_count` is zero.
-    pub fn move_autocomplete_selection(&mut self, delta: i32, item_count: usize) {
-        if item_count == 0 {
-            return;
-        }
-        let current = self.autocomplete_selected as i32;
-        let next = (current + delta).rem_euclid(item_count as i32) as usize;
-        self.autocomplete_selected = next;
     }
 }

--- a/crates/ui_terminal/src/state.rs
+++ b/crates/ui_terminal/src/state.rs
@@ -24,6 +24,12 @@ pub struct AppState {
     pub current_model: Option<String>,
     pub info_message: Option<String>,
     pub current_sandbox_policy: Option<SandboxPolicy>,
+    /// Whether the slash-command autocomplete popup is currently visible.
+    pub autocomplete_active: bool,
+    /// The text the user has typed after the leading `/` on the current line.
+    pub autocomplete_query: String,
+    /// Index of the currently highlighted entry in the filtered command list.
+    pub autocomplete_selected: usize,
 }
 
 impl AppState {
@@ -42,6 +48,9 @@ impl AppState {
             current_model: None,
             info_message: None,
             current_sandbox_policy: None,
+            autocomplete_active: false,
+            autocomplete_query: String::new(),
+            autocomplete_selected: 0,
         }
     }
 
@@ -104,5 +113,35 @@ impl AppState {
 
     pub fn is_overlay_active(&self) -> bool {
         !matches!(self.overlay_state, OverlayState::None)
+    }
+
+    /// Open (or update) the autocomplete popup with a new query string.
+    ///
+    /// `query` is the text after the leading `/` on the current input line.
+    /// Calling this resets the selection to the first item.
+    pub fn open_autocomplete(&mut self, query: String) {
+        self.autocomplete_active = true;
+        self.autocomplete_query = query;
+        self.autocomplete_selected = 0;
+    }
+
+    /// Close the autocomplete popup and reset all related state.
+    pub fn close_autocomplete(&mut self) {
+        self.autocomplete_active = false;
+        self.autocomplete_query.clear();
+        self.autocomplete_selected = 0;
+    }
+
+    /// Move the selection by `delta` rows (positive = down, negative = up),
+    /// wrapping around within `[0, item_count)`.
+    ///
+    /// Does nothing when `item_count` is zero.
+    pub fn move_autocomplete_selection(&mut self, delta: i32, item_count: usize) {
+        if item_count == 0 {
+            return;
+        }
+        let current = self.autocomplete_selected as i32;
+        let next = (current + delta).rem_euclid(item_count as i32) as usize;
+        self.autocomplete_selected = next;
     }
 }

--- a/crates/ui_terminal/src/textarea.rs
+++ b/crates/ui_terminal/src/textarea.rs
@@ -181,6 +181,20 @@ impl TextArea {
         Some((area.x + col, area.y + i as u16))
     }
 
+    /// Returns the text of the logical line the cursor is currently on.
+    ///
+    /// A "logical line" is the text between two `\n` characters (or the start/end
+    /// of the buffer).  This is the unprocessed content before word-wrap is applied,
+    /// so it may be longer than a single rendered row on screen.
+    ///
+    /// Used by the slash-command autocomplete to check whether the user is typing
+    /// a `/` command without having to re-parse the full textarea text.
+    pub fn current_line(&self) -> &str {
+        let bol = self.beginning_of_current_line();
+        let eol = self.end_of_current_line();
+        &self.text[bol..eol]
+    }
+
     pub fn input(&mut self, event: KeyEvent) {
         match event {
             // C0 control character fallbacks (terminals that don't report CONTROL modifier)
@@ -1138,5 +1152,35 @@ mod tests {
         ta.clear();
         assert_eq!(ta.elements.len(), 0);
         assert_eq!(ta.text(), "");
+    }
+
+    #[test]
+    fn test_current_line_single_line() {
+        let mut ta = TextArea::new();
+        ta.insert_str("hello world");
+        assert_eq!(ta.current_line(), "hello world");
+    }
+
+    #[test]
+    fn test_current_line_multiline_first() {
+        let mut ta = TextArea::new();
+        ta.insert_str("first\nsecond\nthird");
+        // Move cursor to the beginning of the first line
+        ta.set_cursor(0);
+        assert_eq!(ta.current_line(), "first");
+    }
+
+    #[test]
+    fn test_current_line_multiline_last() {
+        let mut ta = TextArea::new();
+        ta.insert_str("first\nsecond\nthird");
+        // Cursor is at the end (after "third")
+        assert_eq!(ta.current_line(), "third");
+    }
+
+    #[test]
+    fn test_current_line_empty() {
+        let ta = TextArea::new();
+        assert_eq!(ta.current_line(), "");
     }
 }


### PR DESCRIPTION
Consolidates @yamaceay's stacked draft PRs #131, #132, #133, #134, #135 onto the new crate layout, then turns the autocomplete UI into a stacked-popup system (Codex-inspired).

### Yamac's commits (preserved verbatim)

- SlashCommand registry (#131)
- `/clear` and `/compact` (#132)
- `TextArea::current_line()` (#133)
- Autocomplete state and input wiring (#134)
- Autocomplete popup rendering (#135)

His "GPUI as optional feature" commit was dropped — already covered by the recent feature gating.

### Follow-up commits on top

- **fix**: Yamac's popup positioned itself at `input_area.y - popup_height`, assuming a full-screen frame. The new inline TUI's frame buffer covers only the active viewport rows, so this panicked the moment the user typed `/`. Moved the popup into the layout and grew `desired_viewport_height` accordingly.
- **feat**: New `slash_popup` module with `SlashPopup` trait, `PopupAction` (Continue/Push/Pop/Commit/Dismiss), `PopupStack`, and two concrete popups: `CommandListPopup` (root) and `ModelPickerPopup` (sub).
- **refactor**: Wired the framework into state/input/app/renderer. `AppState.popup_stack` replaces the flat `autocomplete_*` fields. The renderer paints a breadcrumb header, `›` markers on rows that open sub-popups, and a context-sensitive footer hint.
- **feat**: When a sub-popup is pushed, the composer is cleared so the user can type a fresh substring filter (e.g. `/mo<Enter>` then `son` → `Claude Sonnet 4.5`).

### Resulting UX

- `/` opens root popup; type to filter; arrow keys navigate.
- Enter runs the command, or opens a sub-popup (`/model`).
- In a sub-popup the composer is the substring filter; Esc goes back one level, second Esc dismisses entirely (and deletes the leading `/`).

128 tests pass in `ui_terminal` (100 preexisting + 28 new).

Closes #131, #132, #133, #134, #135.
