### PR TITLE
Permission tiers: gate tool execution on a per-session setting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,16 @@ headless binary without gpui.
 - Supports terminal, Agent Client Protocol, and GPUI interfaces
 - State persistence for continuing sessions
 
+### Permission Tiers
+- Per-session setting deciding when the agent asks before running a tool:
+  `bypass-all` (default, never ask), `write-tools` (ask for anything not
+  tagged `read_only`), `all-tools` (ask always); see `docs/permission-tiers.md`
+- Gate lives in the agent loop (`tools_core::ToolPermissions`); prompts
+  travel through the `PermissionMediator` seam — event-stream mediator for
+  GPUI/terminal (`SessionService::respond_permission`), ACP's native
+  `requestPermission` otherwise; tiers are exposed to ACP clients as
+  session modes
+
 ## Development Notes
 
 ### Testing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10577,6 +10577,7 @@ dependencies = [
  "similar",
  "textwrap",
  "tokio",
+ "tools_core",
  "tracing",
  "tui-markdown",
  "unicode-segmentation",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10547,6 +10547,7 @@ dependencies = [
  "terminal",
  "terminal_view",
  "tokio",
+ "tools_core",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10192,6 +10192,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/agent_core/src/runtime.rs
+++ b/crates/agent_core/src/runtime.rs
@@ -732,6 +732,7 @@ impl AgentRuntime {
     /// Compared to the sequential path, interceptors do not run, the plan is
     /// unavailable, and input modifications are not propagated back into the
     /// message history.
+    #[allow(clippy::too_many_arguments)]
     async fn execute_tool_request_detached(
         tool_request: ToolRequest,
         ui: Arc<dyn AgentUi>,

--- a/crates/agent_core/src/runtime.rs
+++ b/crates/agent_core/src/runtime.rs
@@ -17,7 +17,9 @@ use std::any::Any;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
-use tools_core::{PermissionMediator, ResourcesTracker, ToolContext, ToolError, ToolRegistry};
+use tools_core::{
+    PermissionMediator, ResourcesTracker, ToolContext, ToolError, ToolPermissions, ToolRegistry,
+};
 use tracing::{debug, trace, warn};
 
 /// Everything an [`AgentRuntime`] is built from.
@@ -34,6 +36,9 @@ pub struct AgentRuntimeComponents {
     pub stream_hidden_tools: HiddenTools,
     pub command_executor: Arc<dyn CommandExecutor>,
     pub permission_handler: Option<Arc<dyn PermissionMediator>>,
+    /// The active permission tier plus session-scoped grants; the loop gates
+    /// every tool invocation on it before dispatching.
+    pub permissions: ToolPermissions,
     /// Builds the application services handed to each tool invocation.
     pub services_provider: Arc<dyn ToolServicesProvider>,
     pub state_persistence: Box<dyn SnapshotPersistence>,
@@ -69,6 +74,7 @@ pub struct AgentRuntime {
     services_provider: Arc<dyn ToolServicesProvider>,
 
     permission_handler: Option<Arc<dyn PermissionMediator>>,
+    permissions: ToolPermissions,
 
     // ========================================================================
     // Branching: Tree-based message storage
@@ -128,6 +134,7 @@ impl AgentRuntime {
             stream_hidden_tools,
             command_executor,
             permission_handler,
+            permissions,
             services_provider,
             state_persistence,
             hooks,
@@ -147,6 +154,7 @@ impl AgentRuntime {
             state_persistence,
             services_provider,
             permission_handler,
+            permissions,
             // Branching tree structure
             message_nodes: BTreeMap::new(),
             active_path: Vec::new(),
@@ -669,6 +677,7 @@ impl AgentRuntime {
                 let registry = self.registry.clone();
                 let command_executor = self.command_executor.clone();
                 let permission_handler = self.permission_handler.clone();
+                let permissions = self.permissions.clone();
                 let services_provider = self.services_provider.clone();
                 let scope_tag = self.tool_capability.clone();
 
@@ -681,6 +690,7 @@ impl AgentRuntime {
                         registry,
                         command_executor,
                         permission_handler,
+                        permissions,
                         services_provider,
                         scope_tag,
                     )
@@ -728,6 +738,7 @@ impl AgentRuntime {
         registry: Arc<ToolRegistry>,
         command_executor: Arc<dyn CommandExecutor>,
         permission_handler: Option<Arc<dyn PermissionMediator>>,
+        permissions: ToolPermissions,
         services_provider: Arc<dyn ToolServicesProvider>,
         scope_tag: String,
     ) -> (bool, ToolExecution) {
@@ -758,15 +769,29 @@ impl AgentRuntime {
                 ))
             }
             Some(tool) => {
-                let mut services = services_provider.detached(&tool_request.id);
-                let mut context = ToolContext {
-                    command_executor: command_executor.as_ref(),
-                    tool_id: Some(tool_request.id.clone()),
-                    permission_handler: permission_handler.as_deref(),
-                    extensions: Some(services.as_mut()),
-                };
-                let mut input = tool_request.input.clone();
-                tool.invoke(&mut context, &mut input).await
+                // Tier-based permission gate, mirroring the sequential path.
+                match permissions
+                    .check(
+                        permission_handler.as_deref(),
+                        &tool.spec(),
+                        Some(&tool_request.id),
+                        &tool_request.input,
+                    )
+                    .await
+                {
+                    Err(e) => Err(e),
+                    Ok(()) => {
+                        let mut services = services_provider.detached(&tool_request.id);
+                        let mut context = ToolContext {
+                            command_executor: command_executor.as_ref(),
+                            tool_id: Some(tool_request.id.clone()),
+                            permission_handler: permission_handler.as_deref(),
+                            extensions: Some(services.as_mut()),
+                        };
+                        let mut input = tool_request.input.clone();
+                        tool.invoke(&mut context, &mut input).await
+                    }
+                }
             }
         };
 
@@ -1838,6 +1863,37 @@ impl AgentRuntime {
                 "Tool '{}' is not available in the current scope",
                 tool_request.name
             ));
+        }
+
+        // Tier-based permission gate: ask the user before dispatching when
+        // the active tier requires it for this tool.
+        if let Err(e) = self
+            .permissions
+            .check(
+                self.permission_handler.as_deref(),
+                &tool.spec(),
+                Some(&tool_request.id),
+                &tool_request.input,
+            )
+            .await
+        {
+            let error_text = Self::format_error_for_user(&e);
+            if !is_hidden {
+                self.send_ui(AgentUiEvent::UpdateToolStatus {
+                    tool_id: tool_request.id.clone(),
+                    status: crate::ui::ToolStatus::Error,
+                    message: Some(error_text.clone()),
+                    output: Some(error_text.clone()),
+                    duration_seconds: None,
+                    images: vec![],
+                })
+                .await?;
+            }
+            self.tool_executions.push(ToolExecution::create_parse_error(
+                tool_request.id.clone(),
+                error_text,
+            ));
+            return Err(e);
         }
 
         // Create a tool context. The services provider builds the application

--- a/crates/code_assistant_core/src/agent/runner.rs
+++ b/crates/code_assistant_core/src/agent/runner.rs
@@ -16,7 +16,7 @@ use anyhow::Result;
 use command_executor::CommandExecutor;
 use llm::{LLMProvider, Message};
 use std::sync::{Arc, Mutex};
-use tools_core::permissions::PermissionMediator;
+use tools_core::permissions::{PermissionMediator, ToolPermissions};
 use tracing::debug;
 
 /// Runtime components required to construct an `Agent`.
@@ -27,6 +27,8 @@ pub struct AgentComponents {
     pub ui: Arc<dyn UserInterface>,
     pub state_persistence: Box<dyn AgentStatePersistence>,
     pub permission_handler: Option<Arc<dyn PermissionMediator>>,
+    /// Active permission tier plus session-scoped grants gating tool calls.
+    pub permissions: ToolPermissions,
 
     /// The tool registry the agent selects and executes tools from.
     pub tool_registry: Arc<crate::tools::core::ToolRegistry>,
@@ -57,6 +59,7 @@ impl Agent {
             ui,
             state_persistence,
             permission_handler,
+            permissions,
             tool_registry,
             sub_agent_runner,
             hooks_factory,
@@ -81,6 +84,7 @@ impl Agent {
             tool_capability,
             command_executor,
             permission_handler,
+            permissions,
             services_provider,
             state_persistence: Box::new(SessionStateAdapter::new(state_persistence)),
             hooks: hooks_factory

--- a/crates/code_assistant_core/src/agent/sub_agent.rs
+++ b/crates/code_assistant_core/src/agent/sub_agent.rs
@@ -11,7 +11,7 @@ use llm::Message;
 use sandbox::{SandboxContext, SandboxPolicy};
 use std::collections::HashMap;
 use std::sync::{atomic::AtomicBool, atomic::Ordering, Arc, Mutex};
-use tools_core::permissions::PermissionMediator;
+use tools_core::permissions::{PermissionMediator, ToolPermissions};
 
 /// Cancellation registry keyed by the parent `spawn_agent` tool id.
 #[derive(Default)]
@@ -133,6 +133,8 @@ pub struct DefaultSubAgentRunner {
     ui: Arc<dyn UserInterface>,
     /// Optional permission handler for sub-agent tool invocations.
     permission_handler: Option<Arc<dyn PermissionMediator>>,
+    /// Permission tier and grants shared with the parent session.
+    permissions: ToolPermissions,
     /// The tool registry sub-agents run with (shared with the parent agent).
     tool_registry: Arc<crate::tools::core::ToolRegistry>,
     /// Hook factory sub-agents run with (shared with the parent agent);
@@ -149,6 +151,7 @@ impl DefaultSubAgentRunner {
         cancellation_registry: Arc<SubAgentCancellationRegistry>,
         ui: Arc<dyn UserInterface>,
         permission_handler: Option<Arc<dyn PermissionMediator>>,
+        permissions: ToolPermissions,
         tool_registry: Arc<crate::tools::core::ToolRegistry>,
         hooks_factory: Option<agent_core::hooks::HookRegistryFactory>,
     ) -> Self {
@@ -161,6 +164,7 @@ impl DefaultSubAgentRunner {
             cancellation_registry,
             ui,
             permission_handler,
+            permissions,
             tool_registry,
             hooks_factory,
         }
@@ -218,6 +222,7 @@ impl DefaultSubAgentRunner {
             ui,
             state_persistence: Box::new(NoOpStatePersistence),
             permission_handler,
+            permissions: self.permissions.clone(),
             tool_registry: self.tool_registry.clone(),
             sub_agent_runner: None,
             hooks_factory: self.hooks_factory.clone(),

--- a/crates/code_assistant_core/src/agent/tests.rs
+++ b/crates/code_assistant_core/src/agent/tests.rs
@@ -51,6 +51,7 @@ async fn test_unknown_tool_error_handling() -> Result<()> {
         ui: Arc::new(MockUI::default()),
         state_persistence: Box::new(MockStatePersistence::new()),
         permission_handler: None,
+        permissions: Default::default(),
         tool_registry: crate::tools::test_registry(),
         sub_agent_runner: None,
         hooks_factory: None,
@@ -176,6 +177,7 @@ async fn test_invalid_xml_tool_error_handling() -> Result<()> {
         ui: Arc::new(MockUI::default()),
         state_persistence: Box::new(MockStatePersistence::new()),
         permission_handler: None,
+        permissions: Default::default(),
         tool_registry: crate::tools::test_registry(),
         sub_agent_runner: None,
         hooks_factory: None,
@@ -305,6 +307,7 @@ async fn test_parse_error_handling() -> Result<()> {
         ui: Arc::new(MockUI::default()),
         state_persistence: Box::new(MockStatePersistence::new()),
         permission_handler: None,
+        permissions: Default::default(),
         tool_registry: crate::tools::test_registry(),
         sub_agent_runner: None,
         hooks_factory: None,
@@ -447,6 +450,7 @@ async fn test_write_file_outside_root_error_masks_paths() -> Result<()> {
         ui: Arc::new(MockUI::default()),
         state_persistence: Box::new(MockStatePersistence::new()),
         permission_handler: None,
+        permissions: Default::default(),
         tool_registry: crate::tools::test_registry(),
         sub_agent_runner: None,
         hooks_factory: None,
@@ -551,6 +555,7 @@ async fn test_context_compaction_inserts_summary() -> Result<()> {
         ui: ui.clone(),
         state_persistence: Box::new(MockStatePersistence::new()),
         permission_handler: None,
+        permissions: Default::default(),
         tool_registry: crate::tools::test_registry(),
         sub_agent_runner: None,
         hooks_factory: None,
@@ -707,6 +712,7 @@ async fn test_compaction_reminds_about_active_skills() -> Result<()> {
         ui: ui.clone(),
         state_persistence: Box::new(MockStatePersistence::new()),
         permission_handler: None,
+        permissions: Default::default(),
         tool_registry: crate::tools::test_registry(),
         sub_agent_runner: None,
         hooks_factory: None,
@@ -795,6 +801,7 @@ async fn test_compaction_prompt_not_persisted_in_history() -> Result<()> {
         ui: ui.clone(),
         state_persistence: Box::new(MockStatePersistence::new()),
         permission_handler: None,
+        permissions: Default::default(),
         tool_registry: crate::tools::test_registry(),
         sub_agent_runner: None,
         hooks_factory: None,
@@ -925,6 +932,7 @@ async fn test_context_compaction_uses_only_messages_after_previous_summary() -> 
         ui: ui.clone(),
         state_persistence: Box::new(MockStatePersistence::new()),
         permission_handler: None,
+        permissions: Default::default(),
         tool_registry: crate::tools::test_registry(),
         sub_agent_runner: None,
         hooks_factory: None,
@@ -1132,6 +1140,7 @@ fn test_inject_naming_reminder_skips_tool_result_messages() -> Result<()> {
         ui,
         state_persistence,
         permission_handler: None,
+        permissions: Default::default(),
         tool_registry: crate::tools::test_registry(),
         sub_agent_runner: None,
         hooks_factory: None,
@@ -1500,6 +1509,7 @@ async fn test_load_normalizes_native_dangling_tool_request() -> Result<()> {
         ui: Arc::new(MockUI::default()),
         state_persistence: Box::new(MockStatePersistence::new()),
         permission_handler: None,
+        permissions: Default::default(),
         tool_registry: crate::tools::test_registry(),
         sub_agent_runner: None,
         hooks_factory: None,
@@ -1553,6 +1563,7 @@ async fn test_load_normalizes_native_dangling_tool_request_with_followup_user() 
         ui: Arc::new(MockUI::default()),
         state_persistence: Box::new(MockStatePersistence::new()),
         permission_handler: None,
+        permissions: Default::default(),
         tool_registry: crate::tools::test_registry(),
         sub_agent_runner: None,
         hooks_factory: None,
@@ -1620,6 +1631,7 @@ async fn test_load_normalizes_xml_dangling_tool_request() -> Result<()> {
         ui: Arc::new(MockUI::default()),
         state_persistence: Box::new(MockStatePersistence::new()),
         permission_handler: None,
+        permissions: Default::default(),
         tool_registry: crate::tools::test_registry(),
         sub_agent_runner: None,
         hooks_factory: None,
@@ -1671,6 +1683,7 @@ async fn test_load_keeps_assistant_messages_without_tool_requests() -> Result<()
         ui: Arc::new(MockUI::default()),
         state_persistence: Box::new(MockStatePersistence::new()),
         permission_handler: None,
+        permissions: Default::default(),
         tool_registry: crate::tools::test_registry(),
         sub_agent_runner: None,
         hooks_factory: None,
@@ -1726,6 +1739,7 @@ async fn test_render_tool_results_generates_cancelled_results_for_missing_execut
         ui: Arc::new(MockUI::default()),
         state_persistence: Box::new(MockStatePersistence::new()),
         permission_handler: None,
+        permissions: Default::default(),
         tool_registry: crate::tools::test_registry(),
         sub_agent_runner: None,
         hooks_factory: None,
@@ -1831,6 +1845,7 @@ async fn test_render_tool_results_preserves_existing_tool_results() -> Result<()
         ui: Arc::new(MockUI::default()),
         state_persistence: Box::new(MockStatePersistence::new()),
         permission_handler: None,
+        permissions: Default::default(),
         tool_registry: crate::tools::test_registry(),
         sub_agent_runner: None,
         hooks_factory: None,
@@ -1917,6 +1932,7 @@ async fn test_render_tool_results_handles_multiple_cancelled_tools() -> Result<(
         ui: Arc::new(MockUI::default()),
         state_persistence: Box::new(MockStatePersistence::new()),
         permission_handler: None,
+        permissions: Default::default(),
         tool_registry: crate::tools::test_registry(),
         sub_agent_runner: None,
         hooks_factory: None,
@@ -2073,6 +2089,7 @@ async fn test_prompt_too_long_replaces_large_tool_results() -> Result<()> {
         ui: ui.clone(),
         state_persistence: Box::new(MockStatePersistence::new()),
         permission_handler: None,
+        permissions: Default::default(),
         tool_registry: crate::tools::test_registry(),
         sub_agent_runner: None,
         hooks_factory: None,
@@ -2203,6 +2220,7 @@ async fn test_prompt_too_long_fallback_drops_exchange_and_compacts() -> Result<(
         ui: ui.clone(),
         state_persistence: Box::new(MockStatePersistence::new()),
         permission_handler: None,
+        permissions: Default::default(),
         tool_registry: crate::tools::test_registry(),
         sub_agent_runner: None,
         hooks_factory: None,
@@ -2285,6 +2303,205 @@ async fn test_prompt_too_long_fallback_drops_exchange_and_compacts() -> Result<(
         has_compaction,
         "Expected compaction divider in UI streaming output"
     );
+
+    Ok(())
+}
+
+// ============================================================================
+// Permission tier gating
+// ============================================================================
+
+/// Mediator returning a fixed decision and counting how often it is asked.
+struct ScriptedPermissionMediator {
+    decision: tools_core::PermissionDecision,
+    calls: std::sync::atomic::AtomicUsize,
+}
+
+impl ScriptedPermissionMediator {
+    fn new(decision: tools_core::PermissionDecision) -> Self {
+        Self {
+            decision,
+            calls: std::sync::atomic::AtomicUsize::new(0),
+        }
+    }
+
+    fn call_count(&self) -> usize {
+        self.calls.load(std::sync::atomic::Ordering::Relaxed)
+    }
+}
+
+#[async_trait::async_trait]
+impl tools_core::PermissionMediator for ScriptedPermissionMediator {
+    async fn request_permission(
+        &self,
+        _request: tools_core::PermissionRequest<'_>,
+    ) -> Result<tools_core::PermissionDecision> {
+        self.calls
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        Ok(self.decision)
+    }
+}
+
+fn permission_test_session_config() -> SessionConfig {
+    SessionConfig {
+        init_path: Some(PathBuf::from("./test_path")),
+        initial_project: String::new(),
+        tool_syntax: ToolSyntax::Native,
+        use_diff_blocks: false,
+        sandbox_policy: SandboxPolicy::DangerFullAccess,
+        ..SessionConfig::default()
+    }
+}
+
+#[tokio::test]
+async fn test_write_tier_denied_tool_reports_error_to_llm() -> Result<()> {
+    let mock_llm = MockLLMProvider::new(vec![
+        Ok(create_test_response_text("Understood, stopping.")),
+        Ok(create_test_response(
+            "del-1",
+            "delete_files",
+            serde_json::json!({
+                "project": "test",
+                "paths": ["a.txt"]
+            }),
+            "Deleting a file",
+        )),
+    ]);
+    let mock_llm_ref = mock_llm.clone();
+    let mediator = Arc::new(ScriptedPermissionMediator::new(
+        tools_core::PermissionDecision::Denied,
+    ));
+
+    let components = AgentComponents {
+        llm_provider: Box::new(mock_llm),
+        project_manager: Arc::new(MockProjectManager::new()),
+        command_executor: Arc::new(create_command_executor_mock()),
+        ui: Arc::new(MockUI::default()),
+        state_persistence: Box::new(MockStatePersistence::new()),
+        permission_handler: Some(mediator.clone()),
+        permissions: tools_core::ToolPermissions::new(tools_core::PermissionTier::WriteTools),
+        tool_registry: crate::tools::test_registry(),
+        sub_agent_runner: None,
+        hooks_factory: None,
+    };
+
+    let mut agent = Agent::new(components, permission_test_session_config());
+    agent.disable_naming_reminders();
+    agent.start_with_task("Test task".to_string()).await?;
+
+    assert_eq!(mediator.call_count(), 1);
+
+    // The denial must be reported to the LLM as an error tool result.
+    let requests = mock_llm_ref.get_requests();
+    assert_eq!(requests.len(), 2);
+    let followup = &requests[1];
+    let last_message = followup.messages.last().unwrap();
+    let MessageContent::Structured(blocks) = &last_message.content else {
+        panic!("Expected structured content in follow-up message");
+    };
+    let ContentBlock::ToolResult {
+        tool_use_id,
+        content,
+        is_error,
+        ..
+    } = &blocks[0]
+    else {
+        panic!("Expected ToolResult block");
+    };
+    assert_eq!(tool_use_id, "del-1");
+    assert!(is_error.unwrap_or(false));
+    assert!(content.contains("denied permission"));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_write_tier_does_not_ask_for_read_only_tools() -> Result<()> {
+    let mock_llm = MockLLMProvider::new(vec![
+        Ok(create_test_response_text("Done.")),
+        Ok(create_test_response(
+            "read-1",
+            "read_files",
+            serde_json::json!({
+                "project": "test",
+                "paths": ["test.txt"]
+            }),
+            "Reading a file",
+        )),
+    ]);
+    let mediator = Arc::new(ScriptedPermissionMediator::new(
+        tools_core::PermissionDecision::Denied,
+    ));
+
+    let components = AgentComponents {
+        llm_provider: Box::new(mock_llm),
+        project_manager: Arc::new(MockProjectManager::new()),
+        command_executor: Arc::new(create_command_executor_mock()),
+        ui: Arc::new(MockUI::default()),
+        state_persistence: Box::new(MockStatePersistence::new()),
+        permission_handler: Some(mediator.clone()),
+        permissions: tools_core::ToolPermissions::new(tools_core::PermissionTier::WriteTools),
+        tool_registry: crate::tools::test_registry(),
+        sub_agent_runner: None,
+        hooks_factory: None,
+    };
+
+    let mut agent = Agent::new(components, permission_test_session_config());
+    agent.disable_naming_reminders();
+    agent.start_with_task("Test task".to_string()).await?;
+
+    // read_files is tagged read_only; the mediator must not be consulted.
+    assert_eq!(mediator.call_count(), 0);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_granted_session_asks_only_once_per_tool() -> Result<()> {
+    let mock_llm = MockLLMProvider::new(vec![
+        Ok(create_test_response_text("Done.")),
+        Ok(create_test_response(
+            "del-2",
+            "delete_files",
+            serde_json::json!({
+                "project": "test",
+                "paths": ["b.txt"]
+            }),
+            "Deleting another file",
+        )),
+        Ok(create_test_response(
+            "del-1",
+            "delete_files",
+            serde_json::json!({
+                "project": "test",
+                "paths": ["a.txt"]
+            }),
+            "Deleting a file",
+        )),
+    ]);
+    let mediator = Arc::new(ScriptedPermissionMediator::new(
+        tools_core::PermissionDecision::GrantedSession,
+    ));
+
+    let components = AgentComponents {
+        llm_provider: Box::new(mock_llm),
+        project_manager: Arc::new(MockProjectManager::new()),
+        command_executor: Arc::new(create_command_executor_mock()),
+        ui: Arc::new(MockUI::default()),
+        state_persistence: Box::new(MockStatePersistence::new()),
+        permission_handler: Some(mediator.clone()),
+        permissions: tools_core::ToolPermissions::new(tools_core::PermissionTier::AllTools),
+        tool_registry: crate::tools::test_registry(),
+        sub_agent_runner: None,
+        hooks_factory: None,
+    };
+
+    let mut agent = Agent::new(components, permission_test_session_config());
+    agent.disable_naming_reminders();
+    agent.start_with_task("Test task".to_string()).await?;
+
+    // The session grant from the first call covers the second call.
+    assert_eq!(mediator.call_count(), 1);
 
     Ok(())
 }

--- a/crates/code_assistant_core/src/session/instance.rs
+++ b/crates/code_assistant_core/src/session/instance.rs
@@ -175,6 +175,13 @@ pub struct SessionInstance {
     /// Tracks sandbox-approved roots for this session
     pub sandbox_context: Arc<SandboxContext>,
 
+    /// Tools the user granted "for this session" via the permission tier
+    /// gate. Shared with running agents; survives across agent runs.
+    pub permissions: tools_core::ToolPermissions,
+
+    /// Permission requests currently awaiting a user decision.
+    pub pending_permission_requests: Arc<crate::session::permissions::PendingPermissionRequests>,
+
     /// Cancellation registry for sub-agents running in agent tasks
     pub sub_agent_cancellation_registry: Arc<SubAgentCancellationRegistry>,
 
@@ -224,6 +231,10 @@ impl SessionInstance {
             stop_requested: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             pending_message: Arc::new(Mutex::new(None)),
             sandbox_context,
+            permissions: tools_core::ToolPermissions::default(),
+            pending_permission_requests: Arc::new(
+                crate::session::permissions::PendingPermissionRequests::default(),
+            ),
             sub_agent_cancellation_registry: Arc::new(SubAgentCancellationRegistry::default()),
             agent_lock: None,
             last_ui_synced_path: initial_path,
@@ -239,19 +250,24 @@ impl SessionInstance {
     }
 
     /// Ask the running agent to stop at its next streaming checkpoint.
+    /// Pending permission requests resolve as denied so the agent does not
+    /// stay blocked waiting for an answer.
     pub fn request_stop(&self) {
         self.stop_requested
             .store(true, std::sync::atomic::Ordering::Relaxed);
+        self.pending_permission_requests.deny_all();
     }
 
     /// Reset per-run state when a new agent starts: clears a previous stop
-    /// request and the live tool-status map of the prior run.
+    /// request, the live tool-status map of the prior run, and any stale
+    /// permission requests.
     pub fn begin_agent_run(&self) {
         self.stop_requested
             .store(false, std::sync::atomic::Ordering::Relaxed);
         if let Ok(mut buf) = self.tool_status_buffer.lock() {
             buf.clear();
         }
+        self.pending_permission_requests.deny_all();
     }
 
     /// Get the current activity state
@@ -475,6 +491,8 @@ impl SessionInstance {
             current_model: String::new(),
             allowed_models: Vec::new(),
             sandbox_policy: self.session.config.sandbox_policy.clone(),
+            permission_tier: self.session.config.permission_tier,
+            pending_permission_requests: self.pending_permission_requests.snapshot(),
         })
     }
 

--- a/crates/code_assistant_core/src/session/manager.rs
+++ b/crates/code_assistant_core/src/session/manager.rs
@@ -19,7 +19,7 @@ use crate::utils::file_utils;
 use command_executor::{CommandExecutor, SandboxedCommandExecutor};
 use llm::LLMProvider;
 use sandbox::SandboxPolicy;
-use tools_core::permissions::{PermissionMediator, ToolPermissions};
+use tools_core::permissions::PermissionMediator;
 use tracing::{debug, error, info, warn};
 
 /// Result of checking whether a session may switch to another model.

--- a/crates/code_assistant_core/src/session/manager.rs
+++ b/crates/code_assistant_core/src/session/manager.rs
@@ -779,8 +779,18 @@ impl SessionManager {
             .map(|c| c.model_name.clone())
             .unwrap_or_else(|| self.default_model_name.clone());
         // Permission tier and session-scoped grants, shared between the
-        // agent and its sub-agents.
-        let permissions = ToolPermissions::default();
+        // agent and its sub-agents. The grants live on the session instance
+        // so "always allow" answers survive across agent runs; the tier
+        // always follows the (possibly reloaded) session config.
+        let permissions = {
+            let mut permissions = self
+                .active_sessions
+                .get(session_id)
+                .map(|instance| instance.permissions.clone())
+                .unwrap_or_default();
+            permissions.tier = session_config.permission_tier;
+            permissions
+        };
 
         let sub_agent_runner: Arc<dyn crate::agent::SubAgentRunner> =
             Arc::new(DefaultSubAgentRunner::new(
@@ -1203,6 +1213,63 @@ impl SessionManager {
         }
 
         Ok(())
+    }
+
+    /// Set the permission tier for a session. Takes effect on the next
+    /// agent run; session-scoped grants are kept.
+    pub fn set_session_permission_tier(
+        &mut self,
+        session_id: &str,
+        tier: tools_core::PermissionTier,
+    ) -> Result<()> {
+        let mut session = self
+            .persistence
+            .load_chat_session(session_id)?
+            .ok_or_else(|| anyhow::anyhow!("Session not found: {session_id}"))?;
+
+        session.config.permission_tier = tier;
+        self.persistence.save_chat_session(&session)?;
+
+        if let Some(instance) = self.active_sessions.get_mut(session_id) {
+            instance.session.config.permission_tier = tier;
+            instance.permissions.tier = tier;
+        }
+
+        Ok(())
+    }
+
+    /// Build the event-stream permission mediator for a session, used by the
+    /// `SessionService`-driven frontends (GPUI, terminal). ACP supplies its
+    /// own protocol-level mediator instead.
+    pub fn permission_mediator(&self, session_id: &str) -> Result<Arc<dyn PermissionMediator>> {
+        let instance = self
+            .active_sessions
+            .get(session_id)
+            .ok_or_else(|| anyhow::anyhow!("Session not found: {session_id}"))?;
+        Ok(Arc::new(
+            crate::session::permissions::SessionPermissionMediator::new(
+                session_id.to_string(),
+                self.events.clone(),
+                instance.pending_permission_requests.clone(),
+            ),
+        ))
+    }
+
+    /// Feed a user's decision back to a pending permission request.
+    /// Returns false when the request is unknown (already settled).
+    pub fn resolve_permission_request(
+        &self,
+        session_id: &str,
+        request_id: &str,
+        decision: tools_core::PermissionDecision,
+    ) -> Result<bool> {
+        let instance = self
+            .active_sessions
+            .get(session_id)
+            .ok_or_else(|| anyhow::anyhow!("Session not found: {session_id}"))?;
+        Ok(instance
+            .pending_permission_requests
+            .resolve(request_id, decision))
     }
 
     /// Set the worktree path and branch for a session.

--- a/crates/code_assistant_core/src/session/manager.rs
+++ b/crates/code_assistant_core/src/session/manager.rs
@@ -19,7 +19,7 @@ use crate::utils::file_utils;
 use command_executor::{CommandExecutor, SandboxedCommandExecutor};
 use llm::LLMProvider;
 use sandbox::SandboxPolicy;
-use tools_core::permissions::PermissionMediator;
+use tools_core::permissions::{PermissionMediator, ToolPermissions};
 use tracing::{debug, error, info, warn};
 
 /// Result of checking whether a session may switch to another model.
@@ -778,6 +778,10 @@ impl SessionManager {
             .as_ref()
             .map(|c| c.model_name.clone())
             .unwrap_or_else(|| self.default_model_name.clone());
+        // Permission tier and session-scoped grants, shared between the
+        // agent and its sub-agents.
+        let permissions = ToolPermissions::default();
+
         let sub_agent_runner: Arc<dyn crate::agent::SubAgentRunner> =
             Arc::new(DefaultSubAgentRunner::new(
                 model_name_for_subagent,
@@ -786,6 +790,7 @@ impl SessionManager {
                 sub_agent_cancellation_registry.clone(),
                 publisher.clone(),
                 permission_handler.clone(),
+                permissions.clone(),
                 self.tool_registry.clone(),
                 self.hooks_factory.clone(),
             ));
@@ -797,6 +802,7 @@ impl SessionManager {
             ui: publisher.clone(),
             state_persistence: state_storage,
             permission_handler,
+            permissions,
             tool_registry: self.tool_registry.clone(),
             sub_agent_runner: Some(sub_agent_runner),
             hooks_factory: self.hooks_factory.clone(),

--- a/crates/code_assistant_core/src/session/mod.rs
+++ b/crates/code_assistant_core/src/session/mod.rs
@@ -6,11 +6,13 @@ use sandbox::SandboxPolicy;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::path::PathBuf;
+use tools_core::permissions::PermissionTier;
 
 // New session management architecture
 pub mod event_stream;
 pub mod instance;
 pub mod manager;
+pub mod permissions;
 pub mod service;
 pub mod sleep_inhibitor;
 pub mod watcher;
@@ -41,6 +43,10 @@ pub struct SessionSnapshot {
     pub current_model: String,
     pub allowed_models: Vec<String>,
     pub sandbox_policy: SandboxPolicy,
+    pub permission_tier: PermissionTier,
+    /// Permission requests still awaiting an answer; a connecting frontend
+    /// should render prompts for them.
+    pub pending_permission_requests: Vec<permissions::ToolPermissionRequestData>,
 }
 
 impl SessionSnapshot {
@@ -83,9 +89,17 @@ impl SessionSnapshot {
         events.push(UiEvent::UpdateSandboxPolicy {
             policy: self.sandbox_policy.clone(),
         });
+        events.push(UiEvent::UpdatePermissionTier {
+            tier: self.permission_tier,
+        });
         events.push(UiEvent::UpdateAllowedModels {
             models: self.allowed_models.clone(),
         });
+        for request in &self.pending_permission_requests {
+            events.push(UiEvent::RequestToolPermission {
+                request: request.clone(),
+            });
+        }
         events
     }
 }
@@ -103,6 +117,9 @@ pub struct SessionConfig {
     pub use_diff_blocks: bool,
     #[serde(default)]
     pub sandbox_policy: SandboxPolicy,
+    /// When to ask the user for permission before running a tool.
+    #[serde(default)]
+    pub permission_tier: PermissionTier,
     /// If set, the session operates inside this git worktree instead of `init_path`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub worktree_path: Option<PathBuf>,
@@ -123,6 +140,7 @@ impl Default for SessionConfig {
             tool_syntax: default_tool_syntax(),
             use_diff_blocks: false,
             sandbox_policy: SandboxPolicy::DangerFullAccess,
+            permission_tier: PermissionTier::default(),
             worktree_path: None,
             branch: None,
         }

--- a/crates/code_assistant_core/src/session/permissions.rs
+++ b/crates/code_assistant_core/src/session/permissions.rs
@@ -1,0 +1,215 @@
+//! Session-layer permission mediation: routes a [`PermissionMediator`]
+//! request from the agent through the broadcast [`EventStream`] to whatever
+//! frontend views the session, and resolves it via
+//! [`crate::session::SessionService::respond_permission`].
+
+use crate::session::event_stream::EventStream;
+use crate::ui::UiEvent;
+use anyhow::Result;
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use tokio::sync::oneshot;
+use tools_core::permissions::{PermissionDecision, PermissionMediator, PermissionRequest};
+
+/// A permission request as shown to frontends. Carried by
+/// [`UiEvent::RequestToolPermission`] and included in session snapshots so a
+/// frontend connecting mid-request can still answer it.
+#[derive(Debug, Clone)]
+pub struct ToolPermissionRequestData {
+    /// Identifies the request towards `respond_permission`.
+    pub request_id: String,
+    /// The tool invocation this request belongs to, when known. Frontends
+    /// can anchor the prompt at the tool's UI block.
+    pub tool_id: Option<String>,
+    pub tool_name: String,
+    /// Human-readable description of what is being asked.
+    pub summary: String,
+    /// Structured request details (tool parameters or command line).
+    pub metadata: serde_json::Value,
+}
+
+/// Pending permission requests of one session, keyed by request id.
+///
+/// The mediator inserts before publishing the UI event; `resolve` feeds the
+/// user's decision back. Dropping an entry (e.g. `deny_all` on stop) resolves
+/// the mediator side as `Denied`.
+#[derive(Default)]
+pub struct PendingPermissionRequests {
+    entries: Mutex<HashMap<String, PendingEntry>>,
+}
+
+struct PendingEntry {
+    responder: oneshot::Sender<PermissionDecision>,
+    data: ToolPermissionRequestData,
+}
+
+impl PendingPermissionRequests {
+    fn insert(&self, data: ToolPermissionRequestData) -> oneshot::Receiver<PermissionDecision> {
+        let (tx, rx) = oneshot::channel();
+        self.entries.lock().unwrap().insert(
+            data.request_id.clone(),
+            PendingEntry {
+                responder: tx,
+                data,
+            },
+        );
+        rx
+    }
+
+    /// Feed the user's decision back to the waiting agent. Returns false if
+    /// the request is unknown (already resolved or denied on stop).
+    pub fn resolve(&self, request_id: &str, decision: PermissionDecision) -> bool {
+        match self.entries.lock().unwrap().remove(request_id) {
+            Some(entry) => entry.responder.send(decision).is_ok(),
+            None => false,
+        }
+    }
+
+    /// Drop all pending requests, resolving their mediators as `Denied`.
+    /// Called when the user stops the agent and when a new run begins.
+    pub fn deny_all(&self) {
+        self.entries.lock().unwrap().clear();
+    }
+
+    /// The currently open requests, for session snapshots.
+    pub fn snapshot(&self) -> Vec<ToolPermissionRequestData> {
+        self.entries
+            .lock()
+            .unwrap()
+            .values()
+            .map(|entry| entry.data.clone())
+            .collect()
+    }
+}
+
+/// [`PermissionMediator`] for sessions driven through [`SessionService`]:
+/// publishes the request on the event stream and awaits the decision from
+/// `respond_permission`.
+///
+/// [`SessionService`]: crate::session::SessionService
+pub struct SessionPermissionMediator {
+    session_id: String,
+    events: EventStream,
+    pending: Arc<PendingPermissionRequests>,
+}
+
+impl SessionPermissionMediator {
+    pub fn new(
+        session_id: String,
+        events: EventStream,
+        pending: Arc<PendingPermissionRequests>,
+    ) -> Self {
+        Self {
+            session_id,
+            events,
+            pending,
+        }
+    }
+
+    fn next_request_id() -> String {
+        static COUNTER: AtomicU64 = AtomicU64::new(1);
+        format!("perm-{}", COUNTER.fetch_add(1, Ordering::Relaxed))
+    }
+
+    fn request_data(request: &PermissionRequest<'_>) -> ToolPermissionRequestData {
+        use tools_core::permissions::PermissionRequestReason;
+
+        let (summary, metadata) = match &request.reason {
+            PermissionRequestReason::ExecuteCommand {
+                command_line,
+                working_dir,
+            } => (
+                match working_dir {
+                    Some(dir) => format!("Run `{}` in {}", command_line, dir.display()),
+                    None => format!("Run `{command_line}`"),
+                },
+                serde_json::json!({
+                    "type": "execute_command",
+                    "command_line": command_line,
+                    "working_dir": working_dir.map(|dir| dir.display().to_string()),
+                }),
+            ),
+            PermissionRequestReason::ToolInvocation { params } => (
+                format!("Run tool `{}`", request.tool_name),
+                serde_json::json!({
+                    "type": "tool_invocation",
+                    "params": params,
+                }),
+            ),
+        };
+
+        ToolPermissionRequestData {
+            request_id: Self::next_request_id(),
+            tool_id: request.tool_id.map(|id| id.to_string()),
+            tool_name: request.tool_name.to_string(),
+            summary,
+            metadata,
+        }
+    }
+}
+
+#[async_trait]
+impl PermissionMediator for SessionPermissionMediator {
+    async fn request_permission(
+        &self,
+        request: PermissionRequest<'_>,
+    ) -> Result<PermissionDecision> {
+        let data = Self::request_data(&request);
+        let request_id = data.request_id.clone();
+        let rx = self.pending.insert(data.clone());
+
+        self.events.publish_ui(
+            &self.session_id,
+            UiEvent::RequestToolPermission { request: data },
+        );
+
+        // A dropped responder (stop request, new agent run) counts as denial.
+        let decision = rx.await.unwrap_or(PermissionDecision::Denied);
+
+        // Tell every view the request is settled so open prompts dismiss.
+        self.events.publish_ui(
+            &self.session_id,
+            UiEvent::ToolPermissionRequestResolved { request_id },
+        );
+
+        Ok(decision)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn data(id: &str) -> ToolPermissionRequestData {
+        ToolPermissionRequestData {
+            request_id: id.to_string(),
+            tool_id: None,
+            tool_name: "edit".to_string(),
+            summary: "Run tool `edit`".to_string(),
+            metadata: serde_json::json!({}),
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_feeds_decision_to_waiter() {
+        let pending = PendingPermissionRequests::default();
+        let rx = pending.insert(data("r1"));
+        assert!(pending.resolve("r1", PermissionDecision::GrantedOnce));
+        assert_eq!(rx.await.unwrap(), PermissionDecision::GrantedOnce);
+        // Second resolve for the same id is a no-op.
+        assert!(!pending.resolve("r1", PermissionDecision::Denied));
+    }
+
+    #[tokio::test]
+    async fn deny_all_resolves_waiters_as_denied() {
+        let pending = PendingPermissionRequests::default();
+        let rx = pending.insert(data("r1"));
+        assert_eq!(pending.snapshot().len(), 1);
+        pending.deny_all();
+        assert!(pending.snapshot().is_empty());
+        // Sender dropped: the mediator maps this to Denied.
+        assert!(rx.await.is_err());
+    }
+}

--- a/crates/code_assistant_core/src/session/service.rs
+++ b/crates/code_assistant_core/src/session/service.rs
@@ -1384,7 +1384,7 @@ mod tests {
 
     #[tokio::test]
     async fn respond_permission_resolves_pending_request() {
-        use tools_core::permissions::{PermissionDecision, PermissionMediator};
+        use tools_core::permissions::PermissionDecision;
 
         let tmp = tempfile::tempdir().unwrap();
         let (service, manager) = test_service_with_manager(tmp.path());

--- a/crates/code_assistant_core/src/session/service.rs
+++ b/crates/code_assistant_core/src/session/service.rs
@@ -607,6 +607,42 @@ impl SessionService {
         .await
     }
 
+    /// Change when the agent asks for permission before running tools.
+    /// Takes effect on the next agent run.
+    pub async fn change_permission_tier(
+        &self,
+        session_id: String,
+        tier: tools_core::PermissionTier,
+    ) -> Result<()> {
+        self.call(move |ctx| async move {
+            {
+                let mut manager = ctx.manager.lock().await;
+                manager.set_session_permission_tier(&session_id, tier)?;
+            }
+            // Fan out the change so every view of this session updates.
+            ctx.notify_session(&session_id, UiEvent::UpdatePermissionTier { tier });
+            Ok(())
+        })
+        .await
+    }
+
+    /// Answer a pending tool permission request
+    /// ([`UiEvent::RequestToolPermission`]). Unknown request ids are ignored
+    /// (the request may have been settled by another view or a stop).
+    pub async fn respond_permission(
+        &self,
+        session_id: String,
+        request_id: String,
+        decision: tools_core::PermissionDecision,
+    ) -> Result<()> {
+        self.call(move |ctx| async move {
+            let manager = ctx.manager.lock().await;
+            manager.resolve_permission_request(&session_id, &request_id, decision)?;
+            Ok(())
+        })
+        .await
+    }
+
     // ========================================================================
     // Session branching
     // ========================================================================
@@ -1070,13 +1106,16 @@ async fn start_agent_impl(
     manager
         .set_session_model_config(session_id, Some(session_config))
         .context("Failed to persist model config")?;
+    // Permission prompts travel over the event stream to whatever frontend
+    // views this session; the tier decides whether the agent ever asks.
+    let permission_handler = manager.permission_mediator(session_id).ok();
     manager
         .start_agent_for_session(
             session_id,
             llm_client,
             project_manager,
             command_executor,
-            None,
+            permission_handler,
             tool_scope_override,
         )
         .await
@@ -1091,7 +1130,9 @@ mod tests {
     use crate::persistence::FileSessionPersistence;
     use crate::session::SessionConfig;
 
-    fn test_service(root: &std::path::Path) -> SessionService {
+    fn test_service_with_manager(
+        root: &std::path::Path,
+    ) -> (SessionService, Arc<Mutex<SessionManager>>) {
         let events = EventStream::new();
         let persistence = FileSessionPersistence::new_with_root_dir(root.to_path_buf());
         let manager = Arc::new(Mutex::new(SessionManager::new(
@@ -1109,9 +1150,13 @@ mod tests {
                 Box::new(crate::mocks::create_command_executor_mock())
             }),
         });
-        let (service, worker) = SessionService::new(manager, runtime, events);
+        let (service, worker) = SessionService::new(manager.clone(), runtime, events);
         tokio::spawn(worker);
-        service
+        (service, manager)
+    }
+
+    fn test_service(root: &std::path::Path) -> SessionService {
+        test_service_with_manager(root).0
     }
 
     #[tokio::test]
@@ -1291,5 +1336,111 @@ mod tests {
         }
         assert_eq!(ids.len(), 5);
         assert_eq!(service.list_sessions().await.unwrap().len(), 5);
+    }
+
+    #[tokio::test]
+    async fn change_permission_tier_persists_and_notifies() {
+        use tools_core::PermissionTier;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let service = test_service(tmp.path());
+        let id = service.create_session(None, None).await.unwrap();
+
+        let mut subscription = service.subscribe();
+        service
+            .change_permission_tier(id.clone(), PermissionTier::AllTools)
+            .await
+            .unwrap();
+
+        // The change is fanned out to stream subscribers...
+        loop {
+            let event = subscription.recv().await.unwrap();
+            if let crate::session::event_stream::EventPayload::Ui(UiEvent::UpdatePermissionTier {
+                tier,
+            }) = event.payload
+            {
+                assert_eq!(tier, PermissionTier::AllTools);
+                assert_eq!(event.session_id.as_deref(), Some(id.as_str()));
+                break;
+            }
+        }
+
+        // ...and lands in the snapshot (persisted config).
+        let snapshot = service.load_session(id.clone(), None).await.unwrap();
+        assert_eq!(snapshot.permission_tier, PermissionTier::AllTools);
+        assert!(snapshot.connect_events().iter().any(|e| matches!(
+            e,
+            UiEvent::UpdatePermissionTier {
+                tier: PermissionTier::AllTools
+            }
+        )));
+
+        // Unknown session errors.
+        assert!(service
+            .change_permission_tier("nope".to_string(), PermissionTier::BypassAll)
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn respond_permission_resolves_pending_request() {
+        use tools_core::permissions::{PermissionDecision, PermissionMediator};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let (service, manager) = test_service_with_manager(tmp.path());
+        let id = service.create_session(None, None).await.unwrap();
+
+        // Build the same mediator the agent would get and fire a request.
+        let mediator = manager.lock().await.permission_mediator(&id).unwrap();
+
+        let mut subscription = service.subscribe();
+        let request_task = tokio::spawn(async move {
+            let params = serde_json::json!({"paths": ["a.txt"]});
+            mediator
+                .request_permission(tools_core::PermissionRequest {
+                    tool_id: Some("tool-1"),
+                    tool_name: "delete_files",
+                    reason: tools_core::PermissionRequestReason::ToolInvocation { params: &params },
+                })
+                .await
+        });
+
+        // The prompt arrives on the stream; answer it via the service.
+        let request_id = loop {
+            let event = subscription.recv().await.unwrap();
+            if let crate::session::event_stream::EventPayload::Ui(
+                UiEvent::RequestToolPermission { request },
+            ) = event.payload
+            {
+                assert_eq!(request.tool_name, "delete_files");
+                break request.request_id;
+            }
+        };
+
+        service
+            .respond_permission(
+                id.clone(),
+                request_id.clone(),
+                PermissionDecision::GrantedOnce,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            request_task.await.unwrap().unwrap(),
+            PermissionDecision::GrantedOnce
+        );
+
+        // Every view is told the request settled.
+        loop {
+            let event = subscription.recv().await.unwrap();
+            if let crate::session::event_stream::EventPayload::Ui(
+                UiEvent::ToolPermissionRequestResolved { request_id: rid },
+            ) = event.payload
+            {
+                assert_eq!(rid, request_id);
+                break;
+            }
+        }
     }
 }

--- a/crates/code_assistant_core/src/ui/ui_events.rs
+++ b/crates/code_assistant_core/src/ui/ui_events.rs
@@ -229,6 +229,19 @@ pub enum UiEvent {
     UpdateAllowedModels { models: Vec<String> },
     /// Update the current sandbox selection in the UI
     UpdateSandboxPolicy { policy: SandboxPolicy },
+    /// Update the current permission tier selection in the UI
+    UpdatePermissionTier {
+        tier: tools_core::permissions::PermissionTier,
+    },
+    /// The agent asks the user for permission to run a tool. Answered via
+    /// `SessionService::respond_permission`; a
+    /// [`UiEvent::ToolPermissionRequestResolved`] follows once settled.
+    RequestToolPermission {
+        request: crate::session::permissions::ToolPermissionRequestData,
+    },
+    /// A permission request was settled (answered, or dropped by a stop
+    /// request); open prompts for it should dismiss.
+    ToolPermissionRequestResolved { request_id: String },
 
     /// Schedule a debounced save of the per-session UI state file.
     /// Sent after any mutation to the UI state (tool collapse toggle, plan

--- a/crates/mcp_client/src/config.rs
+++ b/crates/mcp_client/src/config.rs
@@ -29,10 +29,7 @@ impl McpServersConfig {
     /// resolves a variable name (typically `|name| std::env::var(name).ok()`);
     /// an unresolvable variable or an unclosed `${` is an error naming the
     /// offending server.
-    pub fn substitute_env_values(
-        &mut self,
-        lookup: impl Fn(&str) -> Option<String>,
-    ) -> Result<()> {
+    pub fn substitute_env_values(&mut self, lookup: impl Fn(&str) -> Option<String>) -> Result<()> {
         for (name, server) in self.servers.iter_mut() {
             for value in server.env.values_mut() {
                 *value = substitute_variables(value, &lookup)

--- a/crates/tools_core/Cargo.toml
+++ b/crates/tools_core/Cargo.toml
@@ -11,3 +11,6 @@ regex = "1.12"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/tools_core/src/lib.rs
+++ b/crates/tools_core/src/lib.rs
@@ -21,7 +21,7 @@ pub mod tool;
 pub use dyn_tool::{AnyOutput, DynTool};
 pub use permissions::{
     PermissionDecision, PermissionMediator, PermissionRequest, PermissionRequestReason,
-    PermissionTier,
+    PermissionTier, ToolPermissions,
 };
 pub use registry::ToolRegistry;
 pub use render::{ImageData, Render, ResourcesTracker};

--- a/crates/tools_core/src/lib.rs
+++ b/crates/tools_core/src/lib.rs
@@ -21,6 +21,7 @@ pub mod tool;
 pub use dyn_tool::{AnyOutput, DynTool};
 pub use permissions::{
     PermissionDecision, PermissionMediator, PermissionRequest, PermissionRequestReason,
+    PermissionTier,
 };
 pub use registry::ToolRegistry;
 pub use render::{ImageData, Render, ResourcesTracker};

--- a/crates/tools_core/src/permissions.rs
+++ b/crates/tools_core/src/permissions.rs
@@ -1,8 +1,40 @@
 //! Permission mediation for potentially sensitive tool operations.
 
+use crate::spec::{ToolSpec, capabilities};
 use anyhow::Result;
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
 use std::path::Path;
+
+/// When to ask the user for permission before running a tool.
+///
+/// The tier only decides *whether* to ask; the actual question is routed
+/// through the session's [`PermissionMediator`]. Tools may additionally
+/// request permission for specific escalations (e.g. `execute_command`
+/// asking to bypass the sandbox) independently of the tier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum PermissionTier {
+    /// Never ask; every tool call runs without prompting.
+    #[default]
+    BypassAll,
+    /// Ask before running tools that may modify state — anything not
+    /// tagged [`capabilities::READ_ONLY`].
+    WriteTools,
+    /// Ask before running any tool.
+    AllTools,
+}
+
+impl PermissionTier {
+    /// Whether invoking a tool with the given spec requires asking first.
+    pub fn requires_permission(&self, spec: &ToolSpec) -> bool {
+        match self {
+            PermissionTier::BypassAll => false,
+            PermissionTier::WriteTools => !spec.has_capability(capabilities::READ_ONLY),
+            PermissionTier::AllTools => true,
+        }
+    }
+}
 
 /// Context about why permission is being requested.
 #[derive(Debug)]
@@ -11,6 +43,8 @@ pub enum PermissionRequestReason<'a> {
         command_line: &'a str,
         working_dir: Option<&'a Path>,
     },
+    /// Tier-based gate before invoking a tool ([`PermissionTier`]).
+    ToolInvocation { params: &'a serde_json::Value },
 }
 
 /// Request payload passed to a [`PermissionMediator`].
@@ -34,4 +68,58 @@ pub trait PermissionMediator: Send + Sync {
         &self,
         request: PermissionRequest<'_>,
     ) -> Result<PermissionDecision>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec_with(tags: &'static [&'static str]) -> ToolSpec {
+        ToolSpec {
+            name: "test_tool".into(),
+            description: "test".into(),
+            parameters_schema: serde_json::json!({"type": "object"}),
+            annotations: None,
+            capabilities: ToolSpec::capabilities(tags),
+            multiline_params: &[],
+            hidden: false,
+            title_template: None,
+        }
+    }
+
+    #[test]
+    fn bypass_all_never_requires_permission() {
+        let tier = PermissionTier::BypassAll;
+        assert!(!tier.requires_permission(&spec_with(&[capabilities::READ_ONLY])));
+        assert!(!tier.requires_permission(&spec_with(&[capabilities::EDITS_FILES])));
+        assert!(!tier.requires_permission(&spec_with(&[])));
+    }
+
+    #[test]
+    fn write_tools_requires_permission_unless_read_only() {
+        let tier = PermissionTier::WriteTools;
+        assert!(!tier.requires_permission(&spec_with(&[capabilities::READ_ONLY])));
+        assert!(tier.requires_permission(&spec_with(&[capabilities::EDITS_FILES])));
+        // Untagged tools (e.g. MCP tools without a read-only hint) count as writes.
+        assert!(tier.requires_permission(&spec_with(&[])));
+    }
+
+    #[test]
+    fn all_tools_always_requires_permission() {
+        let tier = PermissionTier::AllTools;
+        assert!(tier.requires_permission(&spec_with(&[capabilities::READ_ONLY])));
+        assert!(tier.requires_permission(&spec_with(&[capabilities::EDITS_FILES])));
+        assert!(tier.requires_permission(&spec_with(&[])));
+    }
+
+    #[test]
+    fn tier_serializes_as_kebab_case_and_defaults_to_bypass_all() {
+        assert_eq!(PermissionTier::default(), PermissionTier::BypassAll);
+        assert_eq!(
+            serde_json::to_string(&PermissionTier::WriteTools).unwrap(),
+            "\"write-tools\""
+        );
+        let parsed: PermissionTier = serde_json::from_str("\"all-tools\"").unwrap();
+        assert_eq!(parsed, PermissionTier::AllTools);
+    }
 }

--- a/crates/tools_core/src/permissions.rs
+++ b/crates/tools_core/src/permissions.rs
@@ -4,7 +4,9 @@ use crate::spec::{ToolSpec, capabilities};
 use anyhow::Result;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::path::Path;
+use std::sync::{Arc, Mutex};
 
 /// When to ask the user for permission before running a tool.
 ///
@@ -32,6 +34,83 @@ impl PermissionTier {
             PermissionTier::BypassAll => false,
             PermissionTier::WriteTools => !spec.has_capability(capabilities::READ_ONLY),
             PermissionTier::AllTools => true,
+        }
+    }
+}
+
+/// Per-session permission state handed to the agent loop: the active tier
+/// plus the tools the user granted for the rest of the session.
+///
+/// Cloning shares the grant set (it is session-scoped state), so the loop's
+/// parallel execution path and sub-agents all see the same grants.
+#[derive(Clone, Default)]
+pub struct ToolPermissions {
+    pub tier: PermissionTier,
+    granted_tools: Arc<Mutex<HashSet<String>>>,
+}
+
+impl ToolPermissions {
+    pub fn new(tier: PermissionTier) -> Self {
+        Self {
+            tier,
+            granted_tools: Arc::default(),
+        }
+    }
+
+    pub fn is_granted(&self, tool_name: &str) -> bool {
+        self.granted_tools.lock().unwrap().contains(tool_name)
+    }
+
+    pub fn grant(&self, tool_name: &str) {
+        self.granted_tools
+            .lock()
+            .unwrap()
+            .insert(tool_name.to_string());
+    }
+
+    /// Tier-based gate run by the agent loop before invoking a tool.
+    ///
+    /// Returns `Ok(())` when the invocation may proceed. The `Err` message is
+    /// routed back to the LLM as the tool result, so it tells the model how
+    /// to react to a denial.
+    pub async fn check(
+        &self,
+        handler: Option<&dyn PermissionMediator>,
+        spec: &ToolSpec,
+        tool_id: Option<&str>,
+        params: &serde_json::Value,
+    ) -> Result<()> {
+        if !self.tier.requires_permission(spec) {
+            return Ok(());
+        }
+        if self.is_granted(&spec.name) {
+            return Ok(());
+        }
+        let Some(handler) = handler else {
+            anyhow::bail!(
+                "Permission is required to run tool '{}', but this frontend cannot ask the user. \
+                 The call was denied by policy.",
+                spec.name
+            );
+        };
+        let decision = handler
+            .request_permission(PermissionRequest {
+                tool_id,
+                tool_name: &spec.name,
+                reason: PermissionRequestReason::ToolInvocation { params },
+            })
+            .await?;
+        match decision {
+            PermissionDecision::GrantedOnce => Ok(()),
+            PermissionDecision::GrantedSession => {
+                self.grant(&spec.name);
+                Ok(())
+            }
+            PermissionDecision::Denied => anyhow::bail!(
+                "The user denied permission to run tool '{}'. Do not simply retry; \
+                 ask the user how to proceed or try a different approach.",
+                spec.name
+            ),
         }
     }
 }
@@ -73,6 +152,37 @@ pub trait PermissionMediator: Send + Sync {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Mediator returning a fixed decision and counting how often it is asked.
+    struct ScriptedMediator {
+        decision: PermissionDecision,
+        calls: AtomicUsize,
+    }
+
+    impl ScriptedMediator {
+        fn new(decision: PermissionDecision) -> Self {
+            Self {
+                decision,
+                calls: AtomicUsize::new(0),
+            }
+        }
+
+        fn call_count(&self) -> usize {
+            self.calls.load(Ordering::Relaxed)
+        }
+    }
+
+    #[async_trait]
+    impl PermissionMediator for ScriptedMediator {
+        async fn request_permission(
+            &self,
+            _request: PermissionRequest<'_>,
+        ) -> Result<PermissionDecision> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            Ok(self.decision)
+        }
+    }
 
     fn spec_with(tags: &'static [&'static str]) -> ToolSpec {
         ToolSpec {
@@ -110,6 +220,100 @@ mod tests {
         assert!(tier.requires_permission(&spec_with(&[capabilities::READ_ONLY])));
         assert!(tier.requires_permission(&spec_with(&[capabilities::EDITS_FILES])));
         assert!(tier.requires_permission(&spec_with(&[])));
+    }
+
+    #[tokio::test]
+    async fn bypass_tier_does_not_consult_the_mediator() {
+        let permissions = ToolPermissions::new(PermissionTier::BypassAll);
+        let mediator = ScriptedMediator::new(PermissionDecision::Denied);
+        let params = serde_json::json!({});
+        permissions
+            .check(
+                Some(&mediator),
+                &spec_with(&[capabilities::EDITS_FILES]),
+                None,
+                &params,
+            )
+            .await
+            .unwrap();
+        assert_eq!(mediator.call_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn write_tier_skips_read_only_tools() {
+        let permissions = ToolPermissions::new(PermissionTier::WriteTools);
+        let mediator = ScriptedMediator::new(PermissionDecision::Denied);
+        let params = serde_json::json!({});
+        permissions
+            .check(
+                Some(&mediator),
+                &spec_with(&[capabilities::READ_ONLY]),
+                None,
+                &params,
+            )
+            .await
+            .unwrap();
+        assert_eq!(mediator.call_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn denied_decision_becomes_an_error() {
+        let permissions = ToolPermissions::new(PermissionTier::WriteTools);
+        let mediator = ScriptedMediator::new(PermissionDecision::Denied);
+        let params = serde_json::json!({});
+        let err = permissions
+            .check(Some(&mediator), &spec_with(&[]), None, &params)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("denied permission"));
+        assert_eq!(mediator.call_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn granted_session_is_remembered_per_tool() {
+        let permissions = ToolPermissions::new(PermissionTier::AllTools);
+        let mediator = ScriptedMediator::new(PermissionDecision::GrantedSession);
+        let params = serde_json::json!({});
+        let spec = spec_with(&[capabilities::READ_ONLY]);
+        permissions
+            .check(Some(&mediator), &spec, None, &params)
+            .await
+            .unwrap();
+        permissions
+            .check(Some(&mediator), &spec, None, &params)
+            .await
+            .unwrap();
+        // Second call is served from the session grant, and clones share it.
+        assert_eq!(mediator.call_count(), 1);
+        assert!(permissions.clone().is_granted("test_tool"));
+    }
+
+    #[tokio::test]
+    async fn granted_once_asks_again_next_time() {
+        let permissions = ToolPermissions::new(PermissionTier::AllTools);
+        let mediator = ScriptedMediator::new(PermissionDecision::GrantedOnce);
+        let params = serde_json::json!({});
+        let spec = spec_with(&[]);
+        permissions
+            .check(Some(&mediator), &spec, None, &params)
+            .await
+            .unwrap();
+        permissions
+            .check(Some(&mediator), &spec, None, &params)
+            .await
+            .unwrap();
+        assert_eq!(mediator.call_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn missing_handler_denies_when_tier_requires_asking() {
+        let permissions = ToolPermissions::new(PermissionTier::WriteTools);
+        let params = serde_json::json!({});
+        let err = permissions
+            .check(None, &spec_with(&[]), None, &params)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("cannot ask the user"));
     }
 
     #[test]

--- a/crates/ui_acp/src/agent.rs
+++ b/crates/ui_acp/src/agent.rs
@@ -19,10 +19,56 @@ use command_executor::{CommandExecutor, DefaultCommandExecutor};
 use llm::factory::create_llm_client_from_model;
 use llm::provider_config::ConfigurationSystem;
 use tokio::sync::{mpsc, oneshot};
+use tools_core::permissions::PermissionTier;
 
 /// Config option id used for the model selector exposed via session config
 /// options. This is what the client echoes back in `session/set_config_option`.
 const MODEL_CONFIG_ID: &str = "model";
+
+/// The permission tiers exposed to ACP clients as session modes
+/// (`session/set_mode`). Mode ids match the tier's serde names.
+const PERMISSION_MODES: &[(PermissionTier, &str, &str, &str)] = &[
+    (
+        PermissionTier::BypassAll,
+        "bypass-all",
+        "Bypass Permissions",
+        "Run every tool without asking",
+    ),
+    (
+        PermissionTier::WriteTools,
+        "write-tools",
+        "Ask Before Writes",
+        "Ask before running tools that modify files or state",
+    ),
+    (
+        PermissionTier::AllTools,
+        "all-tools",
+        "Ask For All Tools",
+        "Ask before running any tool",
+    ),
+];
+
+fn permission_mode_state(current: PermissionTier) -> acp::SessionModeState {
+    let available_modes = PERMISSION_MODES
+        .iter()
+        .map(|(_, id, name, description)| {
+            acp::SessionMode::new(*id, *name).description(Some((*description).to_string()))
+        })
+        .collect();
+    let current_id = PERMISSION_MODES
+        .iter()
+        .find(|(tier, ..)| *tier == current)
+        .map(|(_, id, ..)| *id)
+        .unwrap_or("bypass-all");
+    acp::SessionModeState::new(current_id, available_modes)
+}
+
+fn permission_tier_for_mode(mode_id: &str) -> Option<PermissionTier> {
+    PERMISSION_MODES
+        .iter()
+        .find(|(_, id, ..)| *id == mode_id)
+        .map(|(tier, ..)| *tier)
+}
 
 /// If the prompt is a bare `/<token>` slash command (the form clients send when
 /// the user runs an advertised command), return `<token>`. Only the first text
@@ -299,6 +345,7 @@ impl AgentState {
 
         let mut session_config = self.session_config_template.clone();
         session_config.init_path = Some(arguments.cwd.clone());
+        let permission_tier = session_config.permission_tier;
 
         let model_info =
             Self::compute_model_config(&self.model_name, Some(self.model_name.as_str()));
@@ -339,7 +386,42 @@ impl AgentState {
         }
 
         let config_options = model_info.map(|info| info.options);
-        Ok(acp::NewSessionResponse::new(session_id).config_options(config_options))
+        Ok(acp::NewSessionResponse::new(session_id)
+            .config_options(config_options)
+            .modes(Some(permission_mode_state(permission_tier))))
+    }
+
+    /// `session/set_mode`: the client switches the permission tier.
+    pub async fn handle_set_session_mode(
+        &self,
+        arguments: acp::SetSessionModeRequest,
+    ) -> Result<acp::SetSessionModeResponse, acp::Error> {
+        let Some(tier) = permission_tier_for_mode(arguments.mode_id.0.as_ref()) else {
+            tracing::warn!("ACP: Unknown session mode: {}", arguments.mode_id.0);
+            return Err(acp::Error::invalid_params());
+        };
+        let session_id = arguments.session_id.0.to_string();
+
+        // Sessions created but not yet persisted keep the tier in their
+        // pending config; it is stored with the session on the first prompt.
+        {
+            let mut pending = self.pending_sessions.lock().await;
+            if let Some(pending_session) = pending.get_mut(&session_id) {
+                pending_session.config.permission_tier = tier;
+                tracing::info!("ACP: Set permission tier {tier:?} on pending session");
+                return Ok(acp::SetSessionModeResponse::default());
+            }
+        }
+
+        let mut manager = self.session_manager.lock().await;
+        manager
+            .set_session_permission_tier(&session_id, tier)
+            .map_err(|e| {
+                tracing::error!("Failed to set permission tier: {e}");
+                acp::Error::internal_error()
+            })?;
+        tracing::info!("ACP: Set permission tier {tier:?} for session {session_id}");
+        Ok(acp::SetSessionModeResponse::default())
     }
 
     pub async fn handle_load_session(
@@ -363,7 +445,14 @@ impl AgentState {
         }
 
         // Replay message history as session/update events
-        let (tool_syntax, messages, base_path, stored_model_config, initial_project) = {
+        let (
+            tool_syntax,
+            messages,
+            base_path,
+            stored_model_config,
+            initial_project,
+            permission_tier,
+        ) = {
             let manager = self.session_manager.lock().await;
             let session_instance = manager
                 .get_session(&arguments.session_id.0)
@@ -375,6 +464,7 @@ impl AgentState {
                 session_instance.session.config.init_path.clone(),
                 session_instance.session.model_config.clone(),
                 session_instance.session.config.initial_project.clone(),
+                session_instance.session.config.permission_tier,
             )
         };
 
@@ -518,7 +608,9 @@ impl AgentState {
 
         tracing::info!("ACP: Loaded session: {}", arguments.session_id.0);
 
-        Ok(acp::LoadSessionResponse::new().config_options(config_options))
+        Ok(acp::LoadSessionResponse::new()
+            .config_options(config_options)
+            .modes(Some(permission_mode_state(permission_tier))))
     }
 
     pub async fn handle_set_config_option(

--- a/crates/ui_acp/src/app.rs
+++ b/crates/ui_acp/src/app.rs
@@ -224,6 +224,15 @@ pub async fn run(verbose: bool, config: AgentRunConfig) -> Result<()> {
         .on_receive_request(
             {
                 let state = state.clone();
+                async move |req: acp::schema::SetSessionModeRequest, responder, _cx| {
+                    responder.respond_with_result(state.handle_set_session_mode(req).await)
+                }
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        .on_receive_request(
+            {
+                let state = state.clone();
                 async move |req: acp::schema::ListSessionsRequest, responder, _cx| {
                     responder.respond_with_result(state.handle_list_sessions(req).await)
                 }

--- a/crates/ui_acp/src/permissions.rs
+++ b/crates/ui_acp/src/permissions.rs
@@ -117,15 +117,28 @@ impl PermissionMediator for AcpPermissionMediator {
         }
 
         let tool_call = self.tool_call_update(&permission_request);
+        let (allow_always_label, allow_once_label) = match &permission_request.reason {
+            PermissionRequestReason::ExecuteCommand { .. } => (
+                "Always allow in this session".to_string(),
+                "Allow this command".to_string(),
+            ),
+            PermissionRequestReason::ToolInvocation { .. } => (
+                format!(
+                    "Always allow `{}` in this session",
+                    permission_request.tool_name
+                ),
+                "Allow once".to_string(),
+            ),
+        };
         let options = vec![
             acp::PermissionOption::new(
                 ALLOW_ALWAYS_OPTION_ID,
-                "Always allow in this session",
+                allow_always_label,
                 acp::PermissionOptionKind::AllowAlways,
             ),
             acp::PermissionOption::new(
                 ALLOW_OPTION_ID,
-                "Allow this command",
+                allow_once_label,
                 acp::PermissionOptionKind::AllowOnce,
             ),
             acp::PermissionOption::new(

--- a/crates/ui_acp/src/permissions.rs
+++ b/crates/ui_acp/src/permissions.rs
@@ -53,7 +53,7 @@ impl AcpPermissionMediator {
             .title(format!("{} (permission required)", request.tool_name))
             .content(vec![acp::ToolCallContent::Content(acp::Content::new(
                 acp::ContentBlock::Text(acp::TextContent::new(
-                    self.reason_summary(&request.reason),
+                    self.reason_summary(request.tool_name, &request.reason),
                 )),
             ))])
             .raw_input(self.reason_metadata(&request.reason));
@@ -61,7 +61,7 @@ impl AcpPermissionMediator {
         acp::ToolCallUpdate::new(acp::ToolCallId::new(id), fields)
     }
 
-    fn reason_summary(&self, reason: &PermissionRequestReason<'_>) -> String {
+    fn reason_summary(&self, tool_name: &str, reason: &PermissionRequestReason<'_>) -> String {
         match reason {
             PermissionRequestReason::ExecuteCommand {
                 command_line,
@@ -74,6 +74,13 @@ impl AcpPermissionMediator {
                 ),
                 None => format!("Command: `{}`", command_line),
             },
+            PermissionRequestReason::ToolInvocation { params } => {
+                format!(
+                    "Tool: `{}`\nParameters: {}",
+                    tool_name,
+                    serde_json::to_string_pretty(params).unwrap_or_else(|_| params.to_string())
+                )
+            }
         }
     }
 
@@ -86,6 +93,10 @@ impl AcpPermissionMediator {
                 "type": "execute_command",
                 "command_line": command_line,
                 "working_dir": working_dir.map(|dir| dir.display().to_string()),
+            }),
+            PermissionRequestReason::ToolInvocation { params } => json!({
+                "type": "tool_invocation",
+                "params": params,
             }),
         }
     }

--- a/crates/ui_acp/src/ui.rs
+++ b/crates/ui_acp/src/ui.rs
@@ -938,6 +938,11 @@ impl UserInterface for ACPUserUI {
             | UiEvent::ClearError
             | UiEvent::UpdateCurrentModel { .. }
             | UiEvent::UpdateSandboxPolicy { .. }
+            | UiEvent::UpdatePermissionTier { .. }
+            // Permission prompts reach ACP clients through the protocol's
+            // requestPermission RPC (AcpPermissionMediator), not the stream.
+            | UiEvent::RequestToolPermission { .. }
+            | UiEvent::ToolPermissionRequestResolved { .. }
             | UiEvent::HiddenToolCompleted
             | UiEvent::MessageEditReady { .. }
             | UiEvent::UpdateBranchInfo { .. }

--- a/crates/ui_gpui/Cargo.toml
+++ b/crates/ui_gpui/Cargo.toml
@@ -12,6 +12,7 @@ llm = { path = "../llm" }
 sandbox = { path = "../sandbox" }
 terminal = { path = "../terminal" }
 terminal_view = { path = "../terminal_view" }
+tools_core = { path = "../tools_core" }
 
 # GPUI related
 gpui = "0.2.2"

--- a/crates/ui_gpui/src/app/commands.rs
+++ b/crates/ui_gpui/src/app/commands.rs
@@ -344,6 +344,45 @@ impl Gpui {
         });
     }
 
+    pub(crate) fn cmd_change_permission_tier(
+        &self,
+        session_id: String,
+        tier: tools_core::PermissionTier,
+    ) {
+        let Some(service) = self.session_service() else {
+            return;
+        };
+        let gpui = self.clone();
+        self.dispatch(async move {
+            // The UpdatePermissionTier notification arrives via the stream.
+            if let Err(e) = service.change_permission_tier(session_id, tier).await {
+                gpui.display_error(format!("{e:#}"));
+            }
+        });
+    }
+
+    /// Answer a pending tool permission request. The prompt dismisses when
+    /// the ToolPermissionRequestResolved notification arrives via the stream.
+    pub(crate) fn cmd_respond_permission(
+        &self,
+        session_id: String,
+        request_id: String,
+        decision: tools_core::PermissionDecision,
+    ) {
+        let Some(service) = self.session_service() else {
+            return;
+        };
+        let gpui = self.clone();
+        self.dispatch(async move {
+            if let Err(e) = service
+                .respond_permission(session_id, request_id, decision)
+                .await
+            {
+                gpui.display_error(format!("{e:#}"));
+            }
+        });
+    }
+
     // ========================================================================
     // Branching
     // ========================================================================

--- a/crates/ui_gpui/src/app/event_bridge.rs
+++ b/crates/ui_gpui/src/app/event_bridge.rs
@@ -108,6 +108,21 @@ impl Gpui {
             UiEvent::UpdateSandboxPolicy { policy } => {
                 *self.current_sandbox_policy.lock().unwrap() = Some(policy.clone());
             }
+            UiEvent::UpdatePermissionTier { tier } => {
+                *self.current_permission_tier.lock().unwrap() = Some(*tier);
+            }
+            UiEvent::RequestToolPermission { request } => {
+                let mut pending = self.pending_permission_requests.lock().unwrap();
+                if !pending.iter().any(|r| r.request_id == request.request_id) {
+                    pending.push(request.clone());
+                }
+            }
+            UiEvent::ToolPermissionRequestResolved { request_id } => {
+                self.pending_permission_requests
+                    .lock()
+                    .unwrap()
+                    .retain(|r| &r.request_id != request_id);
+            }
             _ => {}
         }
 

--- a/crates/ui_gpui/src/app/event_loop.rs
+++ b/crates/ui_gpui/src/app/event_loop.rs
@@ -752,6 +752,21 @@ impl Gpui {
                 *self.current_sandbox_policy.lock().unwrap() = Some(policy.clone());
                 cx.refresh();
             }
+            UiEvent::UpdatePermissionTier { tier } => {
+                debug!("UI: UpdatePermissionTier event with tier: {:?}", tier);
+                // TODO(permission-tiers): store and render in the selector.
+            }
+            UiEvent::RequestToolPermission { request } => {
+                debug!(
+                    "UI: RequestToolPermission for tool {} ({})",
+                    request.tool_name, request.request_id
+                );
+                // TODO(permission-tiers): render an interactive prompt.
+            }
+            UiEvent::ToolPermissionRequestResolved { request_id } => {
+                debug!("UI: ToolPermissionRequestResolved {request_id}");
+                // TODO(permission-tiers): dismiss the prompt.
+            }
             UiEvent::UpdateWorktreeData {
                 worktrees,
                 current_worktree_path,

--- a/crates/ui_gpui/src/app/event_loop.rs
+++ b/crates/ui_gpui/src/app/event_loop.rs
@@ -754,18 +754,28 @@ impl Gpui {
             }
             UiEvent::UpdatePermissionTier { tier } => {
                 debug!("UI: UpdatePermissionTier event with tier: {:?}", tier);
-                // TODO(permission-tiers): store and render in the selector.
+                *self.current_permission_tier.lock().unwrap() = Some(tier);
+                cx.refresh();
             }
             UiEvent::RequestToolPermission { request } => {
                 debug!(
                     "UI: RequestToolPermission for tool {} ({})",
                     request.tool_name, request.request_id
                 );
-                // TODO(permission-tiers): render an interactive prompt.
+                let mut pending = self.pending_permission_requests.lock().unwrap();
+                if !pending.iter().any(|r| r.request_id == request.request_id) {
+                    pending.push(request);
+                }
+                drop(pending);
+                cx.refresh();
             }
             UiEvent::ToolPermissionRequestResolved { request_id } => {
                 debug!("UI: ToolPermissionRequestResolved {request_id}");
-                // TODO(permission-tiers): dismiss the prompt.
+                self.pending_permission_requests
+                    .lock()
+                    .unwrap()
+                    .retain(|r| r.request_id != request_id);
+                cx.refresh();
             }
             UiEvent::UpdateWorktreeData {
                 worktrees,

--- a/crates/ui_gpui/src/input/mod.rs
+++ b/crates/ui_gpui/src/input/mod.rs
@@ -1,5 +1,6 @@
 pub mod attachment;
 pub mod model_selector;
+pub mod permission_selector;
 pub mod sandbox_selector;
 pub mod skill_completion;
 pub mod worktree_selector;
@@ -15,8 +16,10 @@ use gpui::{
 use gpui_component::input::{Enter, Input, InputEvent, InputState, Paste};
 use gpui_component::{ActiveTheme, Icon};
 use model_selector::{ModelSelector, ModelSelectorEvent};
+use permission_selector::{PermissionSelector, PermissionSelectorEvent};
 use sandbox::SandboxPolicy;
 use sandbox_selector::{SandboxSelector, SandboxSelectorEvent};
+use tools_core::permissions::PermissionTier;
 use worktree_selector::{WorktreeSelector, WorktreeSelectorEvent};
 
 /// Events emitted by the InputArea component
@@ -50,6 +53,8 @@ pub enum InputAreaEvent {
     ModelChanged { model_name: String },
     /// Sandbox mode changed
     SandboxChanged { policy: SandboxPolicy },
+    /// Permission tier changed
+    PermissionTierChanged { tier: PermissionTier },
     /// User wants to switch to local (no worktree)
     WorktreeSwitchedToLocal,
     /// User selected an existing worktree
@@ -68,9 +73,11 @@ pub struct InputArea {
     text_input: Entity<InputState>,
     model_selector: Entity<ModelSelector>,
     sandbox_selector: Entity<SandboxSelector>,
+    permission_selector: Entity<PermissionSelector>,
     worktree_selector: Entity<WorktreeSelector>,
     current_model: Option<String>,
     current_sandbox_policy: SandboxPolicy,
+    current_permission_tier: PermissionTier,
     attachments: Vec<DraftAttachment>,
     attachment_views: Vec<Entity<AttachmentView>>,
     focus_handle: FocusHandle,
@@ -91,6 +98,7 @@ pub struct InputArea {
     _input_subscription: Subscription,
     _model_selector_subscription: Subscription,
     _sandbox_selector_subscription: Subscription,
+    _permission_selector_subscription: Subscription,
     _worktree_selector_subscription: Subscription,
 }
 
@@ -117,6 +125,7 @@ impl InputArea {
         // Create the model selector
         let model_selector = cx.new(|cx| ModelSelector::new(window, cx));
         let sandbox_selector = cx.new(|cx| SandboxSelector::new(window, cx));
+        let permission_selector = cx.new(|cx| PermissionSelector::new(window, cx));
         let worktree_selector = cx.new(|cx| WorktreeSelector::new(window, cx));
 
         // Subscribe to model selector events
@@ -124,6 +133,11 @@ impl InputArea {
             cx.subscribe_in(&model_selector, window, Self::on_model_selector_event);
         let sandbox_selector_subscription =
             cx.subscribe_in(&sandbox_selector, window, Self::on_sandbox_selector_event);
+        let permission_selector_subscription = cx.subscribe_in(
+            &permission_selector,
+            window,
+            Self::on_permission_selector_event,
+        );
         let worktree_selector_subscription =
             cx.subscribe_in(&worktree_selector, window, Self::on_worktree_selector_event);
 
@@ -131,9 +145,11 @@ impl InputArea {
             text_input,
             model_selector,
             sandbox_selector,
+            permission_selector,
             worktree_selector,
             current_model: None,
             current_sandbox_policy: SandboxPolicy::DangerFullAccess,
+            current_permission_tier: PermissionTier::default(),
             attachments: Vec::new(),
             attachment_views: Vec::new(),
             focus_handle: cx.focus_handle(),
@@ -148,6 +164,7 @@ impl InputArea {
             _input_subscription: input_subscription,
             _model_selector_subscription: model_selector_subscription,
             _sandbox_selector_subscription: sandbox_selector_subscription,
+            _permission_selector_subscription: permission_selector_subscription,
             _worktree_selector_subscription: worktree_selector_subscription,
         }
     }
@@ -246,6 +263,22 @@ impl InputArea {
 
     pub fn current_sandbox_policy(&self) -> SandboxPolicy {
         self.current_sandbox_policy.clone()
+    }
+
+    pub fn set_current_permission_tier(
+        &mut self,
+        tier: PermissionTier,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.current_permission_tier = tier;
+        self.permission_selector.update(cx, |selector, cx| {
+            selector.set_tier(tier, window, cx);
+        });
+    }
+
+    pub fn current_permission_tier(&self) -> PermissionTier {
+        self.current_permission_tier
     }
 
     /// Ensure the model list stays up to date
@@ -497,6 +530,21 @@ impl InputArea {
         }
     }
 
+    fn on_permission_selector_event(
+        &mut self,
+        _selector: &Entity<PermissionSelector>,
+        event: &PermissionSelectorEvent,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        match event {
+            PermissionSelectorEvent::TierChanged { tier } => {
+                self.current_permission_tier = *tier;
+                cx.emit(InputAreaEvent::PermissionTierChanged { tier: *tier });
+            }
+        }
+    }
+
     fn on_worktree_selector_event(
         &mut self,
         _selector: &Entity<WorktreeSelector>,
@@ -697,7 +745,7 @@ impl InputArea {
                                     .track_focus(&text_input_handle)
                                     .child(Input::new(&self.text_input).appearance(false))
                             })
-                            // Selector row: model | worktree | sandbox | context ring
+                            // Selector row: model | worktree | sandbox | permissions | context ring
                             .child(
                                 div()
                                     .flex()
@@ -715,6 +763,12 @@ impl InputArea {
                                             .flex_none()
                                             .flex()
                                             .child(self.sandbox_selector.clone()),
+                                    )
+                                    .child(
+                                        div()
+                                            .flex_none()
+                                            .flex()
+                                            .child(self.permission_selector.clone()),
                                     )
                                     .child({
                                         let ratio = self.context_usage_ratio.unwrap_or(0.0);

--- a/crates/ui_gpui/src/input/permission_selector.rs
+++ b/crates/ui_gpui/src/input/permission_selector.rs
@@ -1,0 +1,117 @@
+use gpui::{div, prelude::*, px, Context, Entity, EventEmitter, Focusable, Render, Window};
+use gpui_component::{
+    select::{Select, SelectEvent, SelectItem, SelectState},
+    ActiveTheme, Icon, Sizable, Size,
+};
+use tools_core::permissions::PermissionTier;
+
+#[derive(Clone, Debug)]
+pub enum PermissionSelectorEvent {
+    TierChanged { tier: PermissionTier },
+}
+
+#[derive(Clone, Debug)]
+struct PermissionOption {
+    label: &'static str,
+    tier: PermissionTier,
+}
+
+impl PermissionOption {
+    fn new(label: &'static str, tier: PermissionTier) -> Self {
+        Self { label, tier }
+    }
+}
+
+impl SelectItem for PermissionOption {
+    type Value = PermissionTier;
+
+    fn title(&self) -> gpui::SharedString {
+        self.label.into()
+    }
+
+    fn display_title(&self) -> Option<gpui::AnyElement> {
+        None
+    }
+
+    fn value(&self) -> &Self::Value {
+        &self.tier
+    }
+}
+
+pub struct PermissionSelector {
+    dropdown_state: Entity<SelectState<Vec<PermissionOption>>>,
+    _subscription: gpui::Subscription,
+}
+
+impl EventEmitter<PermissionSelectorEvent> for PermissionSelector {}
+
+impl PermissionSelector {
+    pub fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
+        let options = Self::options();
+        let default_tier = PermissionTier::default();
+        let dropdown_state =
+            cx.new(|cx| SelectState::new(Vec::<PermissionOption>::new(), None, window, cx));
+
+        dropdown_state.update(cx, |state, cx| {
+            state.set_items(options, window, cx);
+            state.set_selected_value(&default_tier, window, cx);
+        });
+
+        let subscription = cx.subscribe_in(&dropdown_state, window, Self::on_dropdown_event);
+
+        Self {
+            dropdown_state,
+            _subscription: subscription,
+        }
+    }
+
+    fn options() -> Vec<PermissionOption> {
+        vec![
+            PermissionOption::new("Bypass Permissions", PermissionTier::BypassAll),
+            PermissionOption::new("Ask Before Writes", PermissionTier::WriteTools),
+            PermissionOption::new("Ask For All Tools", PermissionTier::AllTools),
+        ]
+    }
+
+    fn on_dropdown_event(
+        &mut self,
+        _: &Entity<SelectState<Vec<PermissionOption>>>,
+        event: &SelectEvent<Vec<PermissionOption>>,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if let SelectEvent::Confirm(Some(tier)) = event {
+            cx.emit(PermissionSelectorEvent::TierChanged { tier: *tier });
+        }
+    }
+
+    pub fn set_tier(&mut self, tier: PermissionTier, window: &mut Window, cx: &mut Context<Self>) {
+        self.dropdown_state.update(cx, |state, cx| {
+            state.set_selected_value(&tier, window, cx);
+        });
+    }
+}
+
+impl Focusable for PermissionSelector {
+    fn focus_handle(&self, cx: &gpui::App) -> gpui::FocusHandle {
+        self.dropdown_state.focus_handle(cx)
+    }
+}
+
+impl Render for PermissionSelector {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        div().text_color(cx.theme().muted_foreground).child(
+            Select::new(&self.dropdown_state)
+                .placeholder("Permissions")
+                .with_size(Size::XSmall)
+                .appearance(false)
+                .icon(
+                    Icon::default()
+                        .path("icons/chevron_up_down.svg")
+                        .with_size(Size::XSmall)
+                        .text_color(cx.theme().muted_foreground),
+                )
+                .min_w(px(130.)),
+        )
+    }
+}

--- a/crates/ui_gpui/src/lib.rs
+++ b/crates/ui_gpui/src/lib.rs
@@ -97,6 +97,14 @@ pub struct Gpui {
     // Current sandbox selection.
     current_sandbox_policy: Arc<Mutex<Option<SandboxPolicy>>>,
 
+    // Current permission tier selection.
+    current_permission_tier: Arc<Mutex<Option<tools_core::PermissionTier>>>,
+
+    // Tool permission requests awaiting the user's decision, rendered as a
+    // prompt above the input area. Keyed order = arrival order.
+    pending_permission_requests:
+        Arc<Mutex<Vec<code_assistant_core::session::permissions::ToolPermissionRequestData>>>,
+
     // Current worktree state (branches + worktrees listing from backend)
     current_worktree_data: Arc<Mutex<Option<WorktreeData>>>,
 
@@ -313,6 +321,8 @@ impl Gpui {
         *self.current_model.lock().unwrap() = None;
         *self.allowed_models.lock().unwrap() = None;
         *self.current_sandbox_policy.lock().unwrap() = None;
+        *self.current_permission_tier.lock().unwrap() = None;
+        self.pending_permission_requests.lock().unwrap().clear();
         *self.current_worktree_data.lock().unwrap() = None;
         *self.current_session_last_usage.lock().unwrap() = None;
     }
@@ -396,6 +406,10 @@ impl Gpui {
             allowed_models: Arc::new(Mutex::new(None)),
             // Current sandbox selection.
             current_sandbox_policy: Arc::new(Mutex::new(None)),
+
+            // Current permission tier selection + open permission prompts
+            current_permission_tier: Arc::new(Mutex::new(None)),
+            pending_permission_requests: Arc::new(Mutex::new(Vec::new())),
 
             // Pending message edit state
             pending_edit: Arc::new(Mutex::new(None)),
@@ -690,6 +704,16 @@ impl Gpui {
 
     pub fn get_current_sandbox_policy(&self) -> Option<SandboxPolicy> {
         self.current_sandbox_policy.lock().unwrap().clone()
+    }
+
+    pub fn get_current_permission_tier(&self) -> Option<tools_core::PermissionTier> {
+        *self.current_permission_tier.lock().unwrap()
+    }
+
+    pub fn get_pending_permission_requests(
+        &self,
+    ) -> Vec<code_assistant_core::session::permissions::ToolPermissionRequestData> {
+        self.pending_permission_requests.lock().unwrap().clone()
     }
 
     pub fn get_current_worktree_data(&self) -> Option<WorktreeData> {

--- a/crates/ui_gpui/src/main_screen/mod.rs
+++ b/crates/ui_gpui/src/main_screen/mod.rs
@@ -528,6 +528,14 @@ impl MainScreen {
                     gpui.cmd_change_sandbox_policy(session_id.clone(), policy.clone());
                 }
             }
+            InputAreaEvent::PermissionTierChanged { tier } => {
+                if let Some(session_id) = &self.current_session_id {
+                    let gpui = cx
+                        .try_global::<Gpui>()
+                        .expect("Failed to obtain Gpui global");
+                    gpui.cmd_change_permission_tier(session_id.clone(), *tier);
+                }
+            }
             InputAreaEvent::WorktreeSwitchedToLocal => {
                 if let Some(session_id) = &self.current_session_id {
                     let gpui = cx
@@ -872,6 +880,116 @@ impl MainScreen {
         status_popover::render_status_popover(self, cx)
     }
 
+    /// Banner above the input area listing tool permission requests waiting
+    /// for a decision, each with allow-once / always / deny buttons.
+    fn render_permission_prompts(&self, cx: &mut Context<Self>) -> Option<gpui::AnyElement> {
+        use tools_core::PermissionDecision;
+
+        let requests = cx
+            .try_global::<Gpui>()
+            .map(|gpui| gpui.get_pending_permission_requests())
+            .unwrap_or_default();
+        if requests.is_empty() {
+            return None;
+        }
+        let session_id = self.current_session_id.clone()?;
+
+        let respond = |session_id: &str, request_id: &str, decision: PermissionDecision| {
+            let session_id = session_id.to_string();
+            let request_id = request_id.to_string();
+            move |_: &gpui::ClickEvent, _: &mut gpui::Window, cx: &mut gpui::App| {
+                if let Some(gpui) = cx.try_global::<Gpui>() {
+                    gpui.cmd_respond_permission(session_id.clone(), request_id.clone(), decision);
+                }
+            }
+        };
+
+        let button = |id: String, label: &'static str, emphasized: bool, cx: &mut Context<Self>| {
+            div()
+                .id(SharedString::from(id))
+                .px_2()
+                .py_0p5()
+                .rounded_md()
+                .cursor_pointer()
+                .text_xs()
+                .when(emphasized, |this| {
+                    this.bg(cx.theme().primary)
+                        .text_color(cx.theme().primary_foreground)
+                        .hover(|s| s.bg(cx.theme().primary.opacity(0.8)))
+                })
+                .when(!emphasized, |this| {
+                    this.border_1()
+                        .border_color(cx.theme().border)
+                        .text_color(cx.theme().muted_foreground)
+                        .hover(|s| s.bg(cx.theme().muted.opacity(0.5)))
+                })
+                .child(label)
+        };
+
+        Some(
+            div()
+                .flex_none()
+                .border_t_1()
+                .border_color(cx.theme().border)
+                .bg(cx.theme().warning.opacity(0.08))
+                .p_2()
+                .flex()
+                .flex_col()
+                .gap_2()
+                .children(requests.into_iter().map(|request| {
+                    let rid = request.request_id.clone();
+                    div()
+                        .flex()
+                        .flex_row()
+                        .items_center()
+                        .gap_2()
+                        .child(
+                            div()
+                                .flex_1()
+                                .min_w_0()
+                                .flex()
+                                .flex_col()
+                                .child(
+                                    div()
+                                        .text_sm()
+                                        .font_weight(gpui::FontWeight::MEDIUM)
+                                        .text_color(cx.theme().foreground)
+                                        .child(format!(
+                                            "Permission required: {}",
+                                            request.tool_name
+                                        )),
+                                )
+                                .child(
+                                    div()
+                                        .text_xs()
+                                        .text_color(cx.theme().muted_foreground)
+                                        .overflow_hidden()
+                                        .text_ellipsis()
+                                        .child(request.summary.clone()),
+                                ),
+                        )
+                        .child(
+                            button(format!("perm-allow-{rid}"), "Allow once", true, cx).on_click(
+                                respond(&session_id, &rid, PermissionDecision::GrantedOnce),
+                            ),
+                        )
+                        .child(
+                            button(format!("perm-always-{rid}"), "Always (session)", false, cx)
+                                .on_click(respond(
+                                    &session_id,
+                                    &rid,
+                                    PermissionDecision::GrantedSession,
+                                )),
+                        )
+                        .child(
+                            button(format!("perm-deny-{rid}"), "Deny", false, cx)
+                                .on_click(respond(&session_id, &rid, PermissionDecision::Denied)),
+                        )
+                }))
+                .into_any_element(),
+        )
+    }
+
     // Handle session change: load new draft (no need to save current - already saved on every change)
     fn handle_session_change(
         &mut self,
@@ -993,6 +1111,7 @@ impl Render for MainScreen {
             current_model,
             plan_state,
             current_sandbox_policy,
+            current_permission_tier,
             current_worktree_data,
             current_last_usage,
         ) = if let Some(gpui) = cx.try_global::<Gpui>() {
@@ -1003,11 +1122,12 @@ impl Render for MainScreen {
                 gpui.get_current_model(),
                 gpui.get_plan_state(),
                 gpui.get_current_sandbox_policy(),
+                gpui.get_current_permission_tier(),
                 gpui.get_current_worktree_data(),
                 gpui.get_current_session_last_usage(),
             )
         } else {
-            (Vec::new(), None, None, None, None, None, None, None)
+            (Vec::new(), None, None, None, None, None, None, None, None)
         };
 
         // Update project sidebar if needed
@@ -1088,6 +1208,14 @@ impl Render for MainScreen {
             if self.input_area.read(cx).current_sandbox_policy() != policy {
                 self.input_area.update(cx, |input_area, cx| {
                     input_area.set_current_sandbox_policy(policy.clone(), window, cx);
+                });
+            }
+        }
+
+        if let Some(tier) = current_permission_tier {
+            if self.input_area.read(cx).current_permission_tier() != tier {
+                self.input_area.update(cx, |input_area, cx| {
+                    input_area.set_current_permission_tier(tier, window, cx);
                 });
             }
         }
@@ -1185,6 +1313,7 @@ impl Render for MainScreen {
 
         let new_project_dialog = self.new_project_dialog.clone();
         let sidebar_scale = self.sidebar_animation_scale();
+        let permission_prompts = self.render_permission_prompts(cx);
 
         // Main container with titlebar and content
         div()
@@ -1413,6 +1542,8 @@ impl Render for MainScreen {
                             )
                             // Session plan banner (if available)
                             .when(plan_visible, |s| s.child(self.plan_banner.clone()))
+                            // Pending tool permission prompts (if any)
+                            .children(permission_prompts)
                             // Input area sits at the bottom
                             .child(
                                 div()

--- a/crates/ui_terminal/Cargo.toml
+++ b/crates/ui_terminal/Cargo.toml
@@ -9,6 +9,7 @@ agent_core = { path = "../agent_core" }
 command_executor = { path = "../command_executor" }
 llm = { path = "../llm" }
 sandbox = { path = "../sandbox" }
+tools_core = { path = "../tools_core" }
 
 # Terminal UI
 crossterm = { version = "0.28.1", features = ["bracketed-paste", "event-stream"] }

--- a/crates/ui_terminal/src/app.rs
+++ b/crates/ui_terminal/src/app.rs
@@ -467,15 +467,21 @@ async fn handle_command_result(
                 actions.change_permission_tier(session_id, tier);
             }
         }
-        CommandResult::RespondPermission(decision) => {
+        CommandResult::RespondPermission {
+            request_id,
+            decision,
+        } => {
             let (session_id, request_id) = {
                 let state = app_state.lock().await;
                 (
                     state.current_session_id.clone(),
-                    state
-                        .pending_permission_requests
-                        .first()
-                        .map(|r| r.request_id.clone()),
+                    // Slash commands pass no id and answer the oldest request.
+                    request_id.or_else(|| {
+                        state
+                            .pending_permission_requests
+                            .first()
+                            .map(|r| r.request_id.clone())
+                    }),
                 )
             };
             match (session_id, request_id) {
@@ -592,6 +598,11 @@ async fn event_loop(
                 match maybe_event {
                     Some(Ok(event)) => match event {
                         Event::Key(key_event) => {
+                            // Permission prompts push popups from the backend
+                            // event task; resync routing before each key so
+                            // Up/Down/Enter reach an asynchronously opened popup.
+                            input_manager.popup_active =
+                                app_state.lock().await.popup_stack.is_active();
                             let key_result = input_manager.handle_key_event(key_event);
 
                             match key_result {
@@ -803,29 +814,20 @@ async fn event_loop(
                                         actions.change_permission_tier(session_id, tier);
                                     }
                                 }
-                                KeyEventResult::RespondPermission(decision) => {
-                                    let (session_id, request_id) = {
-                                        let state = app_state.lock().await;
-                                        (
-                                            state.current_session_id.clone(),
-                                            state
-                                                .pending_permission_requests
-                                                .first()
-                                                .map(|r| r.request_id.clone()),
-                                        )
-                                    };
-                                    match (session_id, request_id) {
-                                        (Some(session_id), Some(request_id)) => {
-                                            actions.respond_permission(
-                                                session_id, request_id, decision,
-                                            );
-                                        }
-                                        _ => {
-                                            app_state.lock().await.set_info_message(Some(
-                                                "No pending permission request".to_string(),
-                                            ));
-                                        }
-                                    }
+                                KeyEventResult::RespondPermission {
+                                    request_id,
+                                    decision,
+                                } => {
+                                    handle_command_result(
+                                        crate::commands::CommandResult::RespondPermission {
+                                            request_id,
+                                            decision,
+                                        },
+                                        &app_state,
+                                        &renderer,
+                                        &actions,
+                                    )
+                                    .await;
                                 }
 
                                 KeyEventResult::OpenSkillPicker => {
@@ -878,10 +880,18 @@ async fn event_loop(
                                         // Capture root-Esc *before* dispatch so we can also
                                         // delete the leading "/" from the composer when the
                                         // user dismisses the root popup.
+                                        // Permission prompts are not opened by a
+                                        // typed "/", so dismissing one must not
+                                        // eat a leading slash from the composer.
+                                        let top_is_permission_prompt = state
+                                            .popup_stack
+                                            .top()
+                                            .is_some_and(|p| p.permission_request_id().is_some());
                                         let was_root_esc = matches!(
                                             key.code,
                                             crossterm::event::KeyCode::Esc
-                                        ) && state.popup_stack.depth() == 1;
+                                        ) && state.popup_stack.depth() == 1
+                                            && !top_is_permission_prompt;
                                         let depth_before = state.popup_stack.depth();
                                         let result = state.popup_stack.handle_key(key);
                                         let depth_after = state.popup_stack.depth();
@@ -892,6 +902,7 @@ async fn event_loop(
                                             still_active,
                                             depth_before,
                                             depth_after,
+                                            top_is_permission_prompt,
                                         )
                                     };
                                     let (
@@ -900,6 +911,7 @@ async fn event_loop(
                                         still_active,
                                         depth_before,
                                         depth_after,
+                                        top_was_permission_prompt,
                                     ) = outcome;
                                     input_manager.popup_active = still_active;
 
@@ -923,7 +935,11 @@ async fn event_loop(
                                         // The popup committed a final command; clear the
                                         // composer line (the slash word) and dispatch the
                                         // command via the same path as inline /commands.
-                                        clear_slash_command_word(&mut input_manager.textarea);
+                                        // Permission prompts were not opened by a typed
+                                        // "/word", so their commit leaves the composer alone.
+                                        if !top_was_permission_prompt {
+                                            clear_slash_command_word(&mut input_manager.textarea);
+                                        }
                                         handle_command_result(cmd, &app_state, &renderer, &actions)
                                             .await;
                                     }

--- a/crates/ui_terminal/src/app.rs
+++ b/crates/ui_terminal/src/app.rs
@@ -240,6 +240,36 @@ impl Actions {
         });
     }
 
+    fn change_permission_tier(&self, session_id: String, tier: tools_core::PermissionTier) {
+        let this = self.clone();
+        tokio::spawn(async move {
+            if this.refuse_if_view_only().await {
+                return;
+            }
+            if let Err(e) = this.service.change_permission_tier(session_id, tier).await {
+                this.display_error(format!("{e:#}"));
+            }
+        });
+    }
+
+    fn respond_permission(
+        &self,
+        session_id: String,
+        request_id: String,
+        decision: tools_core::PermissionDecision,
+    ) {
+        let this = self.clone();
+        tokio::spawn(async move {
+            if let Err(e) = this
+                .service
+                .respond_permission(session_id, request_id, decision)
+                .await
+            {
+                this.display_error(format!("{e:#}"));
+            }
+        });
+    }
+
     fn invoke_skill(&self, session_id: String, scope: String, name: String) {
         let this = self.clone();
         tokio::spawn(async move {
@@ -420,6 +450,43 @@ async fn handle_command_result(
                         .lock()
                         .await
                         .set_info_message(Some(format!("No skill named '{name}' was found")));
+                }
+            }
+        }
+        CommandResult::ShowPermissionTier => {
+            let mut state = app_state.lock().await;
+            let message = match state.current_permission_tier {
+                Some(tier) => format!("Permission tier: {tier:?}"),
+                None => "No active session".to_string(),
+            };
+            state.set_info_message(Some(message));
+        }
+        CommandResult::SetPermissionTier(tier) => {
+            let session_id = app_state.lock().await.current_session_id.clone();
+            if let Some(session_id) = session_id {
+                actions.change_permission_tier(session_id, tier);
+            }
+        }
+        CommandResult::RespondPermission(decision) => {
+            let (session_id, request_id) = {
+                let state = app_state.lock().await;
+                (
+                    state.current_session_id.clone(),
+                    state
+                        .pending_permission_requests
+                        .first()
+                        .map(|r| r.request_id.clone()),
+                )
+            };
+            match (session_id, request_id) {
+                (Some(session_id), Some(request_id)) => {
+                    actions.respond_permission(session_id, request_id, decision);
+                }
+                _ => {
+                    app_state
+                        .lock()
+                        .await
+                        .set_info_message(Some("No pending permission request".to_string()));
                 }
             }
         }
@@ -716,6 +783,48 @@ async fn event_loop(
                                     };
                                     if let Some(session_id) = current_session_id {
                                         actions.compact_context(session_id);
+                                    }
+                                }
+
+                                KeyEventResult::ShowPermissionTier => {
+                                    let mut state = app_state.lock().await;
+                                    let message = match state.current_permission_tier {
+                                        Some(tier) => format!("Permission tier: {tier:?}"),
+                                        None => "No active session".to_string(),
+                                    };
+                                    state.set_info_message(Some(message));
+                                }
+                                KeyEventResult::SetPermissionTier(tier) => {
+                                    let current_session_id = {
+                                        let state = app_state.lock().await;
+                                        state.current_session_id.clone()
+                                    };
+                                    if let Some(session_id) = current_session_id {
+                                        actions.change_permission_tier(session_id, tier);
+                                    }
+                                }
+                                KeyEventResult::RespondPermission(decision) => {
+                                    let (session_id, request_id) = {
+                                        let state = app_state.lock().await;
+                                        (
+                                            state.current_session_id.clone(),
+                                            state
+                                                .pending_permission_requests
+                                                .first()
+                                                .map(|r| r.request_id.clone()),
+                                        )
+                                    };
+                                    match (session_id, request_id) {
+                                        (Some(session_id), Some(request_id)) => {
+                                            actions.respond_permission(
+                                                session_id, request_id, decision,
+                                            );
+                                        }
+                                        _ => {
+                                            app_state.lock().await.set_info_message(Some(
+                                                "No pending permission request".to_string(),
+                                            ));
+                                        }
                                     }
                                 }
 

--- a/crates/ui_terminal/src/commands.rs
+++ b/crates/ui_terminal/src/commands.rs
@@ -113,8 +113,13 @@ pub enum CommandResult {
     ShowPermissionTier,
     /// Switch the permission tier.
     SetPermissionTier(tools_core::permissions::PermissionTier),
-    /// Answer the oldest pending tool permission request.
-    RespondPermission(tools_core::PermissionDecision),
+    /// Answer a tool permission request. `request_id: None` (slash commands)
+    /// answers the oldest pending request; the permission prompt popup
+    /// carries the id of the request it was opened for.
+    RespondPermission {
+        request_id: Option<String>,
+        decision: tools_core::PermissionDecision,
+    },
 }
 
 /// Process slash commands in terminal UI
@@ -150,13 +155,18 @@ impl CommandProcessor {
             "clear" => CommandResult::ClearContext,
             "compact" => CommandResult::CompactContext,
             "permissions" => Self::process_permissions_command(&parts[1..]),
-            "allow" => {
-                CommandResult::RespondPermission(tools_core::PermissionDecision::GrantedOnce)
-            }
-            "always" => {
-                CommandResult::RespondPermission(tools_core::PermissionDecision::GrantedSession)
-            }
-            "deny" => CommandResult::RespondPermission(tools_core::PermissionDecision::Denied),
+            "allow" => CommandResult::RespondPermission {
+                request_id: None,
+                decision: tools_core::PermissionDecision::GrantedOnce,
+            },
+            "always" => CommandResult::RespondPermission {
+                request_id: None,
+                decision: tools_core::PermissionDecision::GrantedSession,
+            },
+            "deny" => CommandResult::RespondPermission {
+                request_id: None,
+                decision: tools_core::PermissionDecision::Denied,
+            },
             "skill" => {
                 if parts.len() > 1 {
                     CommandResult::InvokeSkill {

--- a/crates/ui_terminal/src/commands.rs
+++ b/crates/ui_terminal/src/commands.rs
@@ -51,6 +51,27 @@ pub fn all_commands() -> &'static [SlashCommand] {
             description: "Summarize and compact the conversation context",
         },
         SlashCommand {
+            name: "permissions",
+            aliases: &[],
+            description:
+                "Show or set the permission tier: /permissions [bypass-all|write-tools|all-tools]",
+        },
+        SlashCommand {
+            name: "allow",
+            aliases: &[],
+            description: "Allow the pending tool permission request once",
+        },
+        SlashCommand {
+            name: "always",
+            aliases: &[],
+            description: "Allow the pending tool permission request for this session",
+        },
+        SlashCommand {
+            name: "deny",
+            aliases: &[],
+            description: "Deny the pending tool permission request",
+        },
+        SlashCommand {
             name: "skill",
             aliases: &[],
             description: "Activate a skill: /skill <name> (or pick from the list)",
@@ -88,6 +109,12 @@ pub enum CommandResult {
     /// `:config:` / `:system:`); `None` means resolve it from the cached
     /// catalog by name.
     InvokeSkill { scope: Option<String>, name: String },
+    /// Show the current permission tier.
+    ShowPermissionTier,
+    /// Switch the permission tier.
+    SetPermissionTier(tools_core::permissions::PermissionTier),
+    /// Answer the oldest pending tool permission request.
+    RespondPermission(tools_core::PermissionDecision),
 }
 
 /// Process slash commands in terminal UI
@@ -122,6 +149,14 @@ impl CommandProcessor {
             "plan" => CommandResult::TogglePlan,
             "clear" => CommandResult::ClearContext,
             "compact" => CommandResult::CompactContext,
+            "permissions" => Self::process_permissions_command(&parts[1..]),
+            "allow" => {
+                CommandResult::RespondPermission(tools_core::PermissionDecision::GrantedOnce)
+            }
+            "always" => {
+                CommandResult::RespondPermission(tools_core::PermissionDecision::GrantedSession)
+            }
+            "deny" => CommandResult::RespondPermission(tools_core::PermissionDecision::Denied),
             "skill" => {
                 if parts.len() > 1 {
                     CommandResult::InvokeSkill {
@@ -150,6 +185,28 @@ impl CommandProcessor {
             CommandResult::InvalidCommand(format!(
                 "Model '{model_name}' not found. Use '/model' to list available models.",
             ))
+        }
+    }
+
+    fn process_permissions_command(args: &[&str]) -> CommandResult {
+        use tools_core::permissions::PermissionTier;
+        match args {
+            [] => CommandResult::ShowPermissionTier,
+            [tier] => match tier.to_lowercase().as_str() {
+                "bypass-all" | "bypass" => {
+                    CommandResult::SetPermissionTier(PermissionTier::BypassAll)
+                }
+                "write-tools" | "write" => {
+                    CommandResult::SetPermissionTier(PermissionTier::WriteTools)
+                }
+                "all-tools" | "all" => CommandResult::SetPermissionTier(PermissionTier::AllTools),
+                other => CommandResult::InvalidCommand(format!(
+                    "Unknown permission tier '{other}'. Use bypass-all, write-tools or all-tools.",
+                )),
+            },
+            _ => CommandResult::InvalidCommand(
+                "Usage: /permissions [bypass-all|write-tools|all-tools]".to_string(),
+            ),
         }
     }
 

--- a/crates/ui_terminal/src/input.rs
+++ b/crates/ui_terminal/src/input.rs
@@ -48,8 +48,11 @@ pub enum KeyEventResult {
     ShowPermissionTier,
     /// Switch the permission tier.
     SetPermissionTier(tools_core::permissions::PermissionTier),
-    /// Answer the oldest pending tool permission request.
-    RespondPermission(tools_core::PermissionDecision),
+    /// Answer a tool permission request (`None` = oldest pending).
+    RespondPermission {
+        request_id: Option<String>,
+        decision: tools_core::PermissionDecision,
+    },
     /// The slash-prefix on the current input line changed.
     ///
     /// `Some("")` means the user just typed `/` (open the popup at root).
@@ -209,9 +212,13 @@ impl InputManager {
                             CommandResult::SetPermissionTier(tier) => {
                                 KeyEventResult::SetPermissionTier(tier)
                             }
-                            CommandResult::RespondPermission(decision) => {
-                                KeyEventResult::RespondPermission(decision)
-                            }
+                            CommandResult::RespondPermission {
+                                request_id,
+                                decision,
+                            } => KeyEventResult::RespondPermission {
+                                request_id,
+                                decision,
+                            },
                             CommandResult::InvalidCommand(error) => {
                                 KeyEventResult::ShowInfo(format!("Error: {error}"))
                             }

--- a/crates/ui_terminal/src/input.rs
+++ b/crates/ui_terminal/src/input.rs
@@ -44,6 +44,12 @@ pub enum KeyEventResult {
     /// Activate a skill. `scope` is the scope token, or `None` to resolve it
     /// from the cached catalog by name.
     InvokeSkill { scope: Option<String>, name: String },
+    /// Show the current permission tier.
+    ShowPermissionTier,
+    /// Switch the permission tier.
+    SetPermissionTier(tools_core::permissions::PermissionTier),
+    /// Answer the oldest pending tool permission request.
+    RespondPermission(tools_core::PermissionDecision),
     /// The slash-prefix on the current input line changed.
     ///
     /// `Some("")` means the user just typed `/` (open the popup at root).
@@ -198,6 +204,13 @@ impl InputManager {
                             CommandResult::OpenSkillPicker => KeyEventResult::OpenSkillPicker,
                             CommandResult::InvokeSkill { scope, name } => {
                                 KeyEventResult::InvokeSkill { scope, name }
+                            }
+                            CommandResult::ShowPermissionTier => KeyEventResult::ShowPermissionTier,
+                            CommandResult::SetPermissionTier(tier) => {
+                                KeyEventResult::SetPermissionTier(tier)
+                            }
+                            CommandResult::RespondPermission(decision) => {
+                                KeyEventResult::RespondPermission(decision)
                             }
                             CommandResult::InvalidCommand(error) => {
                                 KeyEventResult::ShowInfo(format!("Error: {error}"))

--- a/crates/ui_terminal/src/slash_popup/mod.rs
+++ b/crates/ui_terminal/src/slash_popup/mod.rs
@@ -17,10 +17,12 @@
 
 pub mod command_list;
 pub mod model_picker;
+pub mod permission_prompt;
 pub mod skill_picker;
 
 pub use command_list::CommandListPopup;
 pub use model_picker::ModelPickerPopup;
+pub use permission_prompt::PermissionPromptPopup;
 pub use skill_picker::SkillPickerPopup;
 
 use crate::commands::CommandResult;
@@ -93,6 +95,13 @@ pub trait SlashPopup: Send {
 
     /// Activate the currently highlighted row.
     fn activate(&self) -> PopupAction;
+
+    /// For permission prompts: the id of the request this popup answers.
+    /// `None` for all other popups. Lets the stack find/remove the prompt
+    /// when its request resolves elsewhere.
+    fn permission_request_id(&self) -> Option<&str> {
+        None
+    }
 }
 
 /// Stack of nested popups. Empty stack ↔ no popup visible.
@@ -200,6 +209,20 @@ impl PopupStack {
         if let Some(top) = self.top_mut() {
             top.set_query(query);
         }
+    }
+
+    /// Whether a permission prompt is anywhere on the stack.
+    pub fn has_permission_popup(&self) -> bool {
+        self.stack
+            .iter()
+            .any(|p| p.permission_request_id().is_some())
+    }
+
+    /// Remove the permission prompt for the given request id, wherever it
+    /// sits on the stack (the request resolved through another channel).
+    pub fn remove_permission_popup(&mut self, request_id: &str) {
+        self.stack
+            .retain(|p| p.permission_request_id() != Some(request_id));
     }
 }
 

--- a/crates/ui_terminal/src/slash_popup/permission_prompt.rs
+++ b/crates/ui_terminal/src/slash_popup/permission_prompt.rs
@@ -1,0 +1,160 @@
+//! Modal prompt for a tool permission request.
+//!
+//! Unlike the other popups this one is not user-initiated: the app event
+//! layer pushes it when a [`UiEvent::RequestToolPermission`] arrives (one at
+//! a time, oldest first) and removes it when the request resolves. Enter
+//! commits the highlighted decision; Esc closes the popup without answering —
+//! the request stays pending and can still be answered with `/allow`,
+//! `/always` or `/deny`.
+//!
+//! [`UiEvent::RequestToolPermission`]: code_assistant_core::ui::UiEvent::RequestToolPermission
+
+use crate::commands::CommandResult;
+use crate::slash_popup::{PopupAction, PopupRow, SlashPopup};
+use code_assistant_core::session::permissions::ToolPermissionRequestData;
+use tools_core::PermissionDecision;
+
+const DECISIONS: &[(PermissionDecision, &str, &str)] = &[
+    (
+        PermissionDecision::GrantedOnce,
+        "Allow once",
+        "Run this tool call, ask again next time",
+    ),
+    (
+        PermissionDecision::GrantedSession,
+        "Always allow (session)",
+        "Run and stop asking for this tool in this session",
+    ),
+    (
+        PermissionDecision::Denied,
+        "Deny",
+        "Reject the call; the agent is told not to retry",
+    ),
+];
+
+pub struct PermissionPromptPopup {
+    request_id: String,
+    title: String,
+    rows: Vec<PopupRow>,
+    selected: usize,
+}
+
+impl PermissionPromptPopup {
+    pub fn for_request(request: &ToolPermissionRequestData) -> Self {
+        let rows = DECISIONS
+            .iter()
+            .map(|(_, label, description)| PopupRow {
+                label: (*label).to_string(),
+                description: (*description).to_string(),
+                has_submenu: false,
+            })
+            .collect();
+        Self {
+            request_id: request.request_id.clone(),
+            title: format!("Permission required: {}", request.summary),
+            rows,
+            selected: 0,
+        }
+    }
+}
+
+impl SlashPopup for PermissionPromptPopup {
+    fn title(&self) -> &str {
+        &self.title
+    }
+
+    fn set_query(&mut self, _query: &str) {
+        // The user may keep composing a message while the prompt is open;
+        // the typed text is not a filter.
+    }
+
+    fn rows(&self) -> &[PopupRow] {
+        &self.rows
+    }
+
+    fn selected(&self) -> usize {
+        self.selected
+    }
+
+    fn move_selection(&mut self, delta: i32) {
+        let len = self.rows.len() as i32;
+        self.selected = (self.selected as i32 + delta).rem_euclid(len) as usize;
+    }
+
+    fn activate(&self) -> PopupAction {
+        let (decision, ..) = DECISIONS[self.selected];
+        PopupAction::Commit(CommandResult::RespondPermission {
+            request_id: Some(self.request_id.clone()),
+            decision,
+        })
+    }
+
+    fn permission_request_id(&self) -> Option<&str> {
+        Some(&self.request_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::slash_popup::PopupStack;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    fn request(id: &str) -> ToolPermissionRequestData {
+        ToolPermissionRequestData {
+            request_id: id.to_string(),
+            tool_id: Some("tool-1".to_string()),
+            tool_name: "delete_files".to_string(),
+            summary: "Run tool `delete_files`".to_string(),
+            metadata: serde_json::json!({}),
+        }
+    }
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn enter_commits_decision_with_request_id() {
+        let mut stack = PopupStack::new();
+        stack.push(Box::new(PermissionPromptPopup::for_request(&request("r1"))));
+        stack.handle_key(key(KeyCode::Down)); // "Always allow (session)"
+        let result = stack.handle_key(key(KeyCode::Enter));
+        assert!(matches!(
+            result,
+            Some(CommandResult::RespondPermission {
+                ref request_id,
+                decision: PermissionDecision::GrantedSession,
+            }) if request_id.as_deref() == Some("r1")
+        ));
+        assert!(!stack.is_active());
+    }
+
+    #[test]
+    fn esc_closes_without_answering() {
+        let mut stack = PopupStack::new();
+        stack.push(Box::new(PermissionPromptPopup::for_request(&request("r1"))));
+        let result = stack.handle_key(key(KeyCode::Esc));
+        assert!(result.is_none());
+        assert!(!stack.is_active());
+    }
+
+    #[test]
+    fn typed_query_does_not_change_rows() {
+        let mut popup = PermissionPromptPopup::for_request(&request("r1"));
+        popup.set_query("some draft text");
+        assert_eq!(popup.rows().len(), 3);
+    }
+
+    #[test]
+    fn stack_finds_and_removes_permission_popup_by_id() {
+        let mut stack = PopupStack::new();
+        stack.push(Box::new(PermissionPromptPopup::for_request(&request("r1"))));
+        assert!(stack.has_permission_popup());
+        stack.remove_permission_popup("other");
+        assert!(stack.has_permission_popup());
+        stack.remove_permission_popup("r1");
+        assert!(!stack.has_permission_popup());
+        assert!(!stack.is_active());
+    }
+}

--- a/crates/ui_terminal/src/state.rs
+++ b/crates/ui_terminal/src/state.rs
@@ -130,6 +130,25 @@ impl AppState {
             .retain(|r| r.request_id != request_id);
     }
 
+    /// Show the modal prompt for the oldest pending permission request, one
+    /// at a time, and keep the info banner (with the slash-command fallback
+    /// for a dismissed prompt) in sync. No-op while a prompt is already open.
+    pub fn open_next_permission_prompt(&mut self) {
+        let Some(next) = self.pending_permission_requests.first().cloned() else {
+            self.set_info_message(None);
+            return;
+        };
+        self.set_info_message(Some(format!(
+            "Permission required: {} — /allow, /always or /deny",
+            next.summary
+        )));
+        if !self.popup_stack.has_permission_popup() {
+            self.popup_stack.push(Box::new(
+                crate::slash_popup::PermissionPromptPopup::for_request(&next),
+            ));
+        }
+    }
+
     pub fn set_info_message(&mut self, message: Option<String>) {
         self.info_message = message;
     }

--- a/crates/ui_terminal/src/state.rs
+++ b/crates/ui_terminal/src/state.rs
@@ -1,10 +1,12 @@
 use crate::slash_popup::PopupStack;
 use code_assistant_core::persistence::{ChatMetadata, NodeId};
 use code_assistant_core::session::instance::SessionActivityState;
+use code_assistant_core::session::permissions::ToolPermissionRequestData;
 use code_assistant_core::session::service::SkillCatalogEntry;
 use code_assistant_core::types::PlanState;
 use sandbox::SandboxPolicy;
 use std::collections::{HashMap, HashSet};
+use tools_core::permissions::PermissionTier;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OverlayState {
@@ -26,6 +28,10 @@ pub struct AppState {
     pub current_model: Option<String>,
     pub info_message: Option<String>,
     pub current_sandbox_policy: Option<SandboxPolicy>,
+    pub current_permission_tier: Option<PermissionTier>,
+    /// Tool permission requests awaiting a decision (FIFO; `/allow`,
+    /// `/always` and `/deny` answer the oldest).
+    pub pending_permission_requests: Vec<ToolPermissionRequestData>,
     /// Skills available to the current session, cached for the `/skill` picker.
     pub skills: Vec<SkillCatalogEntry>,
     /// Slash-command popup stack. Empty stack ↔ no popup visible.
@@ -53,6 +59,8 @@ impl AppState {
             current_model: None,
             info_message: None,
             current_sandbox_policy: None,
+            current_permission_tier: None,
+            pending_permission_requests: Vec::new(),
             skills: Vec::new(),
             popup_stack: PopupStack::new(),
             seen_node_ids: HashSet::new(),
@@ -101,6 +109,25 @@ impl AppState {
 
     pub fn update_sandbox_policy(&mut self, policy: Option<SandboxPolicy>) {
         self.current_sandbox_policy = policy;
+    }
+
+    pub fn update_permission_tier(&mut self, tier: Option<PermissionTier>) {
+        self.current_permission_tier = tier;
+    }
+
+    pub fn push_permission_request(&mut self, request: ToolPermissionRequestData) {
+        if !self
+            .pending_permission_requests
+            .iter()
+            .any(|r| r.request_id == request.request_id)
+        {
+            self.pending_permission_requests.push(request);
+        }
+    }
+
+    pub fn remove_permission_request(&mut self, request_id: &str) {
+        self.pending_permission_requests
+            .retain(|r| r.request_id != request_id);
     }
 
     pub fn set_info_message(&mut self, message: Option<String>) {

--- a/crates/ui_terminal/src/ui.rs
+++ b/crates/ui_terminal/src/ui.rs
@@ -499,6 +499,32 @@ impl UserInterface for TerminalUI {
                     renderer_guard.clear_error();
                 }
             }
+            UiEvent::UpdatePermissionTier { tier } => {
+                let mut state = self.app_state.lock().await;
+                state.update_permission_tier(Some(tier));
+            }
+            UiEvent::RequestToolPermission { request } => {
+                let mut state = self.app_state.lock().await;
+                let prompt = format!(
+                    "Permission required: {} — respond with /allow, /always or /deny",
+                    request.summary
+                );
+                state.push_permission_request(request);
+                state.set_info_message(Some(prompt));
+            }
+            UiEvent::ToolPermissionRequestResolved { request_id } => {
+                let mut state = self.app_state.lock().await;
+                state.remove_permission_request(&request_id);
+                if state.pending_permission_requests.is_empty() {
+                    state.set_info_message(None);
+                } else if let Some(next) = state.pending_permission_requests.first() {
+                    let prompt = format!(
+                        "Permission required: {} — respond with /allow, /always or /deny",
+                        next.summary
+                    );
+                    state.set_info_message(Some(prompt));
+                }
+            }
             UiEvent::ShowTransientStatus { message } => {
                 debug!("Transient status: {}", message);
                 // In the terminal UI, show as a brief info message via the error strip

--- a/crates/ui_terminal/src/ui.rs
+++ b/crates/ui_terminal/src/ui.rs
@@ -505,25 +505,14 @@ impl UserInterface for TerminalUI {
             }
             UiEvent::RequestToolPermission { request } => {
                 let mut state = self.app_state.lock().await;
-                let prompt = format!(
-                    "Permission required: {} — respond with /allow, /always or /deny",
-                    request.summary
-                );
                 state.push_permission_request(request);
-                state.set_info_message(Some(prompt));
+                state.open_next_permission_prompt();
             }
             UiEvent::ToolPermissionRequestResolved { request_id } => {
                 let mut state = self.app_state.lock().await;
                 state.remove_permission_request(&request_id);
-                if state.pending_permission_requests.is_empty() {
-                    state.set_info_message(None);
-                } else if let Some(next) = state.pending_permission_requests.first() {
-                    let prompt = format!(
-                        "Permission required: {} — respond with /allow, /always or /deny",
-                        next.summary
-                    );
-                    state.set_info_message(Some(prompt));
-                }
+                state.popup_stack.remove_permission_popup(&request_id);
+                state.open_next_permission_prompt();
             }
             UiEvent::ShowTransientStatus { message } => {
                 debug!("Transient status: {}", message);

--- a/docs/permission-tiers.md
+++ b/docs/permission-tiers.md
@@ -47,8 +47,11 @@ an error tool result telling it not to retry.
   requests render as a banner above the input with *Allow once / Always
   (session) / Deny*.
 - **Terminal**: `/permissions [bypass-all|write-tools|all-tools]` shows or
-  switches the tier; requests appear as an info banner and are answered
-  with `/allow`, `/always`, or `/deny` (oldest first).
+  switches the tier. An incoming request opens a modal prompt above the
+  composer (arrow keys + Enter: *Allow once / Always allow (session) /
+  Deny*), one at a time, oldest first. Esc dismisses the prompt without
+  answering; the request stays pending (info banner) and can still be
+  answered with `/allow`, `/always`, or `/deny`.
 - **ACP**: the tiers are advertised as session modes (`bypass-all`,
   `write-tools`, `all-tools`) in `new_session`/`load_session`; clients
   switch via `session/set_mode`. Prompts arrive as native ACP permission

--- a/docs/permission-tiers.md
+++ b/docs/permission-tiers.md
@@ -1,0 +1,58 @@
+# Permission Tiers
+
+Permission tiers decide **when the agent asks the user before running a
+tool**. They are orthogonal to the sandbox: the sandbox constrains what a
+command can touch once it runs, the tier decides whether a tool call runs at
+all without confirmation.
+
+## Tiers
+
+| Tier (serde id) | Behavior |
+|---|---|
+| `bypass-all` (default) | Never ask; every tool call runs without prompting. |
+| `write-tools` | Ask before any tool **not** tagged `read_only` — file edits, command execution, and untagged tools (e.g. MCP tools without a read-only hint) count as writes. |
+| `all-tools` | Ask before every tool call. |
+
+The tier is stored per session in `SessionConfig.permission_tier` and takes
+effect on the next agent run. Answer options on each prompt are **allow
+once**, **always allow this tool for this session**, and **deny**. Session
+grants live on the `SessionInstance` (shared with sub-agents) and survive
+across agent runs but are not persisted. A denial is returned to the LLM as
+an error tool result telling it not to retry.
+
+## Architecture
+
+- **Decision + gate**: `tools_core::permissions` — `PermissionTier`
+  classifies via the `read_only` capability tag; `ToolPermissions`
+  (tier + grant set) runs the gate. `agent_core::AgentRuntime` consults it
+  in both the sequential and the parallel tool-execution path before
+  dispatching a tool.
+- **Prompt transport**: the existing `PermissionMediator` seam. Which
+  mediator is used depends on the frontend:
+  - **GPUI / terminal** (via `SessionService`):
+    `SessionPermissionMediator` publishes
+    `UiEvent::RequestToolPermission` on the broadcast stream and awaits
+    `SessionService::respond_permission`. Open requests are included in
+    session snapshots and resolve as *denied* when the user stops the agent
+    or a new run starts.
+  - **ACP**: `AcpPermissionMediator` uses the protocol's
+    `session/request_permission` RPC.
+- **Escalations stay separate**: `execute_command`'s explicit
+  `ask_user_approval` (sandbox bypass) keeps using the mediator directly,
+  independent of the tier.
+
+## Frontend surfaces
+
+- **GPUI**: "Permissions" dropdown in the input-area selector row; incoming
+  requests render as a banner above the input with *Allow once / Always
+  (session) / Deny*.
+- **Terminal**: `/permissions [bypass-all|write-tools|all-tools]` shows or
+  switches the tier; requests appear as an info banner and are answered
+  with `/allow`, `/always`, or `/deny` (oldest first).
+- **ACP**: the tiers are advertised as session modes (`bypass-all`,
+  `write-tools`, `all-tools`) in `new_session`/`load_session`; clients
+  switch via `session/set_mode`. Prompts arrive as native ACP permission
+  requests.
+- **MCP server / headless**: no mediator is available; under an asking tier
+  a gated tool call is denied with an explanatory error, so keep
+  `bypass-all` there.


### PR DESCRIPTION
Adds a per-session **permission tier** deciding when the agent asks the user before running a tool. Stacked on #<!-- mcp-client-mode --> `feature/mcp-client-mode`.

## Tiers

| Tier | Behavior |
|---|---|
| `bypass-all` (default) | Never ask — matches previous behavior everywhere (incl. MCP server mode / headless, which have no way to prompt). |
| `write-tools` | Ask before any tool **not** tagged `read_only`; untagged tools (e.g. MCP tools without a read-only hint) count as writes. |
| `all-tools` | Ask before every tool call. |

Prompt options everywhere: **allow once / always allow this tool for this session / deny**. A denial returns an error tool result telling the model not to retry. Session grants are shared with sub-agents and survive agent runs (not persisted).

## Architecture

- **`tools_core`**: `PermissionTier` + `ToolPermissions` (tier + grant set) with the gate logic, classified via the existing `read_only` capability tag; new `PermissionRequestReason::ToolInvocation`.
- **`agent_core`**: the loop consults the gate before dispatching a tool, on both the sequential and the parallel execution path.
- **Session layer**: `permission_tier` on `SessionConfig` (mirrors `sandbox_policy`: `SessionService::change_permission_tier` + `UpdatePermissionTier` fan-out + snapshot). New `SessionPermissionMediator` publishes `RequestToolPermission` on the event stream and awaits `respond_permission` — GPUI/terminal get a working `PermissionMediator` for the first time (the service start path previously hard-coded `None`). Open requests ride in snapshots and resolve as denied on stop or a new run.
- **ACP**: tiers advertised as session modes (`session/set_mode` switches them, e.g. from Zed's mode selector); prompts keep using the protocol's native `requestPermission`.
- **GPUI**: "Permissions" dropdown in the selector row; requests render as a banner above the input with the three actions.
- **Terminal**: incoming requests open a modal popup above the composer (arrows + Enter), one at a time, oldest first; Esc dismisses without answering and `/allow` / `/always` / `/deny` remain as fallback. `/permissions [tier]` shows/switches the tier.

The existing `execute_command` sandbox-escape approval stays orthogonal to the tier. Docs: `docs/permission-tiers.md`.

## Testing

- Gate logic unit tests (`tools_core`), agent-loop integration tests with scripted mediator (deny → error result to LLM, read-only skip, session-grant asks once), service-level tests for tier persistence/fan-out and the request/respond roundtrip, popup-stack tests for the terminal prompt.
- `cargo test` (862 green), `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check`.

## Follow-ups (not in this PR)

- Durable "always allow" across sessions (à la Codex execpolicy prefix rules).
- Tier changes apply on the next agent run (same semantics as the sandbox policy).