### PR TITLE
ui_gpui: copy markdown source of a text selection (cmd-C/ctrl-C)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2534,7 +2534,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2814,7 +2814,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4537,7 +4537,7 @@ dependencies = [
 [[package]]
 name = "gpui-component"
 version = "0.5.2"
-source = "git+https://github.com/stippi/gpui-component?rev=bc2fabed2f26feb0bdde51978328ae304bcb5726#bc2fabed2f26feb0bdde51978328ae304bcb5726"
+source = "git+https://github.com/stippi/gpui-component?rev=1a66dc72424ae70300aae2ee02b04c4ce4e71d5a#1a66dc72424ae70300aae2ee02b04c4ce4e71d5a"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -4585,7 +4585,7 @@ dependencies = [
 [[package]]
 name = "gpui-component-assets"
 version = "0.5.1"
-source = "git+https://github.com/stippi/gpui-component?rev=bc2fabed2f26feb0bdde51978328ae304bcb5726#bc2fabed2f26feb0bdde51978328ae304bcb5726"
+source = "git+https://github.com/stippi/gpui-component?rev=1a66dc72424ae70300aae2ee02b04c4ce4e71d5a#1a66dc72424ae70300aae2ee02b04c4ce4e71d5a"
 dependencies = [
  "anyhow",
  "gpui",
@@ -4599,7 +4599,7 @@ dependencies = [
 [[package]]
 name = "gpui-component-macros"
 version = "0.5.1"
-source = "git+https://github.com/stippi/gpui-component?rev=bc2fabed2f26feb0bdde51978328ae304bcb5726#bc2fabed2f26feb0bdde51978328ae304bcb5726"
+source = "git+https://github.com/stippi/gpui-component?rev=1a66dc72424ae70300aae2ee02b04c4ce4e71d5a#1a66dc72424ae70300aae2ee02b04c4ce4e71d5a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5322,7 +5322,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -5760,7 +5760,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6826,7 +6826,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8318,7 +8318,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9009,7 +9009,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10422,7 +10422,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10483,7 +10483,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12233,7 +12233,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ ratatui = { git = "https://github.com/nornagon/ratatui", branch = "nornagon-v0.2
 gpui = { git = "https://github.com/zed-industries/zed", rev = "1a246efd7e1b83ab568ec5e3e6c1a43a42e1abba", version = "=0.2.2" }
 gpui_platform = { git = "https://github.com/zed-industries/zed", rev = "1a246efd7e1b83ab568ec5e3e6c1a43a42e1abba" }
 gpui_macros = { git = "https://github.com/zed-industries/zed", rev = "1a246efd7e1b83ab568ec5e3e6c1a43a42e1abba" }
-gpui-component = { git = "https://github.com/stippi/gpui-component", rev = "bc2fabed2f26feb0bdde51978328ae304bcb5726" }
+gpui-component = { git = "https://github.com/stippi/gpui-component", rev = "1a66dc72424ae70300aae2ee02b04c4ce4e71d5a" }

--- a/crates/ui_gpui/src/blocks/mod.rs
+++ b/crates/ui_gpui/src/blocks/mod.rs
@@ -233,7 +233,13 @@ impl BlockView {
 
     fn markdown_view(&mut self, text: &str, selectable: bool, cx: &mut Context<Self>) -> TextView {
         let state = self.markdown_state(text, cx);
-        TextView::new(&state).selectable(selectable)
+        // When selectable, cmd-C / ctrl-C copies the Markdown *source* of the
+        // selection (e.g. `**bold**`, list markers, code fences) rather than the
+        // rendered plain text. The hover copy button already copies full-block
+        // source; this keeps partial-selection copy consistent.
+        TextView::new(&state)
+            .selectable(selectable)
+            .selectable_source(selectable)
     }
 
     /// Whether the copy button should currently render its "copied" checkmark.


### PR DESCRIPTION
Point the gpui-component patch at the fork's markdown-source-copy branch (adds TextView::selectable_source) and enable it for assistant message blocks. Selecting text in a rendered markdown block and pressing cmd-C/ ctrl-C now copies the markdown *source* of the selection (e.g. **bold**, list markers, code fences) instead of the rendered plain text, matching the hover copy button which already copies full-block source.

The fork commit sits on top of the zed pin (pin-zed-1a246efd), so the dependency graph still resolves to a single gpui.