### PR TITLE
Rebuild the tool registry per agent run (dynamic MCP config)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,8 +82,12 @@ headless binary without gpui.
   `enabled_tools` allowlist, `disabled_tools` denylist; `${ENV_VAR}`
   substitution in `env` values) or programmatically via
   `mcp_client::register_mcp_tools`
-- Servers connect at process start (`tools::default_registry_with_mcp`);
-  config changes need a restart. The gpui settings page ("MCP Servers")
+- The tool registry is rebuilt from the current config at the start of
+  every agent run via the `ToolRegistryProvider` seam
+  (`tools::ConfigToolRegistry`, a fingerprint cache over `tools.json` +
+  `mcp-servers.json`; wired in all three frontends). MCP config changes
+  therefore apply on the next run without a restart; a running agent keeps
+  the registry it started with. The gpui settings page ("MCP Servers")
   edits the file and discovers tools over ephemeral connections
 
 ### Agent Mode

--- a/crates/code_assistant/src/app/gpui.rs
+++ b/crates/code_assistant/src/app/gpui.rs
@@ -31,17 +31,24 @@ pub fn run(config: AgentRunConfig) -> Result<()> {
     let persistence_for_watcher = persistence.clone();
 
     let events = EventStream::new();
-    let multi_session_manager = Arc::new(Mutex::new(SessionManager::new(
+    // Rebuilds the tool registry from the current configuration at the start
+    // of every agent run (connecting configured MCP servers), so settings
+    // edits apply on the next run without restarting the app.
+    let registry_provider = code_assistant_core::tools::ConfigToolRegistry::new();
+    let mut session_manager = SessionManager::new(
         persistence,
         session_config_template,
         config.model.clone(),
         code_assistant_core::tools::default_registry(),
         events.clone(),
-    )));
+    );
+    session_manager.set_tool_registry_provider(registry_provider.as_provider());
+    let multi_session_manager = Arc::new(Mutex::new(session_manager));
     // Connecting configured MCP servers is async; it happens on the backend
     // runtime below (before the service worker starts) so the GUI comes up
     // immediately.
     let manager_for_mcp = multi_session_manager.clone();
+    let registry_provider_for_warm = registry_provider.clone();
 
     // Create the session command service. The GUI gets the handle; the
     // worker runs on the backend tokio runtime below. The GUI consumes the
@@ -67,12 +74,14 @@ pub fn run(config: AgentRunConfig) -> Result<()> {
         let runtime = tokio::runtime::Runtime::new().unwrap();
 
         runtime.block_on(async {
-            // Build the full registry (defaults + configured MCP servers)
-            // and swap it in before the service worker processes its first
-            // command, so every agent sees the MCP tools. Commands the GUI
-            // issues in the meantime queue in the service channel.
-            let registry = code_assistant_core::tools::default_registry_with_mcp().await;
-            manager_for_mcp.lock().await.set_tool_registry(registry);
+            // Pre-warm the registry (connects configured MCP servers) and
+            // swap it in before the service worker processes its first
+            // command, so every agent sees the MCP tools immediately. Later
+            // runs re-consult the provider, so settings edits apply without
+            // restarting the app. Commands the GUI issues in the meantime
+            // queue in the service channel.
+            let warmed = registry_provider_for_warm.current().await;
+            manager_for_mcp.lock().await.set_tool_registry(warmed);
 
             // Wakeup scheduler: lets agents arm timed continuations of their
             // session (schedule_wakeup tool).

--- a/crates/code_assistant_core/src/session/watcher.rs
+++ b/crates/code_assistant_core/src/session/watcher.rs
@@ -112,7 +112,8 @@ impl SessionWatcher {
     }
 
     /// Start a separate watcher for the config directory (providers.json,
-    /// models.json, skills.json) and the skills subtree (SKILL.md files).
+    /// models.json, tools.json, mcp-servers.json, skills.json) and the skills
+    /// subtree (SKILL.md files).
     fn start_config_watcher(
         event_tx: async_channel::Sender<UiEvent>,
         rt: &tokio::runtime::Handle,
@@ -194,12 +195,20 @@ impl SessionWatcher {
 /// Whether a changed file (by name) within the config directory or skills
 /// subtree should trigger a `ConfigChanged` event.
 ///
-/// Covers the provider/model config, the skills toggle (`skills.json`), and
-/// any `SKILL.md` so live edits to skills refresh the UI catalog.
+/// Covers the provider/model config, the tool config (`tools.json`,
+/// `mcp-servers.json`), the skills toggle (`skills.json`), and any `SKILL.md`
+/// so live edits to skills refresh the UI catalog. The agent picks up
+/// tool-config changes on its next run via the registry provider; this event
+/// only keeps the UI in sync.
 fn is_watched_config_change(file_name: &str) -> bool {
     matches!(
         file_name,
-        "providers.json" | "models.json" | "skills.json" | "SKILL.md"
+        "providers.json"
+            | "models.json"
+            | "tools.json"
+            | "mcp-servers.json"
+            | "skills.json"
+            | "SKILL.md"
     )
 }
 
@@ -400,6 +409,8 @@ mod tests {
     fn watched_config_changes_cover_skills() {
         assert!(is_watched_config_change("providers.json"));
         assert!(is_watched_config_change("models.json"));
+        assert!(is_watched_config_change("tools.json"));
+        assert!(is_watched_config_change("mcp-servers.json"));
         assert!(is_watched_config_change("skills.json"));
         assert!(is_watched_config_change("SKILL.md"));
         assert!(!is_watched_config_change("projects.json"));

--- a/crates/code_assistant_core/src/tools/mod.rs
+++ b/crates/code_assistant_core/src/tools/mod.rs
@@ -14,6 +14,9 @@ pub mod mcp;
 pub mod core;
 pub mod impls;
 
+// ToolRegistryProvider that rebuilds the registry from the current config
+pub mod registry_provider;
+
 // Application services handed to tools through ToolContext::extensions
 pub mod services;
 
@@ -27,6 +30,7 @@ pub mod scope;
 mod tests;
 
 pub use parse::parse_search_replace_blocks;
+pub use registry_provider::ConfigToolRegistry;
 pub use services::{ToolServices, ToolServicesAccess};
 pub use terminal_interrupts::TerminalInterrupts;
 

--- a/crates/code_assistant_core/src/tools/registry_provider.rs
+++ b/crates/code_assistant_core/src/tools/registry_provider.rs
@@ -1,0 +1,81 @@
+//! A [`ToolRegistryProvider`] that rebuilds code-assistant's tool registry
+//! from the current on-disk configuration (`tools.json` + `mcp-servers.json`).
+//!
+//! The session manager consults this at the start of every agent run, so
+//! configuration edits — e.g. adding an MCP server via the settings page —
+//! take effect on the next run without restarting the process. A fingerprint
+//! cache keeps rebuilding (which reconnects MCP servers) off the common path
+//! where nothing changed: an unchanged configuration returns the same `Arc`,
+//! and the shared registry keeps its MCP connections alive until the last run
+//! using it ends.
+
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+use crate::session::manager::ToolRegistryProvider;
+use crate::tools::config::ToolsConfig;
+use crate::tools::core::ToolRegistry;
+
+struct Cached {
+    fingerprint: String,
+    registry: Arc<ToolRegistry>,
+}
+
+/// Rebuilds the tool registry from disk on demand, caching by a fingerprint of
+/// the tool-relevant configuration files.
+pub struct ConfigToolRegistry {
+    cached: Mutex<Option<Cached>>,
+}
+
+impl ConfigToolRegistry {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            cached: Mutex::new(None),
+        })
+    }
+
+    /// The registry matching the current configuration — the cached one, or a
+    /// freshly built one (reconnecting MCP servers) when `tools.json` or
+    /// `mcp-servers.json` changed since the last call.
+    pub async fn current(&self) -> Arc<ToolRegistry> {
+        let fingerprint = Self::fingerprint();
+        // The lock is held across the (occasional) rebuild so concurrent
+        // callers never build twice; in practice agent runs are serialized by
+        // the session manager, so there is no contention on the common path.
+        let mut cached = self.cached.lock().await;
+        if let Some(entry) = cached.as_ref() {
+            if entry.fingerprint == fingerprint {
+                return entry.registry.clone();
+            }
+            tracing::info!("Tool configuration changed; rebuilding the tool registry");
+        }
+        let registry = crate::tools::default_registry_with_mcp().await;
+        *cached = Some(Cached {
+            fingerprint,
+            registry: registry.clone(),
+        });
+        registry
+    }
+
+    /// The provider closure for
+    /// [`SessionManager::set_tool_registry_provider`](crate::session::manager::SessionManager::set_tool_registry_provider).
+    pub fn as_provider(self: &Arc<Self>) -> ToolRegistryProvider {
+        let this = self.clone();
+        Arc::new(move || {
+            let this = this.clone();
+            Box::pin(async move { this.current().await })
+        })
+    }
+
+    /// Fingerprint of the tool-relevant configuration files, read raw: equal
+    /// fingerprint means equal registry input. Reading the files verbatim
+    /// keeps `${VAR}` references unresolved, so a changed *environment* alone
+    /// does not trigger a rebuild (matching process-startup semantics — the
+    /// value is only re-read when the file itself changes).
+    fn fingerprint() -> String {
+        let read = |path: std::path::PathBuf| std::fs::read_to_string(path).unwrap_or_default();
+        let tools = ToolsConfig::config_path().map(read).unwrap_or_default();
+        let mcp = read(crate::tools::mcp::mcp_servers_config_path());
+        format!("{tools}\u{0}{mcp}")
+    }
+}

--- a/crates/fs_explorer/src/file_updater.rs
+++ b/crates/fs_explorer/src/file_updater.rs
@@ -243,15 +243,13 @@ pub fn reconstruct_formatted_replacements(
         // Normalize the stable content for matching (handle potential whitespace changes)
         let normalized_stable = encoding::normalize_content(&stable_range.content);
 
-        // Find this stable content in the formatted file
-        if let Some(pos) = normalized_formatted[search_start..].find(&normalized_stable) {
-            let absolute_pos = search_start + pos;
-            stable_positions.push((absolute_pos, absolute_pos + normalized_stable.len()));
-            search_start = absolute_pos + normalized_stable.len();
-        } else {
-            // Stable range not found - formatting changed supposedly stable content
-            return None;
-        }
+        // Find this stable content in the formatted file. If a supposedly
+        // stable range is no longer present, formatting changed it and we
+        // cannot safely reconstruct the replacements.
+        let pos = normalized_formatted[search_start..].find(&normalized_stable)?;
+        let absolute_pos = search_start + pos;
+        stable_positions.push((absolute_pos, absolute_pos + normalized_stable.len()));
+        search_start = absolute_pos + normalized_stable.len();
     }
 
     // Now reconstruct the formatted replacements

--- a/crates/ui_acp/src/app.rs
+++ b/crates/ui_acp/src/app.rs
@@ -70,15 +70,21 @@ pub async fn run(verbose: bool, config: AgentRunConfig) -> Result<()> {
     // Create session manager
     let persistence = FileSessionPersistence::new();
     let persistence_for_watcher = FileSessionPersistence::new();
-    let tool_registry = code_assistant_core::tools::default_registry_with_mcp().await;
+    // The registry provider rebuilds the tool set from the current
+    // configuration at the start of every agent run, so settings edits
+    // (e.g. adding an MCP server) apply on the next run without restarting.
+    let registry_provider = code_assistant_core::tools::ConfigToolRegistry::new();
+    let tool_registry = registry_provider.current().await;
     let events = code_assistant_core::session::event_stream::EventStream::new();
-    let session_manager = Arc::new(Mutex::new(SessionManager::new(
+    let mut manager = SessionManager::new(
         persistence,
         session_config_template.clone(),
         model_name.clone(),
         tool_registry.clone(),
         events.clone(),
-    )));
+    );
+    manager.set_tool_registry_provider(registry_provider.as_provider());
+    let session_manager = Arc::new(Mutex::new(manager));
 
     // Channel for session notifications: `ACPUserUI` instances push into the
     // sender; the forwarding task (below) drains and sends to the client.

--- a/crates/ui_terminal/src/app.rs
+++ b/crates/ui_terminal/src/app.rs
@@ -1021,15 +1021,20 @@ impl TerminalTuiApp {
             ..SessionConfig::default()
         };
 
-        // Create session manager
+        // Create session manager. The registry provider rebuilds the tool
+        // set from the current configuration at the start of every agent run,
+        // so settings edits (e.g. adding an MCP server) apply on the next run
+        // without restarting.
         let events = code_assistant_core::session::event_stream::EventStream::new();
-        let session_manager = SessionManager::new(
+        let registry_provider = code_assistant_core::tools::ConfigToolRegistry::new();
+        let mut session_manager = SessionManager::new(
             session_persistence,
             session_config_template,
             config.model.clone(),
-            code_assistant_core::tools::default_registry_with_mcp().await,
+            registry_provider.current().await,
             events.clone(),
         );
+        session_manager.set_tool_registry_provider(registry_provider.as_provider());
         let multi_session_manager = Arc::new(Mutex::new(session_manager));
 
         // Create terminal UI and wrap as UserInterface

--- a/crates/ui_terminal/src/slash_popup/mod.rs
+++ b/crates/ui_terminal/src/slash_popup/mod.rs
@@ -173,10 +173,7 @@ impl PopupStack {
     ///   commit).
     /// - `Some(CommandResult)` — caller should run this command.
     pub fn handle_key(&mut self, key: KeyEvent) -> Option<CommandResult> {
-        let action = match self.top_mut() {
-            Some(top) => top.handle_key(key),
-            None => return None,
-        };
+        let action = self.top_mut()?.handle_key(key);
         self.apply(action)
     }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -93,32 +93,6 @@ code-assistant --list-models
 code-assistant --list-providers
 ```
 
-### Note on Claude Opus 4.7+ extended thinking
-
-Starting with Claude Opus 4.7, Anthropic no longer accepts the manual
-`thinking: { type: "enabled", budget_tokens: N }` form (it returns a 400 error).
-These models require *adaptive* thinking, where depth is controlled via
-`output_config.effort` (`low`, `medium`, `high`, `xhigh`, `max`):
-
-```json
-{
-  "Claude Opus 4.8": {
-    "provider": "anthropic-main",
-    "id": "claude-opus-4-7",
-    "config": {
-      "max_tokens": 64000,
-      "thinking": { "type": "adaptive", "display": "summarized" },
-      "output_config": { "effort": "medium" }
-    }
-  }
-}
-```
-
-code-assistant detects Opus 4.7+ model IDs (`claude-opus-4-7`, `claude-opus-4-8`,
-`claude-opus-latest`) and emits the correct request shape by default. See
-Anthropic's [extended thinking](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking)
-and [effort](https://docs.anthropic.com/en/docs/build-with-claude/effort) docs.
-
 ## Tool settings — `tools.json`
 
 Some tools need external API keys:
@@ -181,8 +155,9 @@ code-assistant can connect to external Model Context Protocol servers and
 register their tools. Configure them via the Settings screen ("MCP Servers") or
 in `~/.config/code-assistant/mcp-servers.json` (per-server `enabled`,
 `enabled_tools` allowlist, `disabled_tools` denylist, and `${ENV_VAR}`
-substitution in `env` values). Servers connect at process start; config changes
-require a restart.
+substitution in `env` values). Configuration changes apply on the next agent
+run — no restart required. A running agent keeps the tool set it started with;
+the next message picks up added, removed or re-configured servers.
 
 ## Advanced CLI options
 

--- a/docs/mcp-client-mode.md
+++ b/docs/mcp-client-mode.md
@@ -125,8 +125,12 @@ What landed (step 2 of the order above, plus code-assistant UI):
   (`Cow`) for runtime-discovered tools.
 - **code-assistant binding** (`code_assistant_core::tools::mcp`):
   `<config_dir>/mcp-servers.json` with `${ENV_VAR}` substitution in `env`
-  values; `tools::default_registry_with_mcp()` for the wiring layers. The
-  registry stays immutable per process — config changes apply on restart.
+  values; `tools::default_registry_with_mcp()` builds the registry. The
+  wiring layers install `tools::ConfigToolRegistry` as the session
+  manager's `ToolRegistryProvider`, which rebuilds the registry (behind a
+  fingerprint cache) at the start of every agent run — so config changes
+  apply on the next run, not only on restart. A running agent keeps the
+  registry it started with.
 - **gpui settings page** ("MCP Servers"): expandable card per server with
   enable switch, add/edit/delete, live tool discovery and per-tool
   toggles persisted to `disabled_tools`.


### PR DESCRIPTION
Configured MCP servers used to connect once at process start, so adding or changing a server in mcp-servers.json only took effect after a restart. The ToolRegistryProvider seam on the SessionManager (consulted at the start of every run) already existed but was not wired into any frontend.

Add a central ConfigToolRegistry: a ToolRegistryProvider that rebuilds the registry from the current tools.json + mcp-servers.json, behind a fingerprint cache so an unchanged configuration returns the same Arc (keeping MCP connections alive and off the per-run path). Reading the files raw keeps ${VAR} references unresolved, so an environment change alone does not trigger a rebuild.

Install it in all three frontends (gpui, terminal, acp) instead of the one-shot registry setup; the gpui backend thread still pre-warms the registry so MCP tools are available immediately. Config changes now apply on the next agent run without a restart; a running agent keeps the registry it started with.

Also watch tools.json and mcp-servers.json in the config file watcher so external edits refresh the settings UI, and update the docs. Drops a redundant Claude Opus 4.7 thinking note from configuration.md (the current model examples already show the adaptive form).