### PR TITLE
feat(mcp): project-local .mcp.json with trust and per-session toggles

### DIFF
--- a/crates/agent_core/src/runtime.rs
+++ b/crates/agent_core/src/runtime.rs
@@ -32,6 +32,10 @@ pub struct AgentRuntimeComponents {
     pub registry: Arc<ToolRegistry>,
     /// Capability tag selecting the tool set within the registry.
     pub tool_capability: String,
+    /// Capability tags whose tools are excluded for this run (e.g. the
+    /// `scope:mcp-<server>` tags of MCP servers the session deactivated).
+    /// A tool carrying any of these is neither offered nor dispatched.
+    pub excluded_tool_capabilities: Vec<String>,
     /// Which tool invocations the stream processors suppress in the UI.
     pub stream_hidden_tools: HiddenTools,
     pub command_executor: Arc<dyn CommandExecutor>,
@@ -66,6 +70,7 @@ pub struct AgentRuntime {
     dialect: Arc<dyn ToolDialect>,
     registry: Arc<ToolRegistry>,
     tool_capability: String,
+    excluded_tool_capabilities: Vec<String>,
     stream_hidden_tools: HiddenTools,
     command_executor: Arc<dyn CommandExecutor>,
     ui: Arc<dyn AgentUi>,
@@ -131,6 +136,7 @@ impl AgentRuntime {
             ui,
             registry,
             tool_capability,
+            excluded_tool_capabilities,
             stream_hidden_tools,
             command_executor,
             permission_handler,
@@ -148,6 +154,7 @@ impl AgentRuntime {
             dialect,
             registry,
             tool_capability,
+            excluded_tool_capabilities,
             stream_hidden_tools,
             command_executor,
             ui,
@@ -680,6 +687,7 @@ impl AgentRuntime {
                 let permissions = self.permissions.clone();
                 let services_provider = self.services_provider.clone();
                 let scope_tag = self.tool_capability.clone();
+                let excluded_capabilities = self.excluded_tool_capabilities.clone();
                 let session_id = self.session_id.clone();
 
                 async move {
@@ -694,6 +702,7 @@ impl AgentRuntime {
                         permissions,
                         services_provider,
                         scope_tag,
+                        excluded_capabilities,
                         session_id,
                     )
                     .await;
@@ -744,6 +753,7 @@ impl AgentRuntime {
         permissions: ToolPermissions,
         services_provider: Arc<dyn ToolServicesProvider>,
         scope_tag: String,
+        excluded_capabilities: Vec<String>,
         session_id: Option<String>,
     ) -> (bool, ToolExecution) {
         let is_hidden = registry.is_tool_hidden(&tool_request.name, &scope_tag);
@@ -766,7 +776,12 @@ impl AgentRuntime {
 
         let invoke_result = match registry.get(&tool_request.name) {
             None => Err(ToolError::UnknownTool(tool_request.name.clone()).into()),
-            Some(_) if !registry.tool_has_capability(&tool_request.name, &scope_tag) => {
+            Some(_)
+                if !registry.tool_has_capability(&tool_request.name, &scope_tag)
+                    || excluded_capabilities
+                        .iter()
+                        .any(|cap| registry.tool_has_capability(&tool_request.name, cap)) =>
+            {
                 Err(anyhow::anyhow!(
                     "Tool '{}' is not available in the current scope",
                     tool_request.name
@@ -1023,7 +1038,10 @@ impl AgentRuntime {
                 Some(to_tool_definitions(
                     self.registry
                         .as_ref()
-                        .get_tool_definitions_with_capability(self.tool_capability.as_str()),
+                        .get_tool_definitions_with_capability_excluding(
+                            self.tool_capability.as_str(),
+                            &self.excluded_tool_capabilities,
+                        ),
                 ))
             } else {
                 None
@@ -1174,7 +1192,10 @@ impl AgentRuntime {
                 Some(to_tool_definitions(
                     self.registry
                         .as_ref()
-                        .get_tool_definitions_with_capability(self.tool_capability.as_str()),
+                        .get_tool_definitions_with_capability_excluding(
+                            self.tool_capability.as_str(),
+                            &self.excluded_tool_capabilities,
+                        ),
                 ))
             } else {
                 None
@@ -1872,6 +1893,11 @@ impl AgentRuntime {
             .registry
             .as_ref()
             .tool_has_capability(&tool_request.name, self.tool_capability.as_str())
+            || self.excluded_tool_capabilities.iter().any(|cap| {
+                self.registry
+                    .as_ref()
+                    .tool_has_capability(&tool_request.name, cap)
+            })
         {
             return Err(anyhow::anyhow!(
                 "Tool '{}' is not available in the current scope",

--- a/crates/code_assistant_core/src/agent/runner.rs
+++ b/crates/code_assistant_core/src/agent/runner.rs
@@ -96,6 +96,13 @@ impl Agent {
 
         let app_state = AgentAppState::new(session_config.clone());
         let tool_capability = app_state.tool_scope.tag().to_string();
+        // MCP servers the session deactivated → their per-server scope tags,
+        // which the runtime excludes from the offered/dispatchable tool set.
+        let excluded_tool_capabilities: Vec<String> = session_config
+            .disabled_mcp_servers
+            .iter()
+            .map(|server| mcp_client::server_scope_capability(server))
+            .collect();
 
         let ui_adapter = Arc::new(AgentUiAdapter::new(ui.clone()));
         // Cloned out before the handle moves into the services provider, so the
@@ -120,6 +127,7 @@ impl Agent {
             stream_hidden_tools: tool_registry.hidden_tools(ToolScope::Agent.tag()),
             registry: tool_registry,
             tool_capability,
+            excluded_tool_capabilities,
             command_executor,
             permission_handler,
             permissions,

--- a/crates/code_assistant_core/src/session/instance.rs
+++ b/crates/code_assistant_core/src/session/instance.rs
@@ -525,6 +525,13 @@ impl SessionInstance {
             allowed_models: Vec::new(),
             sandbox_policy: self.session.config.sandbox_policy.clone(),
             permission_tier: self.session.config.permission_tier,
+            mcp_servers: crate::tools::mcp::session_mcp_servers(
+                self.session
+                    .config
+                    .effective_project_path()
+                    .map(|p| p.as_path()),
+                &self.session.config.disabled_mcp_servers,
+            ),
             pending_permission_requests: self.pending_permission_requests.snapshot(),
         })
     }

--- a/crates/code_assistant_core/src/session/manager.rs
+++ b/crates/code_assistant_core/src/session/manager.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context as _, Result};
 use llm::{ContentBlock, Message};
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::SystemTime;
 use tokio::sync::Mutex;
@@ -19,17 +19,31 @@ use crate::utils::file_utils;
 use command_executor::{CommandExecutor, SandboxedCommandExecutor};
 use llm::LLMProvider;
 use sandbox::SandboxPolicy;
-use tools_core::permissions::PermissionMediator;
+use tools_core::permissions::{
+    PermissionDecision, PermissionMediator, PermissionRequest, PermissionRequestReason,
+};
 use tracing::{debug, error, info, warn};
+
+/// What registry a run needs: the project it operates in, and whether that
+/// project's local `.mcp.json` servers should be included (i.e. the user has
+/// approved them). `Default` — no project, no local MCP — is the global-only
+/// registry used for the process-startup pre-warm.
+#[derive(Debug, Clone, Default)]
+pub struct RegistryRequest {
+    pub project_dir: Option<PathBuf>,
+    pub include_local_mcp: bool,
+}
 
 /// Provides the tool registry for the next agent run. Consulted at the
 /// start of every run, so embedders can rebuild the registry from their
 /// current configuration (e.g. reconnect MCP servers after a settings
-/// change). Within one run the registry stays the one the run started
-/// with; the provider must be cheap when nothing changed (return the
-/// same `Arc`).
+/// change) and scope it to the run's project (see [`RegistryRequest`]).
+/// Within one run the registry stays the one the run started with; the
+/// provider must be cheap when nothing changed (return the same `Arc`).
 pub type ToolRegistryProvider = Arc<
-    dyn Fn() -> futures::future::BoxFuture<'static, Arc<crate::tools::core::ToolRegistry>>
+    dyn Fn(
+            RegistryRequest,
+        ) -> futures::future::BoxFuture<'static, Arc<crate::tools::core::ToolRegistry>>
         + Send
         + Sync,
 >;
@@ -230,14 +244,14 @@ impl SessionManager {
         &self.tool_registry
     }
 
-    /// Pull the current registry from the provider (no-op without one).
+    /// Pull the registry for `req` from the provider (no-op without one).
     /// Session instances follow the swap so their UI rebuilds resolve tool
     /// executions against the same registry the next run uses.
-    async fn refresh_tool_registry(&mut self) {
+    async fn refresh_tool_registry(&mut self, req: RegistryRequest) {
         let Some(provider) = &self.tool_registry_provider else {
             return;
         };
-        let fresh = provider().await;
+        let fresh = provider(req).await;
         if Arc::ptr_eq(&fresh, &self.tool_registry) {
             return;
         }
@@ -245,6 +259,65 @@ impl SessionManager {
         self.tool_registry = fresh.clone();
         for instance in self.active_sessions.values_mut() {
             instance.tool_registry = fresh.clone();
+        }
+    }
+
+    /// Decide whether a run in `project_dir` may load that project's local
+    /// `.mcp.json` servers. Returns `false` when there is no project or no
+    /// `.mcp.json`. An untrusted (or edited) `.mcp.json` is prompted through
+    /// `handler`: "always (this project)" persists the trust across sessions
+    /// (keyed to the file's contents), "load once" allows just this run, and
+    /// denial (or no frontend to ask) skips the local servers. Launching a
+    /// project's MCP servers runs project-supplied commands, so this gate is
+    /// what keeps an untrusted repository from doing that silently.
+    pub async fn resolve_local_mcp_trust(
+        project_dir: Option<&Path>,
+        handler: Option<&dyn PermissionMediator>,
+    ) -> bool {
+        let Some(dir) = project_dir else {
+            return false;
+        };
+        let Ok(content) = std::fs::read_to_string(dir.join(".mcp.json")) else {
+            return false; // no project-local .mcp.json
+        };
+        let fingerprint = crate::tools::mcp_trust::fingerprint(&content);
+        if crate::tools::mcp_trust::is_trusted(dir, &fingerprint) {
+            return true;
+        }
+        let Some(handler) = handler else {
+            warn!(
+                "Project {} has an untrusted .mcp.json but this frontend cannot ask; \
+                 skipping its MCP servers",
+                dir.display()
+            );
+            return false;
+        };
+        let server_names = crate::tools::mcp::parse_local_mcp_json(&content)
+            .map(|cfg| cfg.servers.into_keys().collect::<Vec<_>>())
+            .unwrap_or_default();
+        let decision = handler
+            .request_permission(PermissionRequest {
+                tool_id: None,
+                tool_name: ".mcp.json",
+                reason: PermissionRequestReason::TrustLocalMcp {
+                    project_dir: dir,
+                    server_names,
+                },
+            })
+            .await;
+        match decision {
+            Ok(PermissionDecision::GrantedPersistent) => {
+                if let Err(error) = crate::tools::mcp_trust::add_trusted(dir, &fingerprint) {
+                    warn!("Failed to persist .mcp.json trust: {error:#}");
+                }
+                true
+            }
+            Ok(PermissionDecision::GrantedOnce | PermissionDecision::GrantedSession) => true,
+            Ok(PermissionDecision::Denied) => false,
+            Err(error) => {
+                warn!("Trust prompt for .mcp.json failed: {error:#}");
+                false
+            }
         }
     }
 
@@ -704,6 +777,7 @@ impl SessionManager {
         project_manager: Box<dyn ProjectManager>,
         command_executor: Box<dyn CommandExecutor>,
         permission_handler: Option<Arc<dyn PermissionMediator>>,
+        registry_request: RegistryRequest,
     ) -> Result<()> {
         // Add the message first
         self.add_user_message(session_id, content_blocks, branch_parent_id)?;
@@ -717,6 +791,7 @@ impl SessionManager {
             permission_handler,
             None,
             None,
+            registry_request,
         )
         .await
     }
@@ -744,10 +819,15 @@ impl SessionManager {
         permission_handler: Option<Arc<dyn PermissionMediator>>,
         tool_scope_override: Option<crate::tools::core::ToolScope>,
         turn_recorder: Option<Arc<crate::session::turn::TurnRecorder>>,
+        registry_request: RegistryRequest,
     ) -> Result<()> {
-        // A new run is the point where configuration changes take effect:
-        // pull the current registry before anything below binds to it.
-        self.refresh_tool_registry().await;
+        // A new run is the point where configuration changes take effect: pull
+        // the registry the caller resolved for this run (scoped to the
+        // session's project, and to whether its local `.mcp.json` was trusted)
+        // before anything below binds to it. Trust is resolved by the caller —
+        // not here — because prompting must happen without the manager lock
+        // that wraps this call, or the response could never be delivered.
+        self.refresh_tool_registry(registry_request).await;
 
         // Acquire exclusive cross-process agent lock.
         // This prevents another code-assistant instance from running an agent
@@ -1410,6 +1490,40 @@ impl SessionManager {
         Ok(())
     }
 
+    /// Set the MCP servers deactivated for a session (by config name), persist
+    /// it, and update the live instance. Returns the recomputed server list
+    /// (available servers with their per-session enabled state) for the UI.
+    /// Mirrors [`set_session_permission_tier`]; takes effect on the next run
+    /// (tools are bound at run start).
+    ///
+    /// [`set_session_permission_tier`]: Self::set_session_permission_tier
+    pub fn set_session_disabled_mcp_servers(
+        &mut self,
+        session_id: &str,
+        disabled: Vec<String>,
+    ) -> Result<Vec<crate::ui::ui_events::McpServerToggle>> {
+        let mut session = self
+            .persistence
+            .load_chat_session(session_id)?
+            .ok_or_else(|| anyhow::anyhow!("Session not found: {session_id}"))?;
+
+        session.config.disabled_mcp_servers = disabled.clone();
+        self.persistence.save_chat_session(&session)?;
+
+        if let Some(instance) = self.active_sessions.get_mut(session_id) {
+            instance.session.config.disabled_mcp_servers = disabled.clone();
+        }
+
+        let project_dir = session
+            .config
+            .effective_project_path()
+            .map(|p| p.to_path_buf());
+        Ok(crate::tools::mcp::session_mcp_servers(
+            project_dir.as_deref(),
+            &disabled,
+        ))
+    }
+
     /// Build the event-stream permission mediator for a session, used by the
     /// `SessionService`-driven frontends (GPUI, terminal). ACP supplies its
     /// own protocol-level mediator instead.
@@ -2026,10 +2140,120 @@ mod tests {
     fn fixed_registry_provider(
         registry: Arc<crate::tools::core::ToolRegistry>,
     ) -> ToolRegistryProvider {
-        Arc::new(move || {
+        Arc::new(move |_req: RegistryRequest| {
             let registry = registry.clone();
             Box::pin(async move { registry })
         })
+    }
+
+    /// Permission mediator returning a fixed decision and counting prompts.
+    struct CountingMediator {
+        calls: std::sync::atomic::AtomicUsize,
+        decision: PermissionDecision,
+    }
+
+    impl CountingMediator {
+        fn new(decision: PermissionDecision) -> Self {
+            Self {
+                calls: std::sync::atomic::AtomicUsize::new(0),
+                decision,
+            }
+        }
+        fn calls(&self) -> usize {
+            self.calls.load(std::sync::atomic::Ordering::Relaxed)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl PermissionMediator for CountingMediator {
+        async fn request_permission(
+            &self,
+            _request: PermissionRequest<'_>,
+        ) -> Result<PermissionDecision> {
+            self.calls
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            Ok(self.decision)
+        }
+    }
+
+    const LOCAL_MCP: &str = r#"{ "mcpServers": { "srv": { "type": "stdio", "command": "uv" } } }"#;
+
+    #[tokio::test]
+    async fn local_mcp_trust_false_without_project_or_file() {
+        // No project → nothing to load.
+        assert!(!SessionManager::resolve_local_mcp_trust(None, None).await);
+        // Project directory without a `.mcp.json` → nothing to load.
+        let project = TempDir::new().unwrap();
+        assert!(!SessionManager::resolve_local_mcp_trust(Some(project.path()), None).await);
+    }
+
+    #[tokio::test]
+    async fn local_mcp_trust_denied_skips_servers() {
+        let config = TempDir::new().unwrap();
+        let project = TempDir::new().unwrap();
+        std::fs::write(project.path().join(".mcp.json"), LOCAL_MCP).unwrap();
+        let handler = CountingMediator::new(PermissionDecision::Denied);
+        let granted = temp_env::async_with_vars(
+            [("CODE_ASSISTANT_CONFIG_DIR", Some(config.path()))],
+            SessionManager::resolve_local_mcp_trust(Some(project.path()), Some(&handler)),
+        )
+        .await;
+        assert!(!granted, "denied trust must skip the local servers");
+        assert_eq!(handler.calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn local_mcp_trust_persistent_persists_and_stops_prompting() {
+        let config = TempDir::new().unwrap();
+        let project = TempDir::new().unwrap();
+        std::fs::write(project.path().join(".mcp.json"), LOCAL_MCP).unwrap();
+        let handler = CountingMediator::new(PermissionDecision::GrantedPersistent);
+        let (first, second) = temp_env::async_with_vars(
+            [("CODE_ASSISTANT_CONFIG_DIR", Some(config.path()))],
+            async {
+                let first =
+                    SessionManager::resolve_local_mcp_trust(Some(project.path()), Some(&handler))
+                        .await;
+                let second =
+                    SessionManager::resolve_local_mcp_trust(Some(project.path()), Some(&handler))
+                        .await;
+                (first, second)
+            },
+        )
+        .await;
+        assert!(first && second, "granted then trusted-from-store");
+        assert_eq!(
+            handler.calls(),
+            1,
+            "persisted trust means the second run does not re-prompt"
+        );
+    }
+
+    #[tokio::test]
+    async fn local_mcp_trust_once_does_not_persist() {
+        let config = TempDir::new().unwrap();
+        let project = TempDir::new().unwrap();
+        std::fs::write(project.path().join(".mcp.json"), LOCAL_MCP).unwrap();
+        let handler = CountingMediator::new(PermissionDecision::GrantedOnce);
+        let (first, second) = temp_env::async_with_vars(
+            [("CODE_ASSISTANT_CONFIG_DIR", Some(config.path()))],
+            async {
+                let first =
+                    SessionManager::resolve_local_mcp_trust(Some(project.path()), Some(&handler))
+                        .await;
+                let second =
+                    SessionManager::resolve_local_mcp_trust(Some(project.path()), Some(&handler))
+                        .await;
+                (first, second)
+            },
+        )
+        .await;
+        assert!(first && second, "each run is allowed once");
+        assert_eq!(
+            handler.calls(),
+            2,
+            "load-once is not remembered, so every run re-prompts"
+        );
     }
 
     /// The provider seam: refreshing swaps the manager's registry and the
@@ -2043,12 +2267,16 @@ mod tests {
         let session_id = manager.create_session(None).expect("create session");
 
         // Without a provider, refreshing changes nothing.
-        manager.refresh_tool_registry().await;
+        manager
+            .refresh_tool_registry(RegistryRequest::default())
+            .await;
         assert!(Arc::ptr_eq(manager.tool_registry(), &initial));
 
         let fresh = crate::tools::test_registry();
         manager.set_tool_registry_provider(fixed_registry_provider(fresh.clone()));
-        manager.refresh_tool_registry().await;
+        manager
+            .refresh_tool_registry(RegistryRequest::default())
+            .await;
 
         assert!(Arc::ptr_eq(manager.tool_registry(), &fresh));
         let instance = manager.get_session(&session_id).expect("instance");
@@ -2080,6 +2308,7 @@ mod tests {
                 project_manager,
                 command_executor,
                 None,
+                RegistryRequest::default(),
             )
             .await
             .expect("start agent");

--- a/crates/code_assistant_core/src/session/mod.rs
+++ b/crates/code_assistant_core/src/session/mod.rs
@@ -51,6 +51,9 @@ pub struct SessionSnapshot {
     pub allowed_models: Vec<String>,
     pub sandbox_policy: SandboxPolicy,
     pub permission_tier: PermissionTier,
+    /// MCP servers available to this session and whether each is enabled for
+    /// it (global `mcp-servers.json` plus the project's trusted `.mcp.json`).
+    pub mcp_servers: Vec<crate::ui::ui_events::McpServerToggle>,
     /// Permission requests still awaiting an answer; a connecting frontend
     /// should render prompts for them.
     pub pending_permission_requests: Vec<permissions::ToolPermissionRequestData>,
@@ -99,6 +102,9 @@ impl SessionSnapshot {
         events.push(UiEvent::UpdatePermissionTier {
             tier: self.permission_tier,
         });
+        events.push(UiEvent::UpdateMcpServers {
+            servers: self.mcp_servers.clone(),
+        });
         events.push(UiEvent::UpdateAllowedModels {
             models: self.allowed_models.clone(),
         });
@@ -133,6 +139,14 @@ pub struct SessionConfig {
     /// The git branch name associated with this session (e.g. `feature/login`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub branch: Option<String>,
+    /// MCP servers deactivated for this session (by config name). Their tools
+    /// are not offered to or callable by this session's agent, without
+    /// affecting other sessions. This filters the *tool set* only — the server
+    /// is still launched when the shared registry is built (registries span
+    /// sessions), so disabling here hides a server's tools rather than
+    /// preventing its process from starting. Empty by default.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub disabled_mcp_servers: Vec<String>,
 }
 
 fn default_tool_syntax() -> ToolSyntax {
@@ -150,6 +164,7 @@ impl Default for SessionConfig {
             permission_tier: PermissionTier::default(),
             worktree_path: None,
             branch: None,
+            disabled_mcp_servers: Vec::new(),
         }
     }
 }

--- a/crates/code_assistant_core/src/session/permissions.rs
+++ b/crates/code_assistant_core/src/session/permissions.rs
@@ -11,7 +11,78 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::sync::oneshot;
-use tools_core::permissions::{PermissionDecision, PermissionMediator, PermissionRequest};
+use tools_core::permissions::{
+    PermissionDecision, PermissionMediator, PermissionRequest, PermissionRequestReason,
+};
+
+/// One selectable answer to a permission request, in display order. The first
+/// option is the recommended/primary action. Frontends render these directly
+/// (label + description) and send back the chosen [`decision`], so they never
+/// hard-code the choices or branch on the request type themselves.
+///
+/// [`decision`]: PermissionOption::decision
+#[derive(Debug, Clone)]
+pub struct PermissionOption {
+    pub decision: PermissionDecision,
+    pub label: String,
+    pub description: String,
+}
+
+impl PermissionOption {
+    fn new(decision: PermissionDecision, label: &str, description: &str) -> Self {
+        Self {
+            decision,
+            label: label.to_string(),
+            description: description.to_string(),
+        }
+    }
+}
+
+/// The choices offered for a given permission request — the single source of
+/// truth shared by every frontend, so labels and semantics stay consistent.
+///
+/// The local-`.mcp.json` trust prompt is durable: its "always" persists the
+/// project across sessions ([`PermissionDecision::GrantedPersistent`]), unlike
+/// the per-session grant offered for ordinary tool prompts.
+pub fn permission_options_for(reason: &PermissionRequestReason<'_>) -> Vec<PermissionOption> {
+    match reason {
+        PermissionRequestReason::TrustLocalMcp { .. } => vec![
+            PermissionOption::new(
+                PermissionDecision::GrantedOnce,
+                "Load once",
+                "Load these servers now; ask again next time",
+            ),
+            PermissionOption::new(
+                PermissionDecision::GrantedPersistent,
+                "Always (this project)",
+                "Trust this project's .mcp.json across sessions",
+            ),
+            PermissionOption::new(
+                PermissionDecision::Denied,
+                "Deny",
+                "Skip these servers; the agent runs without them",
+            ),
+        ],
+        PermissionRequestReason::ExecuteCommand { .. }
+        | PermissionRequestReason::ToolInvocation { .. } => vec![
+            PermissionOption::new(
+                PermissionDecision::GrantedOnce,
+                "Allow once",
+                "Run this call; ask again next time",
+            ),
+            PermissionOption::new(
+                PermissionDecision::GrantedSession,
+                "Always (session)",
+                "Stop asking for this in this session",
+            ),
+            PermissionOption::new(
+                PermissionDecision::Denied,
+                "Deny",
+                "Reject the call; the agent is told not to retry",
+            ),
+        ],
+    }
+}
 
 /// A permission request as shown to frontends. Carried by
 /// [`UiEvent::RequestToolPermission`] and included in session snapshots so a
@@ -28,6 +99,8 @@ pub struct ToolPermissionRequestData {
     pub summary: String,
     /// Structured request details (tool parameters or command line).
     pub metadata: serde_json::Value,
+    /// The answers the user may choose from (see [`permission_options_for`]).
+    pub options: Vec<PermissionOption>,
 }
 
 /// Pending permission requests of one session, keyed by request id.
@@ -121,8 +194,6 @@ impl SessionPermissionMediator {
     }
 
     fn request_data(request: &PermissionRequest<'_>) -> ToolPermissionRequestData {
-        use tools_core::permissions::PermissionRequestReason;
-
         let (summary, metadata) = match &request.reason {
             PermissionRequestReason::ExecuteCommand {
                 command_line,
@@ -145,6 +216,25 @@ impl SessionPermissionMediator {
                     "params": params,
                 }),
             ),
+            PermissionRequestReason::TrustLocalMcp {
+                project_dir,
+                server_names,
+            } => (
+                format!(
+                    "Trust MCP servers from .mcp.json in {}? Launches: {}",
+                    project_dir.display(),
+                    if server_names.is_empty() {
+                        "(none)".to_string()
+                    } else {
+                        server_names.join(", ")
+                    }
+                ),
+                serde_json::json!({
+                    "type": "trust_local_mcp",
+                    "project_dir": project_dir.display().to_string(),
+                    "server_names": server_names,
+                }),
+            ),
         };
 
         ToolPermissionRequestData {
@@ -153,6 +243,7 @@ impl SessionPermissionMediator {
             tool_name: request.tool_name.to_string(),
             summary,
             metadata,
+            options: permission_options_for(&request.reason),
         }
     }
 }
@@ -209,6 +300,7 @@ mod tests {
             tool_name: "edit".to_string(),
             summary: "Run tool `edit`".to_string(),
             metadata: serde_json::json!({}),
+            options: Vec::new(),
         }
     }
 

--- a/crates/code_assistant_core/src/session/service.rs
+++ b/crates/code_assistant_core/src/session/service.rs
@@ -825,6 +825,26 @@ impl SessionService {
         .await
     }
 
+    /// Set the MCP servers deactivated for a session (by config name) and fan
+    /// out the refreshed list. Mirrors [`change_permission_tier`].
+    ///
+    /// [`change_permission_tier`]: Self::change_permission_tier
+    pub async fn set_disabled_mcp_servers(
+        &self,
+        session_id: String,
+        disabled: Vec<String>,
+    ) -> Result<()> {
+        self.call(move |ctx| async move {
+            let servers = {
+                let mut manager = ctx.manager.lock().await;
+                manager.set_session_disabled_mcp_servers(&session_id, disabled)?
+            };
+            ctx.notify_session(&session_id, UiEvent::UpdateMcpServers { servers });
+            Ok(())
+        })
+        .await
+    }
+
     /// Answer a pending tool permission request
     /// ([`UiEvent::RequestToolPermission`]). Unknown request ids are ignored
     /// (the request may have been settled by another view or a stop).
@@ -1453,27 +1473,93 @@ async fn start_agent_impl(
     let project_manager = (ctx.runtime.project_manager_factory)();
     let command_executor = (ctx.runtime.command_executor_factory)(session_id);
 
-    let mut manager = ctx.manager.lock().await;
-    manager
-        .set_session_model_config(session_id, Some(session_config))
-        .context("Failed to persist model config")?;
-    // Permission prompts travel over the event stream to whatever frontend
-    // views this session; the tier decides whether the agent ever asks.
-    let permission_handler = manager.permission_mediator(session_id).ok();
-    manager
-        .start_agent_for_session(
-            session_id,
-            llm_client,
-            project_manager,
-            command_executor,
-            permission_handler,
-            tool_scope_override,
-            turn_recorder,
+    // Resolve local-`.mcp.json` trust, then start the run. The trust prompt is
+    // answered via `respond_permission` — another command on this service's
+    // single-threaded worker — so when a prompt is actually needed we must not
+    // block the worker awaiting it (that would starve the response and hang the
+    // prompt forever). In that case the whole resolve+start runs on a detached
+    // task; the common no-prompt case stays inline and synchronous.
+    let (project_dir, disabled_mcp_servers, permission_handler) = {
+        let manager = ctx.manager.lock().await;
+        let (project_dir, disabled) = manager
+            .get_session(session_id)
+            .map(|instance| {
+                (
+                    instance.session.config.effective_project_path().cloned(),
+                    instance.session.config.disabled_mcp_servers.clone(),
+                )
+            })
+            .unwrap_or((None, Vec::new()));
+        (
+            project_dir,
+            disabled,
+            manager.permission_mediator(session_id).ok(),
         )
-        .await
-        .context("Failed to start agent")?;
-    debug!("Agent started for session {}", session_id);
-    Ok(())
+    };
+    let needs_prompt = project_dir
+        .as_deref()
+        .is_some_and(crate::tools::mcp_trust::needs_prompt);
+
+    let events = ctx.events.clone();
+    let ctx = ctx.clone();
+    let session_id = session_id.to_string();
+    let err_session_id = session_id.clone();
+    let run = async move {
+        let include_local_mcp = SessionManager::resolve_local_mcp_trust(
+            project_dir.as_deref(),
+            permission_handler.as_deref(),
+        )
+        .await;
+        // Trust for this project is now resolved; refresh the input-bar MCP
+        // list so a project's `.mcp.json` servers appear once trusted (the
+        // session snapshot was computed before the trust prompt).
+        ctx.notify_session(
+            &session_id,
+            UiEvent::UpdateMcpServers {
+                servers: crate::tools::mcp::session_mcp_servers(
+                    project_dir.as_deref(),
+                    &disabled_mcp_servers,
+                ),
+            },
+        );
+        let registry_request = crate::session::manager::RegistryRequest {
+            project_dir,
+            include_local_mcp,
+        };
+        let mut manager = ctx.manager.lock().await;
+        manager
+            .set_session_model_config(&session_id, Some(session_config))
+            .context("Failed to persist model config")?;
+        manager
+            .start_agent_for_session(
+                &session_id,
+                llm_client,
+                project_manager,
+                command_executor,
+                permission_handler,
+                tool_scope_override,
+                turn_recorder,
+                registry_request,
+            )
+            .await
+            .context("Failed to start agent")?;
+        debug!("Agent started for session {}", session_id);
+        Ok(())
+    };
+
+    if needs_prompt {
+        // Detach so the worker is free to process the prompt's response.
+        tokio::spawn(async move {
+            if let Err(error) = run.await {
+                let message = format!("Failed to start agent: {error:#}");
+                error!("{message}");
+                events.publish_ui(&err_session_id, UiEvent::DisplayError { message });
+            }
+        });
+        Ok(())
+    } else {
+        run.await
+    }
 }
 
 #[cfg(test)]

--- a/crates/code_assistant_core/src/tools/impls/browser.rs
+++ b/crates/code_assistant_core/src/tools/impls/browser.rs
@@ -806,7 +806,9 @@ async fn login_handoff(
                 "User declined the login handoff.",
             ))
         }
-        PermissionDecision::GrantedOnce | PermissionDecision::GrantedSession => {
+        PermissionDecision::GrantedOnce
+        | PermissionDecision::GrantedSession
+        | PermissionDecision::GrantedPersistent => {
             // Swap the visible login window for a headless browser on the same
             // profile, carrying the login across. The agent then browses in the
             // background, and the user can close the login window without killing

--- a/crates/code_assistant_core/src/tools/impls/execute_command.rs
+++ b/crates/code_assistant_core/src/tools/impls/execute_command.rs
@@ -304,7 +304,9 @@ impl Tool for ExecuteCommandTool {
                         "Command execution cancelled: user denied permission"
                     ));
                 }
-                PermissionDecision::GrantedOnce | PermissionDecision::GrantedSession => {
+                PermissionDecision::GrantedOnce
+                | PermissionDecision::GrantedSession
+                | PermissionDecision::GrantedPersistent => {
                     bypass_sandbox = true;
                 }
             }

--- a/crates/code_assistant_core/src/tools/mcp.rs
+++ b/crates/code_assistant_core/src/tools/mcp.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 
 pub use mcp_client::{
     DiscoveredTool, McpServerConfig, McpServerStatus, McpServersConfig, McpTransport,
-    discover_tools,
+    discover_tools, parse_local_mcp_json,
 };
 
 /// Scope tags every MCP tool carries in code-assistant: offered to the main
@@ -69,18 +69,109 @@ pub fn save_mcp_servers_config_to(path: &Path, config: &McpServersConfig) -> Res
         .with_context(|| format!("Failed to write MCP config: {}", path.display()))
 }
 
-/// Connect to all enabled servers from `mcp-servers.json` and register their
-/// enabled tools with code-assistant's scope tags. Failures degrade to log
-/// warnings — a broken MCP setup must not prevent startup.
-pub async fn register_configured_mcp_tools(registry: &mut ToolRegistry) -> Vec<McpServerStatus> {
-    let config = match load_mcp_servers_config() {
+/// Load a project-local `.mcp.json` from `dir`, if present. Returns `None`
+/// when the file does not exist; logs a warning on parse errors rather than
+/// propagating them, so a malformed local file degrades gracefully.
+pub fn load_local_mcp_json(dir: &Path) -> Option<McpServersConfig> {
+    let path = dir.join(".mcp.json");
+    if !path.exists() {
+        return None;
+    }
+    let content = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!("Failed to read {}: {e}", path.display());
+            return None;
+        }
+    };
+    match parse_local_mcp_json(&content) {
+        Ok(mut config) => {
+            if let Err(e) = config.substitute_env_values(|name| std::env::var(name).ok()) {
+                tracing::warn!("Variable substitution failed in .mcp.json: {e:#}");
+                return None;
+            }
+            Some(config)
+        }
+        Err(e) => {
+            tracing::warn!("Failed to parse {}: {e:#}", path.display());
+            None
+        }
+    }
+}
+
+/// The MCP servers available to a session and whether each is enabled for it.
+/// The list is the global `mcp-servers.json` enabled servers plus, when the
+/// project declares a `.mcp.json`, that file's servers; a name present in
+/// `disabled` is reported as disabled. Read raw (no env substitution) so a
+/// missing secret does not drop a server from the menu.
+///
+/// Listing a project-local server does not depend on trust — the menu shows
+/// what the project offers so the user can manage it. Trust separately gates
+/// whether those servers actually launch (see [`mcp_trust`]).
+///
+/// [`mcp_trust`]: crate::tools::mcp_trust
+pub fn session_mcp_servers(
+    project_dir: Option<&Path>,
+    disabled: &[String],
+) -> Vec<crate::ui::ui_events::McpServerToggle> {
+    use crate::ui::ui_events::McpServerToggle;
+
+    let mut names: Vec<String> = Vec::new();
+    if let Ok(config) = load_mcp_servers_config_raw() {
+        for (name, _) in config.enabled_servers() {
+            names.push(name.clone());
+        }
+    }
+    if let Some(dir) = project_dir
+        && let Ok(content) = std::fs::read_to_string(dir.join(".mcp.json"))
+        && let Ok(local) = parse_local_mcp_json(&content)
+    {
+        for name in local.servers.keys() {
+            names.push(name.clone());
+        }
+    }
+    names.sort();
+    names.dedup();
+    names
+        .into_iter()
+        .map(|name| {
+            let enabled = !disabled.iter().any(|d| d == &name);
+            McpServerToggle { name, enabled }
+        })
+        .collect()
+}
+
+/// Connect to all enabled servers from `mcp-servers.json` (plus, when
+/// `local_mcp_dir` is set, the project-local `.mcp.json` in that directory)
+/// and register their enabled tools with code-assistant's scope tags.
+/// Connections are obtained from `pool`, so servers shared with a previous
+/// build (e.g. the global set, unchanged when only a project differs) stay
+/// connected instead of being relaunched. Failures degrade to log warnings —
+/// a broken MCP setup must not prevent startup.
+pub async fn register_configured_mcp_tools_in(
+    registry: &mut ToolRegistry,
+    local_mcp_dir: Option<&Path>,
+    pool: &dyn mcp_client::ConnectionProvider,
+) -> Vec<McpServerStatus> {
+    let mut config = match load_mcp_servers_config() {
         Ok(config) => config,
         Err(error) => {
             tracing::warn!("Not registering MCP tools: {error:#}");
             return Vec::new();
         }
     };
-    let statuses = mcp_client::register_mcp_tools(registry, &config, MCP_TOOL_SCOPES).await;
+    if let Some(dir) = local_mcp_dir
+        && let Some(local) = load_local_mcp_json(dir)
+    {
+        let count = local.servers.len();
+        config.merge(local);
+        tracing::info!(
+            "Merged {count} server(s) from .mcp.json in {}",
+            dir.display()
+        );
+    }
+    let statuses =
+        mcp_client::register_mcp_tools_pooled(registry, &config, MCP_TOOL_SCOPES, pool).await;
     for status in &statuses {
         match &status.result {
             Ok(tools) => tracing::info!(
@@ -126,9 +217,10 @@ mod tests {
         )
         .unwrap();
 
+        let pool = crate::tools::ConfigToolRegistry::new();
         let registry = temp_env::async_with_vars(
             [("CODE_ASSISTANT_CONFIG_DIR", Some(dir.path()))],
-            crate::tools::default_registry_with_mcp(),
+            crate::tools::default_registry_with_mcp(None, false, pool.as_ref()),
         )
         .await;
 
@@ -151,6 +243,64 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let config = load_mcp_servers_config_from(&dir.path().join("mcp-servers.json")).unwrap();
         assert!(config.servers.is_empty());
+    }
+
+    #[test]
+    fn session_mcp_servers_lists_enabled_global_and_marks_disabled() {
+        let config_dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            config_dir.path().join("mcp-servers.json"),
+            r#"{ "servers": {
+                "alpha": { "command": "a" },
+                "beta": { "command": "b" },
+                "off": { "command": "c", "enabled": false }
+            } }"#,
+        )
+        .unwrap();
+        temp_env::with_var("CODE_ASSISTANT_CONFIG_DIR", Some(config_dir.path()), || {
+            let servers = session_mcp_servers(None, &["beta".to_string()]);
+            let by_name: std::collections::HashMap<_, _> = servers
+                .iter()
+                .map(|s| (s.name.as_str(), s.enabled))
+                .collect();
+            assert_eq!(by_name.get("alpha"), Some(&true));
+            assert_eq!(
+                by_name.get("beta"),
+                Some(&false),
+                "session-disabled server is marked off"
+            );
+            assert!(
+                !by_name.contains_key("off"),
+                "globally-disabled server is not listed"
+            );
+        });
+    }
+
+    #[test]
+    fn session_mcp_servers_includes_project_local_declared() {
+        let config_dir = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        std::fs::write(
+            project.path().join(".mcp.json"),
+            r#"{ "mcpServers": { "local": { "type": "stdio", "command": "uv" } } }"#,
+        )
+        .unwrap();
+        temp_env::with_var("CODE_ASSISTANT_CONFIG_DIR", Some(config_dir.path()), || {
+            // A declared project-local server is listed regardless of trust
+            // (trust separately gates whether it launches).
+            let servers = session_mcp_servers(Some(project.path()), &[]);
+            assert!(
+                servers.iter().any(|s| s.name == "local" && s.enabled),
+                "project-declared server is listed and enabled"
+            );
+            // And a project without a .mcp.json contributes nothing local.
+            let empty = tempfile::tempdir().unwrap();
+            assert!(
+                !session_mcp_servers(Some(empty.path()), &[])
+                    .iter()
+                    .any(|s| s.name == "local")
+            );
+        });
     }
 
     #[test]
@@ -206,5 +356,39 @@ mod tests {
         )
         .unwrap();
         assert!(load_mcp_servers_config_from(&path).is_err());
+    }
+
+    #[test]
+    fn load_local_mcp_json_absent_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(load_local_mcp_json(dir.path()).is_none());
+    }
+
+    #[test]
+    fn load_local_mcp_json_parses_and_substitutes() {
+        temp_env::with_var("LOCAL_MCP_SECRET", Some("tok-xyz"), || {
+            let dir = tempfile::tempdir().unwrap();
+            std::fs::write(
+                dir.path().join(".mcp.json"),
+                r#"{ "mcpServers": { "srv": {
+                    "type": "stdio",
+                    "command": "uv",
+                    "env": { "TOKEN": "${LOCAL_MCP_SECRET}" }
+                } } }"#,
+            )
+            .unwrap();
+            let config = load_local_mcp_json(dir.path()).unwrap();
+            let McpTransport::Stdio { env, .. } = &config.servers["srv"].transport else {
+                panic!("expected stdio");
+            };
+            assert_eq!(env["TOKEN"], "tok-xyz");
+        });
+    }
+
+    #[test]
+    fn load_local_mcp_json_malformed_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".mcp.json"), b"not json").unwrap();
+        assert!(load_local_mcp_json(dir.path()).is_none());
     }
 }

--- a/crates/code_assistant_core/src/tools/mcp_trust.rs
+++ b/crates/code_assistant_core/src/tools/mcp_trust.rs
@@ -1,0 +1,123 @@
+//! Persistent per-project trust for project-local `.mcp.json` files.
+//!
+//! Loading a project's `.mcp.json` launches the MCP servers it names — i.e. it
+//! runs commands supplied by the project. To avoid doing that for an untrusted
+//! repository without the user's say-so, the session manager gates it behind a
+//! permission prompt and records the approval here, keyed to the file's
+//! contents. The record lives in `mcp-trust.json` in the config dir; a later
+//! edit to the `.mcp.json` changes its fingerprint and re-prompts.
+
+use crate::config_dir::config_dir;
+use crate::utils::file_utils::atomic_write_json;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+const TRUST_FILE: &str = "mcp-trust.json";
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct TrustStore {
+    /// Absolute project path → md5 fingerprint of the approved `.mcp.json`.
+    #[serde(default)]
+    trusted: BTreeMap<String, String>,
+}
+
+fn trust_path() -> PathBuf {
+    config_dir().join(TRUST_FILE)
+}
+
+fn load() -> TrustStore {
+    let path = trust_path();
+    let Ok(content) = std::fs::read_to_string(&path) else {
+        return TrustStore::default();
+    };
+    serde_json::from_str(&content).unwrap_or_else(|e| {
+        tracing::warn!("Failed to parse {}: {e}", path.display());
+        TrustStore::default()
+    })
+}
+
+fn key(project_dir: &Path) -> String {
+    // Canonicalize so the same project keyed via different spellings (trailing
+    // slash, symlink, `..`) resolves to one trust entry and does not re-prompt.
+    // Falls back to the path as-is when it cannot be canonicalized (e.g. it no
+    // longer exists), preserving the previous behavior in that case.
+    std::fs::canonicalize(project_dir)
+        .unwrap_or_else(|_| project_dir.to_path_buf())
+        .display()
+        .to_string()
+}
+
+/// The change-detection fingerprint of a `.mcp.json`'s contents. Not
+/// cryptographic — only used to notice edits and re-prompt.
+pub fn fingerprint(content: &str) -> String {
+    format!("{:x}", md5::compute(content))
+}
+
+/// Whether `project_dir`'s `.mcp.json`, at the given content fingerprint, has
+/// been approved. An edited file (different fingerprint) is not trusted.
+pub fn is_trusted(project_dir: &Path, fingerprint: &str) -> bool {
+    load()
+        .trusted
+        .get(&key(project_dir))
+        .is_some_and(|approved| approved == fingerprint)
+}
+
+/// Record approval of `project_dir`'s `.mcp.json` at the given fingerprint,
+/// replacing any previous fingerprint recorded for that project.
+pub fn add_trusted(project_dir: &Path, fingerprint: &str) -> anyhow::Result<()> {
+    let mut store = load();
+    store
+        .trusted
+        .insert(key(project_dir), fingerprint.to_string());
+    atomic_write_json(&trust_path(), &store)
+}
+
+/// Whether `project_dir` has a `.mcp.json` that is not yet trusted — i.e.
+/// loading it would require asking the user. Cheap and non-interactive; lets a
+/// caller decide whether trust resolution must run off its critical path
+/// (the interactive prompt must not block a single-threaded command worker).
+pub fn needs_prompt(project_dir: &Path) -> bool {
+    match std::fs::read_to_string(project_dir.join(".mcp.json")) {
+        Ok(content) => !is_trusted(project_dir, &fingerprint(&content)),
+        Err(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trust_round_trip_and_fingerprint_mismatch() {
+        let dir = tempfile::tempdir().unwrap();
+        temp_env::with_var("CODE_ASSISTANT_CONFIG_DIR", Some(dir.path()), || {
+            let project = Path::new("/some/project");
+            let fp_a = fingerprint("servers-a");
+            assert!(!is_trusted(project, &fp_a), "unrecorded project untrusted");
+
+            add_trusted(project, &fp_a).unwrap();
+            assert!(is_trusted(project, &fp_a), "recorded fingerprint trusted");
+
+            // An edited .mcp.json (different fingerprint) is not trusted.
+            let fp_b = fingerprint("servers-b");
+            assert!(!is_trusted(project, &fp_b), "changed contents re-prompt");
+
+            // Re-approving replaces the fingerprint.
+            add_trusted(project, &fp_b).unwrap();
+            assert!(is_trusted(project, &fp_b));
+            assert!(
+                !is_trusted(project, &fp_a),
+                "old fingerprint no longer trusted"
+            );
+        });
+    }
+
+    #[test]
+    fn unknown_project_is_untrusted() {
+        let dir = tempfile::tempdir().unwrap();
+        temp_env::with_var("CODE_ASSISTANT_CONFIG_DIR", Some(dir.path()), || {
+            assert!(!is_trusted(Path::new("/never/approved"), &fingerprint("x")));
+        });
+    }
+}

--- a/crates/code_assistant_core/src/tools/mod.rs
+++ b/crates/code_assistant_core/src/tools/mod.rs
@@ -10,6 +10,9 @@ pub mod config;
 // MCP client mode: mcp-servers.json + registration of MCP server tools
 pub mod mcp;
 
+// Persistent per-project trust for project-local `.mcp.json` files
+pub mod mcp_trust;
+
 // New trait-based tools implementation
 pub mod core;
 pub mod impls;
@@ -50,15 +53,23 @@ pub fn default_registry() -> Arc<ToolRegistry> {
     Arc::new(registry)
 }
 
-/// [`default_registry`] plus the tools of all MCP servers configured in
-/// `mcp-servers.json`. Connecting to the servers is asynchronous (child
-/// processes, initialize handshake), hence the async variant; wiring layers
-/// without a config or without enabled servers pay nothing.
-pub async fn default_registry_with_mcp() -> Arc<ToolRegistry> {
+/// [`default_registry`] plus the tools of the configured MCP servers: the
+/// global `mcp-servers.json` set, and — when `include_local_mcp` is set — the
+/// project-local `.mcp.json` in `project_dir`. Connections are drawn from
+/// `pool` so servers shared with a previous build stay connected rather than
+/// being relaunched. Connecting is asynchronous (child processes, initialize
+/// handshake), hence the async variant; wiring layers without a config or
+/// without enabled servers pay nothing.
+pub async fn default_registry_with_mcp(
+    project_dir: Option<&std::path::Path>,
+    include_local_mcp: bool,
+    pool: &dyn mcp_client::ConnectionProvider,
+) -> Arc<ToolRegistry> {
     let config = ToolsConfig::load().unwrap_or_default();
     let mut registry = ToolRegistry::new();
     register_default_tools(&mut registry, &config);
-    mcp::register_configured_mcp_tools(&mut registry).await;
+    let local_dir = if include_local_mcp { project_dir } else { None };
+    mcp::register_configured_mcp_tools_in(&mut registry, local_dir, pool).await;
     Arc::new(registry)
 }
 

--- a/crates/code_assistant_core/src/tools/registry_provider.rs
+++ b/crates/code_assistant_core/src/tools/registry_provider.rs
@@ -1,20 +1,32 @@
 //! A [`ToolRegistryProvider`] that rebuilds code-assistant's tool registry
-//! from the current on-disk configuration (`tools.json` + `mcp-servers.json`).
+//! from the current on-disk configuration (`tools.json` + `mcp-servers.json`)
+//! and, for the requested project, its trusted `.mcp.json`.
 //!
 //! The session manager consults this at the start of every agent run, so
 //! configuration edits — e.g. adding an MCP server via the settings page —
 //! take effect on the next run without restarting the process. A fingerprint
-//! cache keeps rebuilding (which reconnects MCP servers) off the common path
-//! where nothing changed: an unchanged configuration returns the same `Arc`,
-//! and the shared registry keeps its MCP connections alive until the last run
-//! using it ends.
+//! cache keeps rebuilding off the common path where nothing changed: an
+//! unchanged request returns the same `Arc`.
+//!
+//! MCP connections are pooled separately from the registry cache. The pool is
+//! keyed by server identity (name + transport), so rebuilding the registry for
+//! a different project reuses the still-open global servers instead of
+//! relaunching them — only that project's own `.mcp.json` servers connect anew.
+//! After each rebuild, pooled connections the new build no longer references
+//! (e.g. the previous project's local servers, or a server removed from the
+//! config) are evicted and their child processes shut down, so switching
+//! projects does not leak processes.
 
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-use crate::session::manager::ToolRegistryProvider;
+use crate::session::manager::{RegistryRequest, ToolRegistryProvider};
 use crate::tools::config::ToolsConfig;
 use crate::tools::core::ToolRegistry;
+use anyhow::Result;
+use async_trait::async_trait;
+use mcp_client::{ConnectionProvider, McpServerConfig, McpServerConnection};
 
 struct Cached {
     fingerprint: String,
@@ -22,23 +34,43 @@ struct Cached {
 }
 
 /// Rebuilds the tool registry from disk on demand, caching by a fingerprint of
-/// the tool-relevant configuration files.
+/// the tool-relevant configuration files and the requested project, and
+/// pooling MCP connections across rebuilds.
 pub struct ConfigToolRegistry {
     cached: Mutex<Option<Cached>>,
+    /// Live MCP connections keyed by [`connection_key`], reused across
+    /// rebuilds so shared servers are not relaunched on a project switch.
+    connections: Mutex<HashMap<String, Arc<McpServerConnection>>>,
+    /// Connection keys requested during the in-progress rebuild, used by
+    /// [`Self::evict_unreferenced`] to drop pooled connections the new build no
+    /// longer uses. Only meaningful while a rebuild holds the `cached` lock
+    /// (rebuilds are serialized by it, and `get_or_connect` runs only within
+    /// one), so it is cleared at the start of every rebuild.
+    building_keys: Mutex<HashSet<String>>,
 }
 
 impl ConfigToolRegistry {
     pub fn new() -> Arc<Self> {
         Arc::new(Self {
             cached: Mutex::new(None),
+            connections: Mutex::new(HashMap::new()),
+            building_keys: Mutex::new(HashSet::new()),
         })
     }
 
-    /// The registry matching the current configuration — the cached one, or a
-    /// freshly built one (reconnecting MCP servers) when `tools.json` or
-    /// `mcp-servers.json` changed since the last call.
+    /// The registry for the global configuration only (no project-local
+    /// `.mcp.json`). Used for the process-startup pre-warm before any session
+    /// has selected a project.
     pub async fn current(&self) -> Arc<ToolRegistry> {
-        let fingerprint = Self::fingerprint();
+        self.current_for(RegistryRequest::default()).await
+    }
+
+    /// The registry matching `req` — the cached one, or a freshly built one
+    /// when `tools.json`, `mcp-servers.json`, the project, or its `.mcp.json`
+    /// changed since the last call. Shared MCP servers are reused from the
+    /// connection pool.
+    pub async fn current_for(&self, req: RegistryRequest) -> Arc<ToolRegistry> {
+        let fingerprint = self.fingerprint(&req);
         // The lock is held across the (occasional) rebuild so concurrent
         // callers never build twice; in practice agent runs are serialized by
         // the session manager, so there is no contention on the common path.
@@ -49,7 +81,17 @@ impl ConfigToolRegistry {
             }
             tracing::info!("Tool configuration changed; rebuilding the tool registry");
         }
-        let registry = crate::tools::default_registry_with_mcp().await;
+        // Record which connections this build touches so we can shut down the
+        // ones it no longer uses. Safe to reset here: the `cached` lock we hold
+        // serializes rebuilds, and `get_or_connect` only runs during one.
+        self.building_keys.lock().await.clear();
+        let registry = crate::tools::default_registry_with_mcp(
+            req.project_dir.as_deref(),
+            req.include_local_mcp,
+            self,
+        )
+        .await;
+        self.evict_unreferenced().await;
         *cached = Some(Cached {
             fingerprint,
             registry: registry.clone(),
@@ -57,25 +99,148 @@ impl ConfigToolRegistry {
         registry
     }
 
+    /// Shut down and drop pooled connections that the just-finished rebuild did
+    /// not request (see [`Self::building_keys`]). A connection an in-flight run
+    /// still holds (its registry `Arc` outlives this rebuild) is only removed
+    /// from the pool here — its last owner terminates the child on drop — so we
+    /// never kill a server a running agent is using.
+    async fn evict_unreferenced(&self) {
+        let live = self.building_keys.lock().await.clone();
+        let stale: Vec<(String, Arc<McpServerConnection>)> = {
+            let mut connections = self.connections.lock().await;
+            let keys: Vec<String> = connections
+                .keys()
+                .filter(|key| !live.contains(*key))
+                .cloned()
+                .collect();
+            keys.into_iter()
+                .filter_map(|key| connections.remove(&key).map(|conn| (key, conn)))
+                .collect()
+        };
+        for (_key, conn) in stale {
+            // Sole owner: terminate the child process explicitly. If still
+            // referenced by a live registry, dropping our pool ref is enough —
+            // the last owner shuts it down when that run ends.
+            if let Ok(conn) = Arc::try_unwrap(conn) {
+                tokio::spawn(async move {
+                    if let Err(error) = conn.shutdown().await {
+                        tracing::warn!("Failed to shut down pooled MCP connection: {error:#}");
+                    }
+                });
+            }
+        }
+    }
+
     /// The provider closure for
     /// [`SessionManager::set_tool_registry_provider`](crate::session::manager::SessionManager::set_tool_registry_provider).
     pub fn as_provider(self: &Arc<Self>) -> ToolRegistryProvider {
         let this = self.clone();
-        Arc::new(move || {
+        Arc::new(move |req: RegistryRequest| {
             let this = this.clone();
-            Box::pin(async move { this.current().await })
+            Box::pin(async move { this.current_for(req).await })
         })
     }
 
-    /// Fingerprint of the tool-relevant configuration files, read raw: equal
-    /// fingerprint means equal registry input. Reading the files verbatim
-    /// keeps `${VAR}` references unresolved, so a changed *environment* alone
-    /// does not trigger a rebuild (matching process-startup semantics — the
-    /// value is only re-read when the file itself changes).
-    fn fingerprint() -> String {
+    /// Fingerprint of the registry inputs for `req`: the tool-relevant config
+    /// files (read raw, so a changed *environment* alone does not trigger a
+    /// rebuild — matching process-startup semantics), the requested project,
+    /// and, when local MCP is included, the project's `.mcp.json` contents (so
+    /// editing it re-prompts and rebuilds).
+    fn fingerprint(&self, req: &RegistryRequest) -> String {
         let read = |path: std::path::PathBuf| std::fs::read_to_string(path).unwrap_or_default();
         let tools = ToolsConfig::config_path().map(read).unwrap_or_default();
         let mcp = read(crate::tools::mcp::mcp_servers_config_path());
-        format!("{tools}\u{0}{mcp}")
+        let project = req
+            .project_dir
+            .as_ref()
+            .map(|p| p.display().to_string())
+            .unwrap_or_default();
+        let local = if req.include_local_mcp {
+            req.project_dir
+                .as_ref()
+                .map(|dir| read(dir.join(".mcp.json")))
+                .unwrap_or_default()
+        } else {
+            String::new()
+        };
+        format!(
+            "{tools}\u{0}{mcp}\u{0}{project}\u{0}{}\u{0}{local}",
+            req.include_local_mcp
+        )
+    }
+}
+
+/// Identity of an MCP server for the connection pool: its name plus its
+/// transport configuration. A changed transport (command, url, headers, …)
+/// yields a different key, so the stale connection is not reused.
+fn connection_key(name: &str, config: &McpServerConfig) -> String {
+    let transport = serde_json::to_string(&config.transport).unwrap_or_default();
+    format!("{name}\u{0}{transport}")
+}
+
+#[async_trait]
+impl ConnectionProvider for ConfigToolRegistry {
+    async fn get_or_connect(
+        &self,
+        name: &str,
+        config: &McpServerConfig,
+    ) -> Result<Arc<McpServerConnection>> {
+        let key = connection_key(name, config);
+        // Mark this server as referenced by the in-progress build so it is not
+        // evicted afterwards.
+        self.building_keys.lock().await.insert(key.clone());
+        if let Some(existing) = self.connections.lock().await.get(&key).cloned() {
+            return Ok(existing);
+        }
+        // Connect outside the lock (slow: process launch / HTTP handshake).
+        let connection = Arc::new(McpServerConnection::connect(name, config).await?);
+        // Re-check under the lock: if another caller connected the same server
+        // meanwhile, keep theirs and drop ours (shut down on drop).
+        let stored = self
+            .connections
+            .lock()
+            .await
+            .entry(key)
+            .or_insert_with(|| connection.clone())
+            .clone();
+        Ok(stored)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mcp_client::McpTransport;
+
+    fn cfg(transport: McpTransport) -> McpServerConfig {
+        McpServerConfig {
+            transport,
+            enabled: true,
+            enabled_tools: None,
+            disabled_tools: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn connection_key_is_stable_and_transport_sensitive() {
+        let stdio = cfg(McpTransport::stdio("uv"));
+        let stdio_again = cfg(McpTransport::stdio("uv"));
+        assert_eq!(
+            connection_key("srv", &stdio),
+            connection_key("srv", &stdio_again),
+            "same name + transport reuses the pooled connection"
+        );
+
+        let http = cfg(McpTransport::http("https://host/mcp"));
+        assert_ne!(
+            connection_key("srv", &stdio),
+            connection_key("srv", &http),
+            "a changed transport must reconnect, not reuse"
+        );
+        assert_ne!(
+            connection_key("srv", &stdio),
+            connection_key("other", &stdio),
+            "the server name distinguishes connections"
+        );
     }
 }

--- a/crates/code_assistant_core/src/ui/ui_events.rs
+++ b/crates/code_assistant_core/src/ui/ui_events.rs
@@ -120,6 +120,18 @@ impl UiEvent {
     }
 }
 
+/// One MCP server offered to a session, with whether it is currently enabled
+/// for that session. Carried by [`UiEvent::UpdateMcpServers`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct McpServerToggle {
+    /// The server's configuration name (its key in `mcp-servers.json` or the
+    /// project's `.mcp.json`).
+    pub name: String,
+    /// Whether the server's tools are offered to this session (i.e. it is not
+    /// in the session's disabled set).
+    pub enabled: bool,
+}
+
 /// Events for UI updates from the agent thread
 #[derive(Debug, Clone)]
 pub enum UiEvent {
@@ -248,6 +260,9 @@ pub enum UiEvent {
     UpdatePermissionTier {
         tier: tools_core::permissions::PermissionTier,
     },
+    /// Update the MCP servers available to the active session and whether each
+    /// is currently enabled for it (see [`McpServerToggle`]).
+    UpdateMcpServers { servers: Vec<McpServerToggle> },
     /// The agent asks the user for permission to run a tool. Answered via
     /// `SessionService::respond_permission`; a
     /// [`UiEvent::ToolPermissionRequestResolved`] follows once settled.

--- a/crates/mcp_client/src/config.rs
+++ b/crates/mcp_client/src/config.rs
@@ -165,6 +165,104 @@ impl McpServerConfig {
     }
 }
 
+/// Deserialisation types for Claude Code's project-local `.mcp.json` format.
+/// The schema differs from our `mcp-servers.json`: the top-level key is
+/// `mcpServers` (not `servers`), and each entry carries an explicit `type`
+/// field (`"stdio"` / `"http"` / `"sse"`).
+mod local_format {
+    use super::*;
+
+    #[derive(Deserialize)]
+    pub(super) struct LocalMcpFile {
+        #[serde(rename = "mcpServers", default)]
+        pub mcp_servers: BTreeMap<String, LocalMcpEntry>,
+    }
+
+    #[derive(Deserialize)]
+    pub(super) struct LocalMcpEntry {
+        #[serde(rename = "type", default)]
+        pub transport_type: Option<String>,
+        // stdio
+        pub command: Option<String>,
+        #[serde(default)]
+        pub args: Vec<String>,
+        #[serde(default)]
+        pub env: HashMap<String, String>,
+        // http / sse
+        pub url: Option<String>,
+        #[serde(default)]
+        pub headers: HashMap<String, String>,
+    }
+
+    impl TryFrom<LocalMcpEntry> for McpTransport {
+        type Error = anyhow::Error;
+
+        fn try_from(e: LocalMcpEntry) -> Result<Self> {
+            let is_http = matches!(
+                e.transport_type.as_deref(),
+                Some("http") | Some("sse") | Some("streamable-http")
+            );
+            // An explicit `"type": "stdio"` forces the stdio transport even if a
+            // stray `url` is present, so a misconfigured entry surfaces a
+            // missing-`command` error rather than being silently reinterpreted
+            // as HTTP. A `url` only *implies* HTTP when no type was given.
+            let is_stdio = matches!(e.transport_type.as_deref(), Some("stdio"));
+            if is_http || (e.url.is_some() && !is_stdio) {
+                let url = e
+                    .url
+                    .ok_or_else(|| anyhow::anyhow!("HTTP server entry is missing 'url'"))?;
+                Ok(McpTransport::Http {
+                    url,
+                    headers: e.headers,
+                })
+            } else {
+                let command = e
+                    .command
+                    .ok_or_else(|| anyhow::anyhow!("stdio server entry is missing 'command'"))?;
+                Ok(McpTransport::Stdio {
+                    command,
+                    args: e.args,
+                    env: e.env,
+                })
+            }
+        }
+    }
+}
+
+/// Parse the contents of a `.mcp.json` file (Claude Code's project-local MCP
+/// config format) into an [`McpServersConfig`]. All servers are enabled with
+/// no tool allow- or denylists (the project file carries no such metadata).
+pub fn parse_local_mcp_json(content: &str) -> Result<McpServersConfig> {
+    let file: local_format::LocalMcpFile =
+        serde_json::from_str(content).context("Failed to parse .mcp.json")?;
+    let mut servers = BTreeMap::new();
+    for (name, entry) in file.mcp_servers {
+        let transport = McpTransport::try_from(entry)
+            .with_context(|| format!("Invalid entry for server '{name}' in .mcp.json"))?;
+        servers.insert(
+            name,
+            McpServerConfig {
+                transport,
+                enabled: true,
+                enabled_tools: None,
+                disabled_tools: Vec::new(),
+            },
+        );
+    }
+    Ok(McpServersConfig { servers })
+}
+
+impl McpServersConfig {
+    /// Merge `other` into `self`, with entries from `other` taking precedence
+    /// on name collision. Used to layer a project-local `.mcp.json` on top of
+    /// the global `mcp-servers.json`.
+    pub fn merge(&mut self, other: McpServersConfig) {
+        for (name, server) in other.servers {
+            self.servers.insert(name, server);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -339,5 +437,109 @@ mod tests {
             .map(|(name, _)| name.as_str())
             .collect();
         assert_eq!(names, ["b"]);
+    }
+
+    #[test]
+    fn parse_local_mcp_json_stdio() {
+        let json = r#"{
+            "mcpServers": {
+                "backlog": {
+                    "type": "stdio",
+                    "command": "uv",
+                    "args": ["run", "server.py"],
+                    "env": { "TOKEN": "abc" }
+                }
+            }
+        }"#;
+        let config = parse_local_mcp_json(json).unwrap();
+        assert_eq!(config.servers.len(), 1);
+        let server = &config.servers["backlog"];
+        assert!(server.enabled);
+        assert!(server.enabled_tools.is_none());
+        assert!(server.disabled_tools.is_empty());
+        assert_eq!(
+            server.transport,
+            McpTransport::Stdio {
+                command: "uv".to_string(),
+                args: vec!["run".to_string(), "server.py".to_string()],
+                env: [("TOKEN".to_string(), "abc".to_string())].into(),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_local_mcp_json_http() {
+        let json = r#"{
+            "mcpServers": {
+                "jira": { "type": "http", "url": "https://example.com/mcp" }
+            }
+        }"#;
+        let config = parse_local_mcp_json(json).unwrap();
+        let server = &config.servers["jira"];
+        assert_eq!(
+            server.transport,
+            McpTransport::Http {
+                url: "https://example.com/mcp".to_string(),
+                headers: HashMap::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_local_mcp_json_sse_transport_name() {
+        let json = r#"{
+            "mcpServers": {
+                "old": { "type": "sse", "url": "https://example.com/sse" }
+            }
+        }"#;
+        let config = parse_local_mcp_json(json).unwrap();
+        assert!(config.servers["old"].transport.is_http());
+    }
+
+    #[test]
+    fn parse_local_mcp_json_implicit_http_via_url() {
+        let json = r#"{
+            "mcpServers": {
+                "srv": { "url": "https://example.com/mcp" }
+            }
+        }"#;
+        let config = parse_local_mcp_json(json).unwrap();
+        assert!(config.servers["srv"].transport.is_http());
+    }
+
+    #[test]
+    fn parse_local_mcp_json_empty_mcp_servers() {
+        let config = parse_local_mcp_json(r#"{ "mcpServers": {} }"#).unwrap();
+        assert!(config.servers.is_empty());
+    }
+
+    #[test]
+    fn merge_local_overrides_global() {
+        let mut global: McpServersConfig = serde_json::from_str(
+            r#"{
+            "servers": {
+                "a": { "command": "global-a" },
+                "b": { "command": "global-b" }
+            }
+        }"#,
+        )
+        .unwrap();
+        let local: McpServersConfig = serde_json::from_str(
+            r#"{
+            "servers": { "b": { "command": "local-b" }, "c": { "command": "local-c" } }
+        }"#,
+        )
+        .unwrap();
+        global.merge(local);
+        assert_eq!(global.servers.len(), 3);
+        let McpTransport::Stdio { command, .. } = &global.servers["b"].transport else {
+            panic!("expected stdio");
+        };
+        assert_eq!(command, "local-b", "local should win on collision");
+        assert!(
+            global.servers.contains_key("a"),
+            "global-only entry preserved"
+        );
+        assert!(global.servers.contains_key("c"), "local-only entry added");
     }
 }

--- a/crates/mcp_client/src/lib.rs
+++ b/crates/mcp_client/src/lib.rs
@@ -17,8 +17,12 @@ pub mod tool;
 mod tests;
 
 pub use client::McpServerConnection;
-pub use config::{McpServerConfig, McpServersConfig, McpTransport, substitute_variables};
+pub use config::{
+    McpServerConfig, McpServersConfig, McpTransport, parse_local_mcp_json, substitute_variables,
+};
 pub use registry::{
-    DiscoveredTool, MCP_CAPABILITY, McpServerStatus, discover_tools, register_mcp_tools,
+    ConnectionProvider, DiscoveredTool, MCP_CAPABILITY, McpServerStatus, discover_tools,
+    register_connection_tools, register_mcp_tools, register_mcp_tools_pooled,
+    server_scope_capability,
 };
 pub use tool::McpTool;

--- a/crates/mcp_client/src/registry.rs
+++ b/crates/mcp_client/src/registry.rs
@@ -9,9 +9,24 @@ use crate::client::McpServerConnection;
 use crate::config::{McpServerConfig, McpServersConfig};
 use crate::tool::McpTool;
 use anyhow::Result;
+use async_trait::async_trait;
 use std::borrow::Cow;
 use std::sync::Arc;
 use tools_core::registry::ToolRegistry;
+
+/// Supplies (and typically caches) live [`McpServerConnection`]s for
+/// [`register_mcp_tools_pooled`]. Implementors return a shared connection —
+/// reusing an already-open one when possible — so registering a server's
+/// tools a second time (e.g. rebuilding the registry for another project)
+/// does not relaunch its child process.
+#[async_trait]
+pub trait ConnectionProvider: Send + Sync {
+    async fn get_or_connect(
+        &self,
+        name: &str,
+        config: &McpServerConfig,
+    ) -> Result<Arc<McpServerConnection>>;
+}
 
 /// Capability tag carried by every MCP-backed tool.
 pub const MCP_CAPABILITY: &str = "mcp";
@@ -50,6 +65,32 @@ pub async fn register_mcp_tools(
                 extra_capabilities,
             )
             .await
+        }
+        .await;
+        statuses.push(McpServerStatus {
+            server: name.clone(),
+            result: result.map_err(|error| format!("{error:#}")),
+        });
+    }
+    statuses
+}
+
+/// Like [`register_mcp_tools`], but obtains each server's connection from a
+/// [`ConnectionProvider`] instead of always connecting fresh. Lets an embedder
+/// pool connections across registry rebuilds so servers shared between builds
+/// (e.g. the global `mcp-servers.json` set, unchanged when only a project's
+/// local config differs) stay connected rather than being relaunched.
+pub async fn register_mcp_tools_pooled(
+    registry: &mut ToolRegistry,
+    config: &McpServersConfig,
+    extra_capabilities: &[&'static str],
+    provider: &dyn ConnectionProvider,
+) -> Vec<McpServerStatus> {
+    let mut statuses = Vec::new();
+    for (name, server_config) in config.enabled_servers() {
+        let result = async {
+            let connection = provider.get_or_connect(name, server_config).await?;
+            register_connection_tools(registry, connection, server_config, extra_capabilities).await
         }
         .await;
         statuses.push(McpServerStatus {

--- a/crates/tools_core/src/permissions.rs
+++ b/crates/tools_core/src/permissions.rs
@@ -107,7 +107,7 @@ impl ToolPermissions {
             .await?;
         match decision {
             PermissionDecision::GrantedOnce => Ok(()),
-            PermissionDecision::GrantedSession => {
+            PermissionDecision::GrantedSession | PermissionDecision::GrantedPersistent => {
                 self.grant(&spec.name);
                 Ok(())
             }
@@ -129,6 +129,13 @@ pub enum PermissionRequestReason<'a> {
     },
     /// Tier-based gate before invoking a tool ([`PermissionTier`]).
     ToolInvocation { params: &'a serde_json::Value },
+    /// Approve loading a project's local `.mcp.json`, which launches the MCP
+    /// servers it defines — i.e. runs project-supplied commands. Not tied to a
+    /// tool invocation; raised before a project's registry is built.
+    TrustLocalMcp {
+        project_dir: &'a Path,
+        server_names: Vec<String>,
+    },
 }
 
 /// Request payload passed to a [`PermissionMediator`].
@@ -141,8 +148,16 @@ pub struct PermissionRequest<'a> {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PermissionDecision {
+    /// Allow this single invocation; ask again next time.
     GrantedOnce,
+    /// Allow for the rest of this session (in-memory grant).
     GrantedSession,
+    /// Allow and remember durably — the embedder persists the approval so it
+    /// survives across sessions and restarts (e.g. trusting a project's local
+    /// `.mcp.json`). Ordinary tier-based tool prompts do not offer this; a
+    /// tool that receives it degrades to a session grant, since there is no
+    /// durable per-tool grant store.
+    GrantedPersistent,
     Denied,
 }
 

--- a/crates/tools_core/src/registry.rs
+++ b/crates/tools_core/src/registry.rs
@@ -80,10 +80,116 @@ impl ToolRegistry {
             })
             .collect()
     }
+
+    /// Like [`Self::get_tool_definitions_with_capability`], but omits tools
+    /// that also carry any capability tag in `excluded`. Used to hide specific
+    /// MCP servers (each tool tagged `scope:mcp-<server>`) from a session
+    /// without mutating the shared registry.
+    pub fn get_tool_definitions_with_capability_excluding(
+        &self,
+        capability: &str,
+        excluded: &[String],
+    ) -> Vec<AnnotatedToolDefinition> {
+        self.tools
+            .values()
+            .filter(|tool| tool.spec().has_capability(capability))
+            .filter(|tool| !excluded.iter().any(|cap| tool.spec().has_capability(cap)))
+            .map(|tool| {
+                let spec = tool.spec();
+                AnnotatedToolDefinition {
+                    name: spec.name.to_string(),
+                    description: spec.description.to_string(),
+                    parameters: spec.parameters_schema.clone(),
+                    annotations: spec.annotations.clone(),
+                }
+            })
+            .collect()
+    }
 }
 
 impl Default for ToolRegistry {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dyn_tool::{AnyOutput, DynTool};
+    use crate::spec::ToolSpec;
+    use crate::tool::ToolContext;
+    use async_trait::async_trait;
+    use serde_json::Value;
+
+    struct FakeTool {
+        name: &'static str,
+        tags: &'static [&'static str],
+    }
+
+    #[async_trait]
+    impl DynTool for FakeTool {
+        fn spec(&self) -> ToolSpec {
+            ToolSpec {
+                name: self.name.into(),
+                description: "test".into(),
+                parameters_schema: serde_json::json!({"type": "object"}),
+                annotations: None,
+                capabilities: ToolSpec::capabilities(self.tags),
+                multiline_params: &[],
+                hidden: false,
+                title_template: None,
+            }
+        }
+        async fn invoke<'a>(
+            &self,
+            _: &mut ToolContext<'a>,
+            _: &mut Value,
+        ) -> anyhow::Result<Box<dyn AnyOutput>> {
+            unreachable!("not exercised in these tests")
+        }
+        fn deserialize_output(&self, _: Value) -> anyhow::Result<Box<dyn AnyOutput>> {
+            unreachable!("not exercised in these tests")
+        }
+    }
+
+    fn tool(name: &'static str, tags: &'static [&'static str]) -> Box<dyn DynTool> {
+        Box::new(FakeTool { name, tags })
+    }
+
+    #[test]
+    fn excluding_drops_tools_carrying_an_excluded_tag() {
+        let mut registry = ToolRegistry::new();
+        registry.register(tool("mcp__a__x", &["scope:agent", "scope:mcp-a"]));
+        registry.register(tool("mcp__b__y", &["scope:agent", "scope:mcp-b"]));
+        registry.register(tool("edit", &["scope:agent"]));
+
+        assert_eq!(
+            registry
+                .get_tool_definitions_with_capability("scope:agent")
+                .len(),
+            3
+        );
+
+        let filtered = registry
+            .get_tool_definitions_with_capability_excluding("scope:agent", &["scope:mcp-a".into()]);
+        let names: Vec<&str> = filtered.iter().map(|d| d.name.as_str()).collect();
+        assert!(names.contains(&"mcp__b__y"));
+        assert!(names.contains(&"edit"));
+        assert!(
+            !names.contains(&"mcp__a__x"),
+            "the excluded server's tool must be dropped"
+        );
+    }
+
+    #[test]
+    fn excluding_empty_matches_plain_and_respects_capability() {
+        let mut registry = ToolRegistry::new();
+        registry.register(tool("edit", &["scope:agent"]));
+        registry.register(tool("peek", &["scope:subagent"]));
+
+        let filtered = registry.get_tool_definitions_with_capability_excluding("scope:agent", &[]);
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].name, "edit");
     }
 }

--- a/crates/ui_acp/src/agent.rs
+++ b/crates/ui_acp/src/agent.rs
@@ -1057,6 +1057,24 @@ impl AgentState {
 
         // Start agent
         if let Err(e) = async {
+            // Resolve local-`.mcp.json` trust before locking the manager for
+            // the run (the trust prompt is awaited without the lock held).
+            let project_dir = {
+                let manager = self.session_manager.lock().await;
+                manager
+                    .get_session(&arguments.session_id.0)
+                    .and_then(|instance| instance.session.config.effective_project_path().cloned())
+            };
+            let include_local_mcp = SessionManager::resolve_local_mcp_trust(
+                project_dir.as_deref(),
+                permission_handler.as_deref(),
+            )
+            .await;
+            let registry_request = code_assistant_core::session::manager::RegistryRequest {
+                project_dir,
+                include_local_mcp,
+            };
+
             let mut manager = self.session_manager.lock().await;
             manager.set_session_model_config(
                 &arguments.session_id.0,
@@ -1072,6 +1090,7 @@ impl AgentState {
                     project_manager,
                     command_executor,
                     permission_handler,
+                    registry_request,
                 )
                 .await
         }

--- a/crates/ui_acp/src/permissions.rs
+++ b/crates/ui_acp/src/permissions.rs
@@ -8,15 +8,33 @@ use crate::{ACPUserUI, ClientConn};
 use agent_client_protocol::schema as acp;
 use anyhow::{Result, anyhow};
 use async_trait::async_trait;
+use code_assistant_core::session::permissions::permission_options_for;
 use serde_json::json;
 use std::sync::{
     Arc,
     atomic::{AtomicBool, Ordering},
 };
 
-const ALLOW_ALWAYS_OPTION_ID: &str = "allow-always";
-const ALLOW_OPTION_ID: &str = "allow-once";
-const DENY_OPTION_ID: &str = "deny-once";
+/// Stable option id for a decision, round-tripped through the ACP protocol.
+fn option_id(decision: PermissionDecision) -> &'static str {
+    match decision {
+        PermissionDecision::GrantedOnce => "granted-once",
+        PermissionDecision::GrantedSession => "granted-session",
+        PermissionDecision::GrantedPersistent => "granted-persistent",
+        PermissionDecision::Denied => "denied",
+    }
+}
+
+/// The ACP option kind that renders each decision appropriately.
+fn option_kind(decision: PermissionDecision) -> acp::PermissionOptionKind {
+    match decision {
+        PermissionDecision::GrantedOnce => acp::PermissionOptionKind::AllowOnce,
+        PermissionDecision::GrantedSession | PermissionDecision::GrantedPersistent => {
+            acp::PermissionOptionKind::AllowAlways
+        }
+        PermissionDecision::Denied => acp::PermissionOptionKind::RejectOnce,
+    }
+}
 
 pub struct AcpPermissionMediator {
     session_id: acp::SessionId,
@@ -81,6 +99,18 @@ impl AcpPermissionMediator {
                     serde_json::to_string_pretty(params).unwrap_or_else(|_| params.to_string())
                 )
             }
+            PermissionRequestReason::TrustLocalMcp {
+                project_dir,
+                server_names,
+            } => format!(
+                "Trust MCP servers from .mcp.json in {}?\nLaunches: {}",
+                project_dir.display(),
+                if server_names.is_empty() {
+                    "(none)".to_string()
+                } else {
+                    server_names.join(", ")
+                }
+            ),
         }
     }
 
@@ -97,6 +127,14 @@ impl AcpPermissionMediator {
             PermissionRequestReason::ToolInvocation { params } => json!({
                 "type": "tool_invocation",
                 "params": params,
+            }),
+            PermissionRequestReason::TrustLocalMcp {
+                project_dir,
+                server_names,
+            } => json!({
+                "type": "trust_local_mcp",
+                "project_dir": project_dir.display().to_string(),
+                "server_names": server_names,
             }),
         }
     }
@@ -117,36 +155,18 @@ impl PermissionMediator for AcpPermissionMediator {
         }
 
         let tool_call = self.tool_call_update(&permission_request);
-        let (allow_always_label, allow_once_label) = match &permission_request.reason {
-            PermissionRequestReason::ExecuteCommand { .. } => (
-                "Always allow in this session".to_string(),
-                "Allow this command".to_string(),
-            ),
-            PermissionRequestReason::ToolInvocation { .. } => (
-                format!(
-                    "Always allow `{}` in this session",
-                    permission_request.tool_name
-                ),
-                "Allow once".to_string(),
-            ),
-        };
-        let options = vec![
-            acp::PermissionOption::new(
-                ALLOW_ALWAYS_OPTION_ID,
-                allow_always_label,
-                acp::PermissionOptionKind::AllowAlways,
-            ),
-            acp::PermissionOption::new(
-                ALLOW_OPTION_ID,
-                allow_once_label,
-                acp::PermissionOptionKind::AllowOnce,
-            ),
-            acp::PermissionOption::new(
-                DENY_OPTION_ID,
-                "Deny",
-                acp::PermissionOptionKind::RejectOnce,
-            ),
-        ];
+        // The choices are the shared source of truth; ACP just renders them
+        // and maps the selection back to a decision.
+        let options = permission_options_for(&permission_request.reason)
+            .into_iter()
+            .map(|option| {
+                acp::PermissionOption::new(
+                    option_id(option.decision),
+                    option.label,
+                    option_kind(option.decision),
+                )
+            })
+            .collect();
 
         let acp_request =
             acp::RequestPermissionRequest::new(self.session_id.clone(), tool_call, options);
@@ -162,37 +182,36 @@ impl PermissionMediator for AcpPermissionMediator {
 
         let decision = match response.outcome {
             acp::RequestPermissionOutcome::Cancelled => PermissionDecision::Denied,
-            acp::RequestPermissionOutcome::Selected(selected)
-                if selected.option_id == acp::PermissionOptionId::from(ALLOW_ALWAYS_OPTION_ID) =>
-            {
-                if matches!(
-                    permission_request.reason,
-                    PermissionRequestReason::ExecuteCommand { .. }
-                ) {
-                    self.allow_execute_command_always
-                        .store(true, Ordering::Relaxed);
-                }
-                PermissionDecision::GrantedSession
-            }
-            acp::RequestPermissionOutcome::Selected(selected)
-                if selected.option_id == acp::PermissionOptionId::from(ALLOW_OPTION_ID) =>
-            {
-                PermissionDecision::GrantedOnce
-            }
-            acp::RequestPermissionOutcome::Selected(selected)
-                if selected.option_id == acp::PermissionOptionId::from(DENY_OPTION_ID) =>
-            {
-                PermissionDecision::Denied
-            }
-            acp::RequestPermissionOutcome::Selected(selected) => {
-                return Err(anyhow!(
+            acp::RequestPermissionOutcome::Selected(selected) => [
+                PermissionDecision::GrantedOnce,
+                PermissionDecision::GrantedSession,
+                PermissionDecision::GrantedPersistent,
+                PermissionDecision::Denied,
+            ]
+            .into_iter()
+            .find(|decision| {
+                selected.option_id == acp::PermissionOptionId::from(option_id(*decision))
+            })
+            .ok_or_else(|| {
+                anyhow!(
                     "Unknown permission option selected: {}",
                     selected.option_id.0
-                ));
-            }
+                )
+            })?,
             // Non-exhaustive enum - handle future variants
             _ => return Err(anyhow!("Unknown permission outcome variant")),
         };
+
+        // Remember an "always allow" for command execution so we stop asking.
+        if decision == PermissionDecision::GrantedSession
+            && matches!(
+                permission_request.reason,
+                PermissionRequestReason::ExecuteCommand { .. }
+            )
+        {
+            self.allow_execute_command_always
+                .store(true, Ordering::Relaxed);
+        }
 
         Ok(decision)
     }

--- a/crates/ui_acp/src/ui.rs
+++ b/crates/ui_acp/src/ui.rs
@@ -948,6 +948,7 @@ impl UserInterface for ACPUserUI {
             | UiEvent::UpdateCurrentModel { .. }
             | UiEvent::UpdateSandboxPolicy { .. }
             | UiEvent::UpdatePermissionTier { .. }
+            | UiEvent::UpdateMcpServers { .. }
             // Permission prompts reach ACP clients through the protocol's
             // requestPermission RPC (AcpPermissionMediator), not the stream.
             | UiEvent::RequestToolPermission { .. }

--- a/crates/ui_gpui/src/app/commands.rs
+++ b/crates/ui_gpui/src/app/commands.rs
@@ -398,6 +398,33 @@ impl Gpui {
         });
     }
 
+    /// Toggle an MCP server on/off for a session. Computes the new disabled
+    /// set from the currently-known server list and persists it; the refreshed
+    /// list arrives back via the `UpdateMcpServers` notification.
+    pub(crate) fn cmd_toggle_mcp_server(&self, session_id: String, name: String, enabled: bool) {
+        let Some(service) = self.session_service() else {
+            return;
+        };
+        // Recompute the disabled set: current disabled servers, plus/minus the
+        // one just toggled.
+        let mut disabled: Vec<String> = self
+            .get_current_mcp_servers()
+            .into_iter()
+            .filter(|s| !s.enabled)
+            .map(|s| s.name)
+            .collect();
+        disabled.retain(|n| n != &name);
+        if !enabled {
+            disabled.push(name);
+        }
+        let gpui = self.clone();
+        self.dispatch(async move {
+            if let Err(e) = service.set_disabled_mcp_servers(session_id, disabled).await {
+                gpui.display_error(format!("{e:#}"));
+            }
+        });
+    }
+
     /// Answer a pending tool permission request. The prompt dismisses when
     /// the ToolPermissionRequestResolved notification arrives via the stream.
     pub(crate) fn cmd_respond_permission(

--- a/crates/ui_gpui/src/app/event_loop.rs
+++ b/crates/ui_gpui/src/app/event_loop.rs
@@ -795,6 +795,14 @@ impl Gpui {
                 *self.current_permission_tier.lock().unwrap() = Some(tier);
                 cx.refresh();
             }
+            UiEvent::UpdateMcpServers { servers } => {
+                debug!(
+                    "UI: UpdateMcpServers event with {} server(s)",
+                    servers.len()
+                );
+                *self.current_mcp_servers.lock().unwrap() = servers;
+                cx.refresh();
+            }
             UiEvent::RequestToolPermission { request } => {
                 debug!(
                     "UI: RequestToolPermission for tool {} ({})",

--- a/crates/ui_gpui/src/input/mcp_selector.rs
+++ b/crates/ui_gpui/src/input/mcp_selector.rs
@@ -107,27 +107,29 @@ impl Render for McpSelector {
                     .flex_col()
                     .gap_0p5()
                     .children(servers.into_iter().map(|server| {
-                    let name = server.name.clone();
-                    let switch_name = server.name.clone();
-                    let toggle_name = server.name.clone();
-                    div()
-                        .flex()
-                        .items_center()
-                        .justify_between()
-                        .gap_2()
-                        .px_2()
-                        .py_1()
-                        .child(
-                            div()
-                                .flex_1()
-                                .min_w_0()
-                                .text_xs()
-                                .text_color(cx.theme().foreground)
-                                .truncate()
-                                .child(SharedString::from(name)),
-                        )
-                        .child(
-                            Switch::new(SharedString::from(format!("mcp-toggle-{switch_name}")))
+                        let name = server.name.clone();
+                        let switch_name = server.name.clone();
+                        let toggle_name = server.name.clone();
+                        div()
+                            .flex()
+                            .items_center()
+                            .justify_between()
+                            .gap_2()
+                            .px_2()
+                            .py_1()
+                            .child(
+                                div()
+                                    .flex_1()
+                                    .min_w_0()
+                                    .text_xs()
+                                    .text_color(cx.theme().foreground)
+                                    .truncate()
+                                    .child(SharedString::from(name)),
+                            )
+                            .child(
+                                Switch::new(SharedString::from(format!(
+                                    "mcp-toggle-{switch_name}"
+                                )))
                                 .checked(server.enabled)
                                 .with_size(Size::Small)
                                 .on_click(cx.listener(
@@ -145,8 +147,9 @@ impl Render for McpSelector {
                                         cx.notify();
                                     },
                                 )),
-                        )
-                })));
+                            )
+                    })),
+            );
             root = root.child(panel);
         }
 

--- a/crates/ui_gpui/src/input/mcp_selector.rs
+++ b/crates/ui_gpui/src/input/mcp_selector.rs
@@ -1,0 +1,155 @@
+//! Input-bar control for toggling MCP servers on/off for the current session.
+//!
+//! A small trigger in the selector row opens a popover listing the servers
+//! available to the session (global `mcp-servers.json` plus the project's
+//! trusted `.mcp.json`); each has a switch that enables/disables it for this
+//! session only. The actual list and enabled state are pushed in from the
+//! session snapshot via [`Self::set_servers`]; toggling emits an event the
+//! `InputArea` forwards to the backend.
+
+use code_assistant_core::ui::ui_events::McpServerToggle;
+use gpui::{Context, EventEmitter, Render, SharedString, Window, deferred, div, prelude::*, px};
+use gpui_component::{ActiveTheme, Icon, Sizable, Size, switch::Switch};
+
+#[derive(Clone, Debug)]
+pub enum McpSelectorEvent {
+    /// The user flipped a server's switch. `enabled == false` deactivates it
+    /// for the session.
+    ServerToggled { name: String, enabled: bool },
+}
+
+pub struct McpSelector {
+    servers: Vec<McpServerToggle>,
+    open: bool,
+}
+
+impl EventEmitter<McpSelectorEvent> for McpSelector {}
+
+impl McpSelector {
+    pub fn new(_window: &mut Window, _cx: &mut Context<Self>) -> Self {
+        Self {
+            servers: Vec::new(),
+            open: false,
+        }
+    }
+
+    /// Replace the server list (from the session snapshot). Closes the popover
+    /// if the session no longer has any MCP servers.
+    pub fn set_servers(&mut self, servers: Vec<McpServerToggle>, cx: &mut Context<Self>) {
+        if self.servers != servers {
+            self.servers = servers;
+            if self.servers.is_empty() {
+                self.open = false;
+            }
+            cx.notify();
+        }
+    }
+}
+
+impl Render for McpSelector {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        // No servers → render nothing so the control disappears from the bar.
+        if self.servers.is_empty() {
+            return div().into_any_element();
+        }
+
+        let total = self.servers.len();
+        let enabled_count = self.servers.iter().filter(|s| s.enabled).count();
+        let is_open = self.open;
+
+        let trigger = div()
+            .id("mcp-selector-trigger")
+            .flex()
+            .items_center()
+            .gap_1()
+            .px_2()
+            .py_0p5()
+            .rounded_md()
+            .cursor_pointer()
+            .text_xs()
+            .text_color(cx.theme().muted_foreground)
+            .hover(|s| s.bg(cx.theme().muted.opacity(0.5)))
+            .child(SharedString::from(format!("MCP {enabled_count}/{total}")))
+            .child(
+                Icon::default()
+                    .path("icons/chevron_up_down.svg")
+                    .with_size(Size::XSmall)
+                    .text_color(cx.theme().muted_foreground),
+            )
+            .on_click(cx.listener(|this, _, _window, cx| {
+                this.open = !this.open;
+                cx.notify();
+            }));
+
+        let mut root = div().relative().flex().child(trigger);
+
+        if is_open {
+            // Owned copy so the per-row closures don't borrow `self`.
+            let servers = self.servers.clone();
+            // Deferred + occlude so the popover paints on the top layer above
+            // the input-area chrome (e.g. the chat/input divider border) rather
+            // than letting it bleed through, and swallows clicks behind it.
+            let panel = deferred(
+                div()
+                    .occlude()
+                    .absolute()
+                    .bottom_full()
+                    .right_0()
+                    .mb_1()
+                    .w(px(240.))
+                    .bg(cx.theme().popover)
+                    .border_1()
+                    .border_color(cx.theme().border)
+                    .rounded_lg()
+                    .shadow_lg()
+                    .p_1()
+                    .flex()
+                    .flex_col()
+                    .gap_0p5()
+                    .children(servers.into_iter().map(|server| {
+                    let name = server.name.clone();
+                    let switch_name = server.name.clone();
+                    let toggle_name = server.name.clone();
+                    div()
+                        .flex()
+                        .items_center()
+                        .justify_between()
+                        .gap_2()
+                        .px_2()
+                        .py_1()
+                        .child(
+                            div()
+                                .flex_1()
+                                .min_w_0()
+                                .text_xs()
+                                .text_color(cx.theme().foreground)
+                                .truncate()
+                                .child(SharedString::from(name)),
+                        )
+                        .child(
+                            Switch::new(SharedString::from(format!("mcp-toggle-{switch_name}")))
+                                .checked(server.enabled)
+                                .with_size(Size::Small)
+                                .on_click(cx.listener(
+                                    move |this, new_value: &bool, _window, cx| {
+                                        let new_value = *new_value;
+                                        if let Some(s) =
+                                            this.servers.iter_mut().find(|s| s.name == toggle_name)
+                                        {
+                                            s.enabled = new_value;
+                                        }
+                                        cx.emit(McpSelectorEvent::ServerToggled {
+                                            name: toggle_name.clone(),
+                                            enabled: new_value,
+                                        });
+                                        cx.notify();
+                                    },
+                                )),
+                        )
+                })));
+            root = root.child(panel);
+        }
+
+        root.into_any_element()
+    }
+}

--- a/crates/ui_gpui/src/input/mod.rs
+++ b/crates/ui_gpui/src/input/mod.rs
@@ -1,4 +1,5 @@
 pub mod attachment;
+pub mod mcp_selector;
 pub mod model_selector;
 pub mod permission_selector;
 pub mod sandbox_selector;
@@ -10,12 +11,14 @@ use super::shared::file_icons;
 use attachment::{AttachmentEvent, AttachmentView};
 use base64::Engine;
 use code_assistant_core::persistence::{DraftAttachment, NodeId};
+use code_assistant_core::ui::ui_events::McpServerToggle;
 use gpui::{
     ClickEvent, ClipboardEntry, Context, CursorStyle, Entity, EventEmitter, FocusHandle, Focusable,
     Render, SharedString, Subscription, Window, div, prelude::*, px,
 };
 use gpui_component::input::{Enter, Input, InputEvent, InputState, Paste};
 use gpui_component::{ActiveTheme, Icon};
+use mcp_selector::{McpSelector, McpSelectorEvent};
 use model_selector::{ModelSelector, ModelSelectorEvent};
 use permission_selector::{PermissionSelector, PermissionSelectorEvent};
 use sandbox::SandboxPolicy;
@@ -56,6 +59,8 @@ pub enum InputAreaEvent {
     SandboxChanged { policy: SandboxPolicy },
     /// Permission tier changed
     PermissionTierChanged { tier: PermissionTier },
+    /// An MCP server was toggled on/off for the session.
+    McpServerToggled { name: String, enabled: bool },
     /// User wants to switch to local (no worktree)
     WorktreeSwitchedToLocal,
     /// User selected an existing worktree
@@ -76,6 +81,7 @@ pub struct InputArea {
     sandbox_selector: Entity<SandboxSelector>,
     permission_selector: Entity<PermissionSelector>,
     worktree_selector: Entity<WorktreeSelector>,
+    mcp_selector: Entity<McpSelector>,
     current_model: Option<String>,
     current_sandbox_policy: SandboxPolicy,
     current_permission_tier: PermissionTier,
@@ -103,6 +109,7 @@ pub struct InputArea {
     _sandbox_selector_subscription: Subscription,
     _permission_selector_subscription: Subscription,
     _worktree_selector_subscription: Subscription,
+    _mcp_selector_subscription: Subscription,
 }
 
 impl InputArea {
@@ -130,6 +137,7 @@ impl InputArea {
         let sandbox_selector = cx.new(|cx| SandboxSelector::new(window, cx));
         let permission_selector = cx.new(|cx| PermissionSelector::new(window, cx));
         let worktree_selector = cx.new(|cx| WorktreeSelector::new(window, cx));
+        let mcp_selector = cx.new(|cx| McpSelector::new(window, cx));
 
         // Subscribe to model selector events
         let model_selector_subscription =
@@ -143,6 +151,8 @@ impl InputArea {
         );
         let worktree_selector_subscription =
             cx.subscribe_in(&worktree_selector, window, Self::on_worktree_selector_event);
+        let mcp_selector_subscription =
+            cx.subscribe_in(&mcp_selector, window, Self::on_mcp_selector_event);
 
         Self {
             text_input,
@@ -150,6 +160,7 @@ impl InputArea {
             sandbox_selector,
             permission_selector,
             worktree_selector,
+            mcp_selector,
             current_model: None,
             current_sandbox_policy: SandboxPolicy::DangerFullAccess,
             current_permission_tier: PermissionTier::default(),
@@ -170,6 +181,7 @@ impl InputArea {
             _sandbox_selector_subscription: sandbox_selector_subscription,
             _permission_selector_subscription: permission_selector_subscription,
             _worktree_selector_subscription: worktree_selector_subscription,
+            _mcp_selector_subscription: mcp_selector_subscription,
         }
     }
 
@@ -556,6 +568,29 @@ impl InputArea {
         }
     }
 
+    fn on_mcp_selector_event(
+        &mut self,
+        _selector: &Entity<McpSelector>,
+        event: &McpSelectorEvent,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        match event {
+            McpSelectorEvent::ServerToggled { name, enabled } => {
+                cx.emit(InputAreaEvent::McpServerToggled {
+                    name: name.clone(),
+                    enabled: *enabled,
+                });
+            }
+        }
+    }
+
+    /// Set the MCP servers shown in the input-bar toggle menu.
+    pub fn set_mcp_servers(&mut self, servers: Vec<McpServerToggle>, cx: &mut Context<Self>) {
+        self.mcp_selector
+            .update(cx, |selector, cx| selector.set_servers(servers, cx));
+    }
+
     fn on_worktree_selector_event(
         &mut self,
         _selector: &Entity<WorktreeSelector>,
@@ -780,6 +815,12 @@ impl InputArea {
                                             .flex_none()
                                             .flex()
                                             .child(self.permission_selector.clone()),
+                                    )
+                                    .child(
+                                        div()
+                                            .flex_none()
+                                            .flex()
+                                            .child(self.mcp_selector.clone()),
                                     )
                                     .child({
                                         let usage = self.context_usage;

--- a/crates/ui_gpui/src/lib.rs
+++ b/crates/ui_gpui/src/lib.rs
@@ -100,6 +100,10 @@ pub struct Gpui {
     // Current permission tier selection.
     current_permission_tier: Arc<Mutex<Option<tools_core::PermissionTier>>>,
 
+    // MCP servers available to the active session and their per-session
+    // enabled state, shown in the input-bar MCP toggle menu.
+    current_mcp_servers: Arc<Mutex<Vec<code_assistant_core::ui::ui_events::McpServerToggle>>>,
+
     // Tool permission requests awaiting the user's decision, rendered as a
     // prompt above the input area. Keyed order = arrival order.
     pending_permission_requests:
@@ -333,6 +337,7 @@ impl Gpui {
         *self.allowed_models.lock().unwrap() = None;
         *self.current_sandbox_policy.lock().unwrap() = None;
         *self.current_permission_tier.lock().unwrap() = None;
+        self.current_mcp_servers.lock().unwrap().clear();
         self.pending_permission_requests.lock().unwrap().clear();
         *self.current_worktree_data.lock().unwrap() = None;
         *self.current_session_last_usage.lock().unwrap() = None;
@@ -426,6 +431,7 @@ impl Gpui {
 
             // Current permission tier selection + open permission prompts
             current_permission_tier: Arc::new(Mutex::new(None)),
+            current_mcp_servers: Arc::new(Mutex::new(Vec::new())),
             pending_permission_requests: Arc::new(Mutex::new(Vec::new())),
 
             // Pending message edit state
@@ -721,6 +727,12 @@ impl Gpui {
 
     pub fn get_current_permission_tier(&self) -> Option<tools_core::PermissionTier> {
         *self.current_permission_tier.lock().unwrap()
+    }
+
+    pub fn get_current_mcp_servers(
+        &self,
+    ) -> Vec<code_assistant_core::ui::ui_events::McpServerToggle> {
+        self.current_mcp_servers.lock().unwrap().clone()
     }
 
     pub fn get_pending_permission_requests(

--- a/crates/ui_gpui/src/main_screen/mod.rs
+++ b/crates/ui_gpui/src/main_screen/mod.rs
@@ -600,6 +600,14 @@ impl MainScreen {
                     gpui.cmd_change_permission_tier(session_id.clone(), *tier);
                 }
             }
+            InputAreaEvent::McpServerToggled { name, enabled } => {
+                if let Some(session_id) = &self.current_session_id {
+                    let gpui = cx
+                        .try_global::<Gpui>()
+                        .expect("Failed to obtain Gpui global");
+                    gpui.cmd_toggle_mcp_server(session_id.clone(), name.clone(), *enabled);
+                }
+            }
             InputAreaEvent::WorktreeSwitchedToLocal => {
                 if let Some(session_id) = &self.current_session_id {
                     let gpui = cx
@@ -972,7 +980,7 @@ impl MainScreen {
             }
         };
 
-        let button = |id: String, label: &'static str, emphasized: bool, cx: &mut Context<Self>| {
+        let button = |id: String, label: SharedString, emphasized: bool, cx: &mut Context<Self>| {
             div()
                 .id(SharedString::from(id))
                 .px_2()
@@ -1036,23 +1044,22 @@ impl MainScreen {
                                         .child(request.summary.clone()),
                                 ),
                         )
-                        .child(
-                            button(format!("perm-allow-{rid}"), "Allow once", true, cx).on_click(
-                                respond(&session_id, &rid, PermissionDecision::GrantedOnce),
-                            ),
-                        )
-                        .child(
-                            button(format!("perm-always-{rid}"), "Always (session)", false, cx)
-                                .on_click(respond(
-                                    &session_id,
-                                    &rid,
-                                    PermissionDecision::GrantedSession,
-                                )),
-                        )
-                        .child(
-                            button(format!("perm-deny-{rid}"), "Deny", false, cx)
-                                .on_click(respond(&session_id, &rid, PermissionDecision::Denied)),
-                        )
+                        // Render whatever choices the request carries; the
+                        // first is the primary action. Frontends don't decide
+                        // the options — the mediator does (permission_options_for).
+                        .children(request.options.iter().enumerate().map(|(i, option)| {
+                            button(
+                                format!("perm-{i}-{rid}"),
+                                option.label.clone().into(),
+                                i == 0,
+                                cx,
+                            )
+                            .on_click(respond(
+                                &session_id,
+                                &rid,
+                                option.decision,
+                            ))
+                        }))
                 }))
                 .into_any_element(),
         )
@@ -1183,6 +1190,7 @@ impl Render for MainScreen {
             current_worktree_data,
             current_last_usage,
             current_total_usage,
+            current_mcp_servers,
         ) = if let Some(gpui) = cx.try_global::<Gpui>() {
             (
                 gpui.get_chat_sessions(),
@@ -1195,6 +1203,7 @@ impl Render for MainScreen {
                 gpui.get_current_worktree_data(),
                 gpui.get_current_session_last_usage(),
                 gpui.get_current_session_total_usage(),
+                gpui.get_current_mcp_servers(),
             )
         } else {
             (
@@ -1208,6 +1217,7 @@ impl Render for MainScreen {
                 None,
                 None,
                 None,
+                Vec::new(),
             )
         };
 
@@ -1300,6 +1310,12 @@ impl Render for MainScreen {
                 input_area.set_current_permission_tier(tier, window, cx);
             });
         }
+
+        // Sync the MCP server list to the input-bar toggle menu (set_servers
+        // no-ops when unchanged).
+        self.input_area.update(cx, |input_area, cx| {
+            input_area.set_mcp_servers(current_mcp_servers, cx);
+        });
 
         // Sync worktree data to the WorktreeSelector (only when changed)
         if current_worktree_data != self.last_worktree_data {

--- a/crates/ui_terminal/src/slash_popup/permission_prompt.rs
+++ b/crates/ui_terminal/src/slash_popup/permission_prompt.rs
@@ -14,45 +14,37 @@ use crate::slash_popup::{PopupAction, PopupRow, SlashPopup};
 use code_assistant_core::session::permissions::ToolPermissionRequestData;
 use tools_core::PermissionDecision;
 
-const DECISIONS: &[(PermissionDecision, &str, &str)] = &[
-    (
-        PermissionDecision::GrantedOnce,
-        "Allow once",
-        "Run this tool call, ask again next time",
-    ),
-    (
-        PermissionDecision::GrantedSession,
-        "Always allow (session)",
-        "Run and stop asking for this tool in this session",
-    ),
-    (
-        PermissionDecision::Denied,
-        "Deny",
-        "Reject the call; the agent is told not to retry",
-    ),
-];
-
 pub struct PermissionPromptPopup {
     request_id: String,
     title: String,
     rows: Vec<PopupRow>,
+    /// Decision per row, parallel to `rows` — taken straight from the
+    /// request's options so this popup never decides the choices itself.
+    decisions: Vec<PermissionDecision>,
     selected: usize,
 }
 
 impl PermissionPromptPopup {
     pub fn for_request(request: &ToolPermissionRequestData) -> Self {
-        let rows = DECISIONS
+        let rows = request
+            .options
             .iter()
-            .map(|(_, label, description)| PopupRow {
-                label: (*label).to_string(),
-                description: (*description).to_string(),
+            .map(|option| PopupRow {
+                label: option.label.clone(),
+                description: option.description.clone(),
                 has_submenu: false,
             })
+            .collect();
+        let decisions = request
+            .options
+            .iter()
+            .map(|option| option.decision)
             .collect();
         Self {
             request_id: request.request_id.clone(),
             title: format!("Permission required: {}", request.summary),
             rows,
+            decisions,
             selected: 0,
         }
     }
@@ -82,10 +74,9 @@ impl SlashPopup for PermissionPromptPopup {
     }
 
     fn activate(&self) -> PopupAction {
-        let (decision, ..) = DECISIONS[self.selected];
         PopupAction::Commit(CommandResult::RespondPermission {
             request_id: Some(self.request_id.clone()),
-            decision,
+            decision: self.decisions[self.selected],
         })
     }
 
@@ -98,7 +89,16 @@ impl SlashPopup for PermissionPromptPopup {
 mod tests {
     use super::*;
     use crate::slash_popup::PopupStack;
+    use code_assistant_core::session::permissions::PermissionOption;
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    fn option(decision: PermissionDecision, label: &str) -> PermissionOption {
+        PermissionOption {
+            decision,
+            label: label.to_string(),
+            description: String::new(),
+        }
+    }
 
     fn request(id: &str) -> ToolPermissionRequestData {
         ToolPermissionRequestData {
@@ -107,6 +107,11 @@ mod tests {
             tool_name: "delete_files".to_string(),
             summary: "Run tool `delete_files`".to_string(),
             metadata: serde_json::json!({}),
+            options: vec![
+                option(PermissionDecision::GrantedOnce, "Allow once"),
+                option(PermissionDecision::GrantedSession, "Always (session)"),
+                option(PermissionDecision::Denied, "Deny"),
+            ],
         }
     }
 


### PR DESCRIPTION
## Summary

Adds support for project-local MCP server configuration alongside the existing global `mcp-servers.json`, with a trust gate for newly-seen local configs and per-session server toggling.

- **Project-local `.mcp.json`** — a repo can ship its own MCP servers in a `.mcp.json` file (Claude Code format). These merge with the global servers when the project is opened.
- **Trust gating** — the first time a project's `.mcp.json` (or a changed one) is seen, the user is prompted to trust it before its servers are launched. Trust is tracked per-project by a content fingerprint, so edits re-prompt. A new `PermissionRequestReason::TrustLocalMcp` and the `GrantedPersistent` permission decision drive this.
- **Per-session MCP toggles** — servers can be switched on/off per session from a new selector in the input bar (GPUI), without editing config files. Disabled servers are filtered from the session's tool set.
- **Connection pooling** — MCP connections are pooled and keyed by name + transport, reused across registry rebuilds, and evicted (with child-process shutdown) once no longer referenced.

## Notes

- Permission options are now sourced from a single `permission_options_for()` shared across the GPUI, terminal, and ACP frontends.
- The trust fingerprint uses a non-cryptographic hash for change detection only — it is not a security boundary.

## Testing

- `cargo build`, `cargo test`, and `cargo clippy` all pass.
- Manual verification of the trust prompt, per-session toggles, and pooled-connection eviction.
