### PR TITLE
feat(vertex): add bearer_auth option to send Authorization: Bearer header

### DIFF
--- a/crates/llm/src/factory.rs
+++ b/crates/llm/src/factory.rs
@@ -608,7 +608,27 @@ async fn create_vertex_client(
         .and_then(|v| v.as_str())
         .unwrap_or(&default_base_url);
 
-    let client = if let Some(path) = record_path {
+    // When `bearer_auth` is true, send the key as an `Authorization: Bearer <token>`
+    // header instead of the default `?key=<api_key>` query parameter. Required for
+    // endpoints or proxies that expect the key in an Authorization header. Defaults
+    // to false so existing Vertex configs are unaffected.
+    let bearer_auth = config
+        .get("bearer_auth")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    let client = if bearer_auth {
+        let mut client = VertexClient::with_customization(
+            model_config.id.clone(),
+            base_url.to_string(),
+            Box::new(crate::vertex::BearerTokenAuth::new(api_key.to_string())),
+            Box::new(crate::vertex::DefaultRequestCustomizer),
+        );
+        if let Some(path) = record_path {
+            client = client.with_recorder(path);
+        }
+        client
+    } else if let Some(path) = record_path {
         VertexClient::new_with_recorder(
             api_key.to_string(),
             model_config.id.clone(),

--- a/crates/llm/src/vertex.rs
+++ b/crates/llm/src/vertex.rs
@@ -65,6 +65,33 @@ impl AuthProvider for ApiKeyAuth {
     }
 }
 
+/// Bearer token authentication provider (sends `Authorization: Bearer <token>` header)
+///
+/// Used for endpoints or proxies that require the key in an `Authorization`
+/// header rather than the `?key=` query parameter used by [`ApiKeyAuth`].
+pub struct BearerTokenAuth {
+    api_key: String,
+}
+
+impl BearerTokenAuth {
+    pub fn new(api_key: String) -> Self {
+        Self { api_key }
+    }
+}
+
+#[async_trait]
+impl AuthProvider for BearerTokenAuth {
+    async fn get_auth(&self) -> Result<VertexAuth> {
+        Ok(VertexAuth {
+            query_params: vec![],
+            headers: vec![(
+                "Authorization".to_string(),
+                format!("Bearer {}", self.api_key),
+            )],
+        })
+    }
+}
+
 /// Default request customizer for Google Generative Language API
 pub struct DefaultRequestCustomizer;
 

--- a/crates/ui_gpui/src/settings_screen/provider_forms/mod.rs
+++ b/crates/ui_gpui/src/settings_screen/provider_forms/mod.rs
@@ -7,6 +7,7 @@
 pub mod ai_core_form;
 pub mod chatgpt_subscription_form;
 pub mod default_form;
+pub mod vertex_form;
 
 use gpui::{AnyElement, App, AppContext as _, Context, Entity, IntoElement, Window};
 use serde_json::Value;
@@ -38,6 +39,7 @@ pub fn form_type_for_provider(provider_type: &str) -> ProviderFormType {
     match provider_type {
         "ai-core" => ProviderFormType::AiCore,
         "openai-responses-ws" => ProviderFormType::ChatGptSubscription,
+        "vertex" => ProviderFormType::Vertex,
         _ => ProviderFormType::Default,
     }
 }
@@ -51,6 +53,8 @@ pub enum ProviderFormType {
     AiCore,
     /// ChatGPT Subscription: OAuth2 browser login
     ChatGptSubscription,
+    /// Vertex form: base_url + api_key + bearer_auth toggle
+    Vertex,
 }
 
 /// A wrapper that can hold any provider form entity and delegate to it.
@@ -61,6 +65,7 @@ pub struct ProviderFormHolder {
     pub default_form: Option<Entity<default_form::DefaultProviderForm>>,
     pub ai_core_form: Option<Entity<ai_core_form::AiCoreProviderForm>>,
     pub chatgpt_form: Option<Entity<chatgpt_subscription_form::ChatGptSubscriptionForm>>,
+    pub vertex_form: Option<Entity<vertex_form::VertexProviderForm>>,
 }
 
 impl ProviderFormHolder {
@@ -76,12 +81,14 @@ impl ProviderFormHolder {
                 default_form: Some(cx.new(|cx| default_form::DefaultProviderForm::new(window, cx))),
                 ai_core_form: None,
                 chatgpt_form: None,
+                vertex_form: None,
             },
             ProviderFormType::AiCore => Self {
                 form_type,
                 default_form: None,
                 ai_core_form: Some(cx.new(|cx| ai_core_form::AiCoreProviderForm::new(window, cx))),
                 chatgpt_form: None,
+                vertex_form: None,
             },
             ProviderFormType::ChatGptSubscription => {
                 Self {
@@ -91,8 +98,16 @@ impl ProviderFormHolder {
                     chatgpt_form: Some(cx.new(|cx| {
                         chatgpt_subscription_form::ChatGptSubscriptionForm::new(window, cx)
                     })),
+                    vertex_form: None,
                 }
             }
+            ProviderFormType::Vertex => Self {
+                form_type,
+                default_form: None,
+                ai_core_form: None,
+                chatgpt_form: None,
+                vertex_form: Some(cx.new(|cx| vertex_form::VertexProviderForm::new(window, cx))),
+            },
         }
     }
 
@@ -116,6 +131,7 @@ impl ProviderFormHolder {
                 }
                 self.ai_core_form = None;
                 self.chatgpt_form = None;
+                self.vertex_form = None;
             }
             ProviderFormType::AiCore => {
                 if self.ai_core_form.is_none() {
@@ -124,6 +140,7 @@ impl ProviderFormHolder {
                 }
                 self.default_form = None;
                 self.chatgpt_form = None;
+                self.vertex_form = None;
             }
             ProviderFormType::ChatGptSubscription => {
                 if self.chatgpt_form.is_none() {
@@ -133,6 +150,16 @@ impl ProviderFormHolder {
                 }
                 self.default_form = None;
                 self.ai_core_form = None;
+                self.vertex_form = None;
+            }
+            ProviderFormType::Vertex => {
+                if self.vertex_form.is_none() {
+                    self.vertex_form =
+                        Some(cx.new(|cx| vertex_form::VertexProviderForm::new(window, cx)));
+                }
+                self.default_form = None;
+                self.ai_core_form = None;
+                self.chatgpt_form = None;
             }
         }
     }
@@ -157,6 +184,13 @@ impl ProviderFormHolder {
             }
             ProviderFormType::ChatGptSubscription => {
                 if let Some(form) = &self.chatgpt_form {
+                    form.clone().into_any_element()
+                } else {
+                    gpui::Empty.into_any_element()
+                }
+            }
+            ProviderFormType::Vertex => {
+                if let Some(form) = &self.vertex_form {
                     form.clone().into_any_element()
                 } else {
                     gpui::Empty.into_any_element()
@@ -189,6 +223,13 @@ impl ProviderFormHolder {
                     serde_json::Map::new()
                 }
             }
+            ProviderFormType::Vertex => {
+                if let Some(form) = &self.vertex_form {
+                    form.read(cx).to_config_json(cx)
+                } else {
+                    serde_json::Map::new()
+                }
+            }
         }
     }
 
@@ -215,6 +256,11 @@ impl ProviderFormHolder {
                     form.update(cx, |form, cx| form.load_config(config, window, cx));
                 }
             }
+            ProviderFormType::Vertex => {
+                if let Some(form) = &self.vertex_form {
+                    form.update(cx, |form, cx| form.load_config(config, window, cx));
+                }
+            }
         }
     }
 
@@ -237,6 +283,11 @@ impl ProviderFormHolder {
             }
             ProviderFormType::ChatGptSubscription => {
                 if let Some(form) = &self.chatgpt_form {
+                    form.update(cx, |form, cx| form.reset(window, cx));
+                }
+            }
+            ProviderFormType::Vertex => {
+                if let Some(form) = &self.vertex_form {
                     form.update(cx, |form, cx| form.reset(window, cx));
                 }
             }

--- a/crates/ui_gpui/src/settings_screen/provider_forms/vertex_form.rs
+++ b/crates/ui_gpui/src/settings_screen/provider_forms/vertex_form.rs
@@ -1,0 +1,163 @@
+//! Vertex provider form: base_url + api_key + bearer_auth toggle.
+//!
+//! Identical to the default form but adds a `bearer_auth` checkbox. When
+//! enabled, the backend sends the key as an `Authorization: Bearer <token>`
+//! header instead of the default `?key=<api_key>` query parameter. This is
+//! required for endpoints or proxies that expect the key in an Authorization
+//! header.
+
+use super::ProviderForm;
+use gpui::{App, Context, Entity, SharedString, Window, div, prelude::*, px};
+use gpui_component::input::{Input, InputState};
+use gpui_component::{ActiveTheme, checkbox::Checkbox};
+use serde_json::Value;
+
+pub struct VertexProviderForm {
+    pub base_url_input: Entity<InputState>,
+    pub api_key_input: Entity<InputState>,
+    /// Whether to send the key as an `Authorization: Bearer` header.
+    pub bearer_auth: bool,
+    /// Whether we're in edit mode (affects placeholder text for API key)
+    pub is_editing: bool,
+}
+
+impl VertexProviderForm {
+    pub fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
+        let base_url_input =
+            cx.new(|cx| InputState::new(window, cx).placeholder("https://api.example.com/v1"));
+        let api_key_input = cx.new(|cx| InputState::new(window, cx).placeholder("sk-..."));
+
+        Self {
+            base_url_input,
+            api_key_input,
+            bearer_auth: false,
+            is_editing: false,
+        }
+    }
+
+    /// Render a form row with label on left, widget on right.
+    fn form_row(
+        &self,
+        label: &str,
+        widget: gpui::AnyElement,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        div()
+            .w_full()
+            .flex()
+            .items_center()
+            .gap_3()
+            .child(
+                div()
+                    .w(px(80.))
+                    .flex_none()
+                    .text_xs()
+                    .font_weight(gpui::FontWeight::MEDIUM)
+                    .text_color(cx.theme().muted_foreground)
+                    .child(SharedString::from(label.to_string())),
+            )
+            .child(div().flex_1().min_w_0().child(widget))
+    }
+}
+
+impl ProviderForm for VertexProviderForm {
+    fn to_config_json(&self, cx: &App) -> serde_json::Map<String, Value> {
+        let mut config = serde_json::Map::new();
+
+        let base_url = self.base_url_input.read(cx).value().to_string();
+        let api_key = self.api_key_input.read(cx).value().to_string();
+
+        if !base_url.is_empty() {
+            config.insert("base_url".to_string(), Value::String(base_url));
+        }
+        if !api_key.is_empty() {
+            config.insert("api_key".to_string(), Value::String(api_key));
+        }
+        // Only persist when enabled to keep configs clean and backward-compatible.
+        if self.bearer_auth {
+            config.insert("bearer_auth".to_string(), Value::Bool(true));
+        }
+
+        config
+    }
+
+    fn load_config(
+        &mut self,
+        config: &serde_json::Map<String, Value>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.is_editing = true;
+
+        if let Some(base_url) = config.get("base_url").and_then(|v| v.as_str()) {
+            self.base_url_input.update(cx, |state, cx| {
+                state.set_value(SharedString::from(base_url.to_string()), window, cx);
+            });
+        }
+        self.bearer_auth = config
+            .get("bearer_auth")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        // Don't populate API key for security
+        self.api_key_input.update(cx, |state, cx| {
+            state.set_value(SharedString::from(""), window, cx);
+        });
+    }
+
+    fn reset(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.is_editing = false;
+        self.bearer_auth = false;
+        self.base_url_input.update(cx, |state, cx| {
+            state.set_value(SharedString::from(""), window, cx);
+        });
+        self.api_key_input.update(cx, |state, cx| {
+            state.set_value(SharedString::from(""), window, cx);
+        });
+    }
+}
+
+impl Render for VertexProviderForm {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let api_key_label = if self.is_editing {
+            "API Key *"
+        } else {
+            "API Key"
+        };
+
+        div()
+            .flex()
+            .flex_col()
+            .gap_2()
+            .child(self.form_row(
+                "Base URL",
+                Input::new(&self.base_url_input).into_any_element(),
+                cx,
+            ))
+            .child(self.form_row(
+                api_key_label,
+                Input::new(&self.api_key_input).into_any_element(),
+                cx,
+            ))
+            .child(self.form_row(
+                "Auth",
+                Checkbox::new("vertex-bearer-auth")
+                    .label("Send key as Authorization: Bearer header")
+                    .checked(self.bearer_auth)
+                    .on_click(cx.listener(|this, checked: &bool, _window, cx| {
+                        this.bearer_auth = *checked;
+                        cx.notify();
+                    }))
+                    .into_any_element(),
+                cx,
+            ))
+            .when(self.is_editing, |el| {
+                el.child(
+                    div()
+                        .pl(px(83.))
+                        .text_xs()
+                        .text_color(cx.theme().muted_foreground)
+                        .child("* Leave empty to keep current key"),
+                )
+            })
+    }
+}

--- a/crates/ui_gpui/src/settings_screen/provider_forms/vertex_form.rs
+++ b/crates/ui_gpui/src/settings_screen/provider_forms/vertex_form.rs
@@ -138,18 +138,20 @@ impl Render for VertexProviderForm {
                 Input::new(&self.api_key_input).into_any_element(),
                 cx,
             ))
-            .child(self.form_row(
-                "Auth",
-                Checkbox::new("vertex-bearer-auth")
-                    .label("Send key as Authorization: Bearer header")
-                    .checked(self.bearer_auth)
-                    .on_click(cx.listener(|this, checked: &bool, _window, cx| {
-                        this.bearer_auth = *checked;
-                        cx.notify();
-                    }))
-                    .into_any_element(),
-                cx,
-            ))
+            .child(
+                self.form_row(
+                    "Auth",
+                    Checkbox::new("vertex-bearer-auth")
+                        .label("Send key as Authorization: Bearer header")
+                        .checked(self.bearer_auth)
+                        .on_click(cx.listener(|this, checked: &bool, _window, cx| {
+                            this.bearer_auth = *checked;
+                            cx.notify();
+                        }))
+                        .into_any_element(),
+                    cx,
+                ),
+            )
             .when(self.is_editing, |el| {
                 el.child(
                     div()


### PR DESCRIPTION
## Summary

Adds a `bearer_auth` option to the Vertex LLM provider. When enabled, the client sends the key as an `Authorization: Bearer <token>` header instead of the default `?key=<api_key>` query parameter.

This is required for endpoints or proxies that expect the key in an `Authorization` header rather than the query parameter, and reject requests lacking one with HTTP 401. The default `ApiKeyAuth` path is unchanged.

## Changes

- **`crates/llm/src/vertex.rs`** — new `BearerTokenAuth` auth provider that emits an `Authorization: Bearer <token>` header and no query params.
- **`crates/llm/src/factory.rs`** — `create_vertex_client` reads a `bearer_auth` bool from config and, when true, constructs the client via `VertexClient::with_customization` using `BearerTokenAuth`. Recorder support preserved on both paths.
- **`crates/ui_gpui/src/settings_screen/provider_forms/vertex_form.rs`** (new) — dedicated Vertex provider form (base URL + API key + a "Send key as Authorization: Bearer header" checkbox), following the existing `ai_core_form` / `chatgpt_subscription_form` pattern rather than modifying the shared default form.
- **`crates/ui_gpui/src/settings_screen/provider_forms/mod.rs`** — registers the new form and its `ProviderFormType::Vertex` dispatch.

## Backward compatibility

`bearer_auth` defaults to `false`, and the config key is only persisted when enabled, so existing Vertex configurations are unaffected.

## Testing

- Built the macOS app bundle and installed locally; the checkbox appears in the Vertex provider form.
- Confirmed the `401` from an Authorization-header-requiring endpoint is resolved once `bearer_auth` is enabled.