### PR TITLE
fix(mcp): per-project registries, registry-independent rendering, per-server ${VAR} handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,9 @@ headless binary without gpui.
   `command`/`args`/`env`, an HTTP server has `url`/`headers`; `${ENV_VAR}`
   substitution in `env`/`headers` values) or programmatically via
   `mcp_client::register_mcp_tools`
+- Projects can ship additional servers in a `.mcp.json` at the project root
+  (Claude Code's format), merged over the global set per project and gated
+  by a trust prompt — see `docs/project-scoped-mcp-servers.md`
 - The tool registry is rebuilt from the current config at the start of
   every agent run via the `ToolRegistryProvider` seam
   (`tools::ConfigToolRegistry`, a fingerprint cache over `tools.json` +

--- a/crates/code_assistant_core/src/session/instance.rs
+++ b/crates/code_assistant_core/src/session/instance.rs
@@ -805,7 +805,10 @@ impl SessionInstance {
         for serialized_execution in &self.session.tool_executions {
             // A tool that has since disappeared (e.g. a reconfigured MCP
             // server) must not break rendering the session: skip its records.
-            if !serialized_execution.tool_available(self.tool_registry.as_ref()) {
+            if !crate::tools::mcp::execution_renderable(
+                serialized_execution,
+                self.tool_registry.as_ref(),
+            ) {
                 tracing::warn!(
                     "Skipping recorded execution of unavailable tool '{}'",
                     serialized_execution.tool_name
@@ -814,7 +817,10 @@ impl SessionInstance {
             }
 
             // Deserialize the tool execution
-            let execution = serialized_execution.deserialize(self.tool_registry.as_ref())?;
+            let execution = crate::tools::mcp::deserialize_tool_execution(
+                serialized_execution,
+                self.tool_registry.as_ref(),
+            )?;
 
             // Generate status and output from result
             let success = execution.result.is_success();

--- a/crates/code_assistant_core/src/session/manager.rs
+++ b/crates/code_assistant_core/src/session/manager.rs
@@ -244,21 +244,30 @@ impl SessionManager {
         &self.tool_registry
     }
 
-    /// Pull the registry for `req` from the provider (no-op without one).
-    /// Session instances follow the swap so their UI rebuilds resolve tool
-    /// executions against the same registry the next run uses.
-    async fn refresh_tool_registry(&mut self, req: RegistryRequest) {
+    /// Pull the registry for `req` from the provider (no-op without one) and
+    /// assign it to `session_id`'s instance — and only that one. Sessions in
+    /// other projects keep the registry of their own last run; MCP tool
+    /// executions render independently of any registry (see
+    /// [`crate::tools::mcp::deserialize_tool_execution`]), so no session
+    /// depends on following a foreign run's swap. The manager-level registry
+    /// follows too: it is this run's working registry and the default for
+    /// instances that have not run yet.
+    async fn refresh_tool_registry(&mut self, session_id: &str, req: RegistryRequest) {
         let Some(provider) = &self.tool_registry_provider else {
             return;
         };
         let fresh = provider(req).await;
-        if Arc::ptr_eq(&fresh, &self.tool_registry) {
-            return;
+        if !Arc::ptr_eq(&fresh, &self.tool_registry) {
+            info!("Tool registry refreshed for the next agent run");
+            self.tool_registry = fresh.clone();
         }
-        info!("Tool registry refreshed for the next agent run");
-        self.tool_registry = fresh.clone();
-        for instance in self.active_sessions.values_mut() {
-            instance.tool_registry = fresh.clone();
+        // Assign even when the manager already held it: a second session in
+        // the same project gets the same `Arc` from the provider's cache, but
+        // its instance may still hold an older registry.
+        if let Some(instance) = self.active_sessions.get_mut(session_id)
+            && !Arc::ptr_eq(&instance.tool_registry, &fresh)
+        {
+            instance.tool_registry = fresh;
         }
     }
 
@@ -827,7 +836,8 @@ impl SessionManager {
         // before anything below binds to it. Trust is resolved by the caller —
         // not here — because prompting must happen without the manager lock
         // that wraps this call, or the response could never be delivered.
-        self.refresh_tool_registry(registry_request).await;
+        self.refresh_tool_registry(session_id, registry_request)
+            .await;
 
         // Acquire exclusive cross-process agent lock.
         // This prevents another code-assistant instance from running an agent
@@ -2265,30 +2275,45 @@ mod tests {
     }
 
     /// The provider seam: refreshing swaps the manager's registry and the
-    /// registries of the active session instances (their UI rebuilds must
-    /// resolve tools against what the next run uses); an unchanged provider
-    /// result (same `Arc`) is a no-op.
+    /// registry of the session the refresh is for — and only that session's.
+    /// Other sessions may be running in other projects with other registries;
+    /// their rendering must not follow a foreign run's swap. An unchanged
+    /// provider result (same `Arc`) is a no-op.
     #[tokio::test]
-    async fn refresh_swaps_manager_and_instance_registries() {
+    async fn refresh_swaps_only_the_requesting_sessions_registry() {
         let (mut manager, _dir) = build_manager(false);
         let initial = manager.tool_registry().clone();
         let session_id = manager.create_session(None).expect("create session");
+        let other_id = manager.create_session(None).expect("create session");
 
         // Without a provider, refreshing changes nothing.
         manager
-            .refresh_tool_registry(RegistryRequest::default())
+            .refresh_tool_registry(&session_id, RegistryRequest::default())
             .await;
         assert!(Arc::ptr_eq(manager.tool_registry(), &initial));
 
         let fresh = crate::tools::test_registry();
         manager.set_tool_registry_provider(fixed_registry_provider(fresh.clone()));
         manager
-            .refresh_tool_registry(RegistryRequest::default())
+            .refresh_tool_registry(&session_id, RegistryRequest::default())
             .await;
 
         assert!(Arc::ptr_eq(manager.tool_registry(), &fresh));
         let instance = manager.get_session(&session_id).expect("instance");
         assert!(Arc::ptr_eq(&instance.tool_registry, &fresh));
+        let other = manager.get_session(&other_id).expect("instance");
+        assert!(
+            Arc::ptr_eq(&other.tool_registry, &initial),
+            "a refresh for one session must not swap another session's registry"
+        );
+
+        // A later refresh *for* the other session catches its instance up,
+        // even though the manager-level registry is already the same Arc.
+        manager
+            .refresh_tool_registry(&other_id, RegistryRequest::default())
+            .await;
+        let other = manager.get_session(&other_id).expect("instance");
+        assert!(Arc::ptr_eq(&other.tool_registry, &fresh));
     }
 
     /// Starting an agent run is the point where the provider is consulted:

--- a/crates/code_assistant_core/src/session/manager.rs
+++ b/crates/code_assistant_core/src/session/manager.rs
@@ -887,7 +887,10 @@ impl SessionManager {
                     // MCP server) must not brick the session: skip its
                     // records, the conversation itself lives in the messages.
                     .filter(|se| {
-                        let available = se.tool_available(self.tool_registry.as_ref());
+                        let available = crate::tools::mcp::execution_renderable(
+                            se,
+                            self.tool_registry.as_ref(),
+                        );
                         if !available {
                             warn!(
                                 "Skipping recorded execution of unavailable tool '{}'",
@@ -896,7 +899,12 @@ impl SessionManager {
                         }
                         available
                     })
-                    .map(|se| se.deserialize(self.tool_registry.as_ref()))
+                    .map(|se| {
+                        crate::tools::mcp::deserialize_tool_execution(
+                            se,
+                            self.tool_registry.as_ref(),
+                        )
+                    })
                     .collect::<Result<Vec<_>>>()?,
 
                 plan: session_instance.session.plan.clone(),

--- a/crates/code_assistant_core/src/tools/mcp.rs
+++ b/crates/code_assistant_core/src/tools/mcp.rs
@@ -69,6 +69,35 @@ pub fn save_mcp_servers_config_to(path: &Path, config: &McpServersConfig) -> Res
         .with_context(|| format!("Failed to write MCP config: {}", path.display()))
 }
 
+/// Whether [`deserialize_tool_execution`] can resolve this recorded
+/// execution. MCP executions and parse errors always can; a native tool must
+/// still be present in `registry`.
+pub fn execution_renderable(
+    se: &agent_core::SerializedToolExecution,
+    registry: &ToolRegistry,
+) -> bool {
+    mcp_client::is_mcp_tool_name(&se.tool_name) || se.tool_available(registry)
+}
+
+/// Deserialize a recorded tool execution for rendering or session state. MCP
+/// executions (`mcp__…` names) deserialize from their self-describing JSON,
+/// deliberately independent of which servers `registry` has connected: a
+/// session must render identically wherever it is viewed — under another
+/// project's registry, or in an instance that never launched (or never
+/// trusted) the producing server.
+pub fn deserialize_tool_execution(
+    se: &agent_core::SerializedToolExecution,
+    registry: &ToolRegistry,
+) -> Result<agent_core::ToolExecution> {
+    if mcp_client::is_mcp_tool_name(&se.tool_name) {
+        return Ok(agent_core::ToolExecution {
+            tool_request: se.tool_request.clone(),
+            result: mcp_client::deserialize_mcp_output(se.result_json.clone())?,
+        });
+    }
+    se.deserialize(registry)
+}
+
 /// Load a project-local `.mcp.json` from `dir`, if present. Returns `None`
 /// when the file does not exist; logs a warning on parse errors rather than
 /// propagating them, so a malformed local file degrades gracefully.
@@ -356,6 +385,47 @@ mod tests {
         )
         .unwrap();
         assert!(load_mcp_servers_config_from(&path).is_err());
+    }
+
+    #[test]
+    fn mcp_execution_renders_without_the_server_registered() {
+        // A session may be viewed by an instance that never connected (or
+        // never trusted) the producing server — the recorded execution must
+        // still deserialize, from its self-describing JSON alone.
+        let se = agent_core::SerializedToolExecution {
+            tool_request: agent_core::ToolRequest {
+                id: "1".into(),
+                name: "mcp__jira__search".into(),
+                input: serde_json::Value::Null,
+                start_offset: None,
+                end_offset: None,
+            },
+            result_json: serde_json::json!({ "text": "3 issues", "is_error": false }),
+            tool_name: "mcp__jira__search".into(),
+        };
+        let empty = ToolRegistry::new();
+        assert!(execution_renderable(&se, &empty));
+        let execution = deserialize_tool_execution(&se, &empty).unwrap();
+        assert!(execution.result.is_success());
+        assert_eq!(execution.result.as_render().status(), "3 issues");
+    }
+
+    #[test]
+    fn native_execution_still_requires_its_tool() {
+        let se = agent_core::SerializedToolExecution {
+            tool_request: agent_core::ToolRequest {
+                id: "1".into(),
+                name: "vanished_tool".into(),
+                input: serde_json::Value::Null,
+                start_offset: None,
+                end_offset: None,
+            },
+            result_json: serde_json::json!({}),
+            tool_name: "vanished_tool".into(),
+        };
+        let empty = ToolRegistry::new();
+        assert!(!execution_renderable(&se, &empty));
+        assert!(deserialize_tool_execution(&se, &empty).is_err());
     }
 
     #[test]

--- a/crates/code_assistant_core/src/tools/mcp.rs
+++ b/crates/code_assistant_core/src/tools/mcp.rs
@@ -25,8 +25,9 @@ pub fn mcp_servers_config_path() -> PathBuf {
 }
 
 /// Load the MCP servers configuration, substituting `${ENV_VAR}` patterns in
-/// server environment values. A missing file yields the default (empty)
-/// configuration.
+/// server environment values. A server whose variables cannot be resolved is
+/// skipped with a log warning (it could not connect anyway); a missing file
+/// yields the default (empty) configuration.
 pub fn load_mcp_servers_config() -> Result<McpServersConfig> {
     load_mcp_servers_config_from(&mcp_servers_config_path())
 }
@@ -40,7 +41,12 @@ pub fn load_mcp_servers_config_from(path: &Path) -> Result<McpServersConfig> {
         .with_context(|| format!("Failed to read MCP config: {}", path.display()))?;
     let mut config: McpServersConfig = serde_json::from_str(&content)
         .with_context(|| format!("Failed to parse MCP config: {}", path.display()))?;
-    config.substitute_env_values(|name| std::env::var(name).ok())?;
+    for (name, error) in config.substitute_env_values(|name| std::env::var(name).ok()) {
+        tracing::warn!(
+            "Skipping MCP server '{name}' from {}: {error:#}",
+            path.display()
+        );
+    }
     Ok(config)
 }
 
@@ -100,7 +106,9 @@ pub fn deserialize_tool_execution(
 
 /// Load a project-local `.mcp.json` from `dir`, if present. Returns `None`
 /// when the file does not exist; logs a warning on parse errors rather than
-/// propagating them, so a malformed local file degrades gracefully.
+/// propagating them, so a malformed local file degrades gracefully. A server
+/// whose `${VAR}` references cannot be resolved is skipped with a log
+/// warning — the other servers still load.
 pub fn load_local_mcp_json(dir: &Path) -> Option<McpServersConfig> {
     let path = dir.join(".mcp.json");
     if !path.exists() {
@@ -115,9 +123,11 @@ pub fn load_local_mcp_json(dir: &Path) -> Option<McpServersConfig> {
     };
     match parse_local_mcp_json(&content) {
         Ok(mut config) => {
-            if let Err(e) = config.substitute_env_values(|name| std::env::var(name).ok()) {
-                tracing::warn!("Variable substitution failed in .mcp.json: {e:#}");
-                return None;
+            for (name, error) in config.substitute_env_values(|name| std::env::var(name).ok()) {
+                tracing::warn!(
+                    "Skipping MCP server '{name}' from {}: {error:#}",
+                    path.display()
+                );
             }
             Some(config)
         }
@@ -373,18 +383,29 @@ mod tests {
     }
 
     #[test]
-    fn unknown_env_var_is_an_error() {
+    fn unknown_env_var_drops_only_that_server() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("mcp-servers.json");
         std::fs::write(
             &path,
-            r#"{ "servers": { "jira": {
-                "command": "npx",
-                "env": { "API_TOKEN": "${MCP_TEST_SURELY_UNSET}" }
-            } } }"#,
+            r#"{ "servers": {
+                "jira": {
+                    "command": "npx",
+                    "env": { "API_TOKEN": "${MCP_TEST_SURELY_UNSET}" }
+                },
+                "docs": { "command": "npx" }
+            } }"#,
         )
         .unwrap();
-        assert!(load_mcp_servers_config_from(&path).is_err());
+        let config = load_mcp_servers_config_from(&path).unwrap();
+        assert!(
+            !config.servers.contains_key("jira"),
+            "server with unresolvable variable is dropped"
+        );
+        assert!(
+            config.servers.contains_key("docs"),
+            "the other server survives"
+        );
     }
 
     #[test]
@@ -453,6 +474,32 @@ mod tests {
             };
             assert_eq!(env["TOKEN"], "tok-xyz");
         });
+    }
+
+    #[test]
+    fn load_local_mcp_json_drops_only_the_failing_server() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(".mcp.json"),
+            r#"{ "mcpServers": {
+                "broken": {
+                    "type": "stdio",
+                    "command": "uv",
+                    "env": { "TOKEN": "${MCP_TEST_SURELY_UNSET}" }
+                },
+                "fine": { "type": "stdio", "command": "uv" }
+            } }"#,
+        )
+        .unwrap();
+        let config = load_local_mcp_json(dir.path()).unwrap();
+        assert!(
+            !config.servers.contains_key("broken"),
+            "server with unresolvable variable is dropped"
+        );
+        assert!(
+            config.servers.contains_key("fine"),
+            "the other server survives"
+        );
     }
 
     #[test]

--- a/crates/code_assistant_core/src/tools/mcp.rs
+++ b/crates/code_assistant_core/src/tools/mcp.rs
@@ -249,7 +249,7 @@ mod tests {
         let pool = crate::tools::ConfigToolRegistry::new();
         let registry = temp_env::async_with_vars(
             [("CODE_ASSISTANT_CONFIG_DIR", Some(dir.path()))],
-            crate::tools::default_registry_with_mcp(None, false, pool.as_ref()),
+            crate::tools::default_registry_with_mcp(None, pool.as_ref()),
         )
         .await;
 

--- a/crates/code_assistant_core/src/tools/mod.rs
+++ b/crates/code_assistant_core/src/tools/mod.rs
@@ -54,22 +54,20 @@ pub fn default_registry() -> Arc<ToolRegistry> {
 }
 
 /// [`default_registry`] plus the tools of the configured MCP servers: the
-/// global `mcp-servers.json` set, and — when `include_local_mcp` is set — the
-/// project-local `.mcp.json` in `project_dir`. Connections are drawn from
-/// `pool` so servers shared with a previous build stay connected rather than
+/// global `mcp-servers.json` set, and — when `local_mcp_dir` is set — the
+/// project-local `.mcp.json` in that directory. Connections are drawn from
+/// `pool` so servers shared with other registries stay connected rather than
 /// being relaunched. Connecting is asynchronous (child processes, initialize
 /// handshake), hence the async variant; wiring layers without a config or
 /// without enabled servers pay nothing.
 pub async fn default_registry_with_mcp(
-    project_dir: Option<&std::path::Path>,
-    include_local_mcp: bool,
+    local_mcp_dir: Option<&std::path::Path>,
     pool: &dyn mcp_client::ConnectionProvider,
 ) -> Arc<ToolRegistry> {
     let config = ToolsConfig::load().unwrap_or_default();
     let mut registry = ToolRegistry::new();
     register_default_tools(&mut registry, &config);
-    let local_dir = if include_local_mcp { project_dir } else { None };
-    mcp::register_configured_mcp_tools_in(&mut registry, local_dir, pool).await;
+    mcp::register_configured_mcp_tools_in(&mut registry, local_mcp_dir, pool).await;
     Arc::new(registry)
 }
 

--- a/crates/code_assistant_core/src/tools/registry_provider.rs
+++ b/crates/code_assistant_core/src/tools/registry_provider.rs
@@ -101,7 +101,8 @@ impl ConfigToolRegistry {
                 .map(|dir| dir.display().to_string())
                 .unwrap_or_else(|| "the global configuration".to_string())
         );
-        let registry = crate::tools::default_registry_with_mcp(local_mcp_dir.as_deref(), self).await;
+        let registry =
+            crate::tools::default_registry_with_mcp(local_mcp_dir.as_deref(), self).await;
         cached.insert(
             local_mcp_dir,
             Cached {
@@ -234,15 +235,32 @@ mod tests {
             [("CODE_ASSISTANT_CONFIG_DIR", Some(config.path()))],
             async {
                 let provider = ConfigToolRegistry::new();
-                let a = provider.current_for(project_request(project_a.path())).await;
-                let b = provider.current_for(project_request(project_b.path())).await;
-                assert!(!Arc::ptr_eq(&a, &b), "distinct projects, distinct registries");
+                let a = provider
+                    .current_for(project_request(project_a.path()))
+                    .await;
+                let b = provider
+                    .current_for(project_request(project_b.path()))
+                    .await;
+                assert!(
+                    !Arc::ptr_eq(&a, &b),
+                    "distinct projects, distinct registries"
+                );
 
                 // Alternating requests hit both caches — no thrash.
-                let a2 = provider.current_for(project_request(project_a.path())).await;
-                let b2 = provider.current_for(project_request(project_b.path())).await;
-                assert!(Arc::ptr_eq(&a, &a2), "project A stays cached across B's build");
-                assert!(Arc::ptr_eq(&b, &b2), "project B stays cached across A's build");
+                let a2 = provider
+                    .current_for(project_request(project_a.path()))
+                    .await;
+                let b2 = provider
+                    .current_for(project_request(project_b.path()))
+                    .await;
+                assert!(
+                    Arc::ptr_eq(&a, &a2),
+                    "project A stays cached across B's build"
+                );
+                assert!(
+                    Arc::ptr_eq(&b, &b2),
+                    "project B stays cached across A's build"
+                );
             },
         )
         .await;

--- a/crates/code_assistant_core/src/tools/registry_provider.rs
+++ b/crates/code_assistant_core/src/tools/registry_provider.rs
@@ -4,21 +4,26 @@
 //!
 //! The session manager consults this at the start of every agent run, so
 //! configuration edits — e.g. adding an MCP server via the settings page —
-//! take effect on the next run without restarting the process. A fingerprint
-//! cache keeps rebuilding off the common path where nothing changed: an
-//! unchanged request returns the same `Arc`.
+//! take effect on the next run without restarting the process. Registries are
+//! cached **per project** (keyed by the directory whose `.mcp.json` is
+//! included; `None` for the global-only registry), so sessions running in
+//! different projects at the same time each keep their own registry: starting
+//! a run in one project does not invalidate — or relaunch the servers of —
+//! another.
 //!
-//! MCP connections are pooled separately from the registry cache. The pool is
-//! keyed by server identity (name + transport), so rebuilding the registry for
-//! a different project reuses the still-open global servers instead of
-//! relaunching them — only that project's own `.mcp.json` servers connect anew.
-//! After each rebuild, pooled connections the new build no longer references
-//! (e.g. the previous project's local servers, or a server removed from the
-//! config) are evicted and their child processes shut down, so switching
-//! projects does not leak processes.
+//! Lifetimes are ownership-driven, not managed by explicit eviction. The
+//! cache holds only `Weak` references: a registry stays alive exactly as long
+//! as something uses it (a session instance between runs, an in-flight run),
+//! and each registry holds its MCP connections via `Arc` inside its tools.
+//! The connection pool is likewise `Weak`-keyed by server identity (name +
+//! transport), so servers shared between builds — typically the global set —
+//! are reused while any registry references them, and a server's child
+//! process terminates (connection drop) once the last registry using it is
+//! gone. No connection a live run holds is ever shut down under it.
 
-use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Weak};
 use tokio::sync::Mutex;
 
 use crate::session::manager::{RegistryRequest, ToolRegistryProvider};
@@ -28,33 +33,34 @@ use anyhow::Result;
 use async_trait::async_trait;
 use mcp_client::{ConnectionProvider, McpServerConfig, McpServerConnection};
 
+/// Cache key: the directory whose `.mcp.json` the registry includes, `None`
+/// for the global-only registry. Requests without (trusted) local MCP
+/// normalize to `None`, so all such sessions share one registry regardless of
+/// their project.
+type CacheKey = Option<PathBuf>;
+
 struct Cached {
     fingerprint: String,
-    registry: Arc<ToolRegistry>,
+    /// Weak: the cache never keeps a registry (or its MCP connections) alive
+    /// on its own — sessions and in-flight runs do, via their `Arc`s.
+    registry: Weak<ToolRegistry>,
 }
 
-/// Rebuilds the tool registry from disk on demand, caching by a fingerprint of
-/// the tool-relevant configuration files and the requested project, and
-/// pooling MCP connections across rebuilds.
+/// Rebuilds the tool registry from disk on demand, caching per project by a
+/// fingerprint of the tool-relevant configuration files, and pooling MCP
+/// connections across builds.
 pub struct ConfigToolRegistry {
-    cached: Mutex<Option<Cached>>,
+    cached: Mutex<HashMap<CacheKey, Cached>>,
     /// Live MCP connections keyed by [`connection_key`], reused across
-    /// rebuilds so shared servers are not relaunched on a project switch.
-    connections: Mutex<HashMap<String, Arc<McpServerConnection>>>,
-    /// Connection keys requested during the in-progress rebuild, used by
-    /// [`Self::evict_unreferenced`] to drop pooled connections the new build no
-    /// longer uses. Only meaningful while a rebuild holds the `cached` lock
-    /// (rebuilds are serialized by it, and `get_or_connect` runs only within
-    /// one), so it is cleared at the start of every rebuild.
-    building_keys: Mutex<HashSet<String>>,
+    /// builds so servers shared between registries are not relaunched.
+    connections: Mutex<HashMap<String, Weak<McpServerConnection>>>,
 }
 
 impl ConfigToolRegistry {
     pub fn new() -> Arc<Self> {
         Arc::new(Self {
-            cached: Mutex::new(None),
+            cached: Mutex::new(HashMap::new()),
             connections: Mutex::new(HashMap::new()),
-            building_keys: Mutex::new(HashSet::new()),
         })
     }
 
@@ -65,70 +71,45 @@ impl ConfigToolRegistry {
         self.current_for(RegistryRequest::default()).await
     }
 
-    /// The registry matching `req` — the cached one, or a freshly built one
-    /// when `tools.json`, `mcp-servers.json`, the project, or its `.mcp.json`
-    /// changed since the last call. Shared MCP servers are reused from the
-    /// connection pool.
+    /// The registry matching `req` — the cached one for its project, or a
+    /// freshly built one when `tools.json`, `mcp-servers.json`, or the
+    /// project's `.mcp.json` changed since that project's last build (or when
+    /// nothing holds the cached registry any more). Shared MCP servers are
+    /// reused from the connection pool.
     pub async fn current_for(&self, req: RegistryRequest) -> Arc<ToolRegistry> {
-        let fingerprint = self.fingerprint(&req);
-        // The lock is held across the (occasional) rebuild so concurrent
-        // callers never build twice; in practice agent runs are serialized by
-        // the session manager, so there is no contention on the common path.
-        let mut cached = self.cached.lock().await;
-        if let Some(entry) = cached.as_ref() {
-            if entry.fingerprint == fingerprint {
-                return entry.registry.clone();
-            }
-            tracing::info!("Tool configuration changed; rebuilding the tool registry");
-        }
-        // Record which connections this build touches so we can shut down the
-        // ones it no longer uses. Safe to reset here: the `cached` lock we hold
-        // serializes rebuilds, and `get_or_connect` only runs during one.
-        self.building_keys.lock().await.clear();
-        let registry = crate::tools::default_registry_with_mcp(
-            req.project_dir.as_deref(),
-            req.include_local_mcp,
-            self,
-        )
-        .await;
-        self.evict_unreferenced().await;
-        *cached = Some(Cached {
-            fingerprint,
-            registry: registry.clone(),
-        });
-        registry
-    }
-
-    /// Shut down and drop pooled connections that the just-finished rebuild did
-    /// not request (see [`Self::building_keys`]). A connection an in-flight run
-    /// still holds (its registry `Arc` outlives this rebuild) is only removed
-    /// from the pool here — its last owner terminates the child on drop — so we
-    /// never kill a server a running agent is using.
-    async fn evict_unreferenced(&self) {
-        let live = self.building_keys.lock().await.clone();
-        let stale: Vec<(String, Arc<McpServerConnection>)> = {
-            let mut connections = self.connections.lock().await;
-            let keys: Vec<String> = connections
-                .keys()
-                .filter(|key| !live.contains(*key))
-                .cloned()
-                .collect();
-            keys.into_iter()
-                .filter_map(|key| connections.remove(&key).map(|conn| (key, conn)))
-                .collect()
+        let local_mcp_dir: CacheKey = if req.include_local_mcp {
+            req.project_dir
+        } else {
+            None
         };
-        for (_key, conn) in stale {
-            // Sole owner: terminate the child process explicitly. If still
-            // referenced by a live registry, dropping our pool ref is enough —
-            // the last owner shuts it down when that run ends.
-            if let Ok(conn) = Arc::try_unwrap(conn) {
-                tokio::spawn(async move {
-                    if let Err(error) = conn.shutdown().await {
-                        tracing::warn!("Failed to shut down pooled MCP connection: {error:#}");
-                    }
-                });
-            }
+        let fingerprint = Self::fingerprint(local_mcp_dir.as_deref());
+        // The lock is held across the (occasional) rebuild so concurrent
+        // callers never build the same registry twice; in practice agent runs
+        // are serialized by the session manager, so there is no contention on
+        // the common path.
+        let mut cached = self.cached.lock().await;
+        if let Some(entry) = cached.get(&local_mcp_dir)
+            && entry.fingerprint == fingerprint
+            && let Some(registry) = entry.registry.upgrade()
+        {
+            return registry;
         }
+        tracing::info!(
+            "Building the tool registry for {}",
+            local_mcp_dir
+                .as_deref()
+                .map(|dir| dir.display().to_string())
+                .unwrap_or_else(|| "the global configuration".to_string())
+        );
+        let registry = crate::tools::default_registry_with_mcp(local_mcp_dir.as_deref(), self).await;
+        cached.insert(
+            local_mcp_dir,
+            Cached {
+                fingerprint,
+                registry: Arc::downgrade(&registry),
+            },
+        );
+        registry
     }
 
     /// The provider closure for
@@ -141,32 +122,19 @@ impl ConfigToolRegistry {
         })
     }
 
-    /// Fingerprint of the registry inputs for `req`: the tool-relevant config
-    /// files (read raw, so a changed *environment* alone does not trigger a
-    /// rebuild — matching process-startup semantics), the requested project,
-    /// and, when local MCP is included, the project's `.mcp.json` contents (so
-    /// editing it re-prompts and rebuilds).
-    fn fingerprint(&self, req: &RegistryRequest) -> String {
+    /// Fingerprint of the registry inputs: the tool-relevant config files
+    /// (read raw, so a changed *environment* alone does not trigger a rebuild
+    /// — matching process-startup semantics) and, when a local MCP dir is
+    /// included, that directory and its `.mcp.json` contents (so editing it
+    /// re-prompts and rebuilds).
+    fn fingerprint(local_mcp_dir: Option<&Path>) -> String {
         let read = |path: std::path::PathBuf| std::fs::read_to_string(path).unwrap_or_default();
         let tools = ToolsConfig::config_path().map(read).unwrap_or_default();
         let mcp = read(crate::tools::mcp::mcp_servers_config_path());
-        let project = req
-            .project_dir
-            .as_ref()
-            .map(|p| p.display().to_string())
+        let (dir, local) = local_mcp_dir
+            .map(|dir| (dir.display().to_string(), read(dir.join(".mcp.json"))))
             .unwrap_or_default();
-        let local = if req.include_local_mcp {
-            req.project_dir
-                .as_ref()
-                .map(|dir| read(dir.join(".mcp.json")))
-                .unwrap_or_default()
-        } else {
-            String::new()
-        };
-        format!(
-            "{tools}\u{0}{mcp}\u{0}{project}\u{0}{}\u{0}{local}",
-            req.include_local_mcp
-        )
+        format!("{tools}\u{0}{mcp}\u{0}{dir}\u{0}{local}")
     }
 }
 
@@ -186,24 +154,24 @@ impl ConnectionProvider for ConfigToolRegistry {
         config: &McpServerConfig,
     ) -> Result<Arc<McpServerConnection>> {
         let key = connection_key(name, config);
-        // Mark this server as referenced by the in-progress build so it is not
-        // evicted afterwards.
-        self.building_keys.lock().await.insert(key.clone());
-        if let Some(existing) = self.connections.lock().await.get(&key).cloned() {
-            return Ok(existing);
+        {
+            let mut connections = self.connections.lock().await;
+            // Prune entries whose connection has died with its last registry.
+            connections.retain(|_, weak| weak.strong_count() > 0);
+            if let Some(existing) = connections.get(&key).and_then(Weak::upgrade) {
+                return Ok(existing);
+            }
         }
         // Connect outside the lock (slow: process launch / HTTP handshake).
         let connection = Arc::new(McpServerConnection::connect(name, config).await?);
         // Re-check under the lock: if another caller connected the same server
         // meanwhile, keep theirs and drop ours (shut down on drop).
-        let stored = self
-            .connections
-            .lock()
-            .await
-            .entry(key)
-            .or_insert_with(|| connection.clone())
-            .clone();
-        Ok(stored)
+        let mut connections = self.connections.lock().await;
+        if let Some(existing) = connections.get(&key).and_then(Weak::upgrade) {
+            return Ok(existing);
+        }
+        connections.insert(key, Arc::downgrade(&connection));
+        Ok(connection)
     }
 }
 
@@ -242,5 +210,108 @@ mod tests {
             connection_key("other", &stdio),
             "the server name distinguishes connections"
         );
+    }
+
+    fn project_request(dir: &Path) -> RegistryRequest {
+        RegistryRequest {
+            project_dir: Some(dir.to_path_buf()),
+            include_local_mcp: true,
+        }
+    }
+
+    /// Two projects' registries are cached independently and stay valid at
+    /// the same time — a run in one project must not invalidate the other's
+    /// registry (the single-slot regression this module used to have).
+    #[tokio::test]
+    async fn distinct_projects_cache_independently() {
+        let config = tempfile::tempdir().unwrap();
+        let project_a = tempfile::tempdir().unwrap();
+        let project_b = tempfile::tempdir().unwrap();
+        std::fs::write(project_a.path().join(".mcp.json"), r#"{"mcpServers":{}}"#).unwrap();
+        std::fs::write(project_b.path().join(".mcp.json"), r#"{"mcpServers":{}}"#).unwrap();
+
+        temp_env::async_with_vars(
+            [("CODE_ASSISTANT_CONFIG_DIR", Some(config.path()))],
+            async {
+                let provider = ConfigToolRegistry::new();
+                let a = provider.current_for(project_request(project_a.path())).await;
+                let b = provider.current_for(project_request(project_b.path())).await;
+                assert!(!Arc::ptr_eq(&a, &b), "distinct projects, distinct registries");
+
+                // Alternating requests hit both caches — no thrash.
+                let a2 = provider.current_for(project_request(project_a.path())).await;
+                let b2 = provider.current_for(project_request(project_b.path())).await;
+                assert!(Arc::ptr_eq(&a, &a2), "project A stays cached across B's build");
+                assert!(Arc::ptr_eq(&b, &b2), "project B stays cached across A's build");
+            },
+        )
+        .await;
+    }
+
+    /// A request without (trusted) local MCP shares the global-only registry,
+    /// whatever its project directory is.
+    #[tokio::test]
+    async fn without_local_mcp_all_projects_share_the_global_registry() {
+        let config = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        temp_env::async_with_vars(
+            [("CODE_ASSISTANT_CONFIG_DIR", Some(config.path()))],
+            async {
+                let provider = ConfigToolRegistry::new();
+                let global = provider.current().await;
+                let projected = provider
+                    .current_for(RegistryRequest {
+                        project_dir: Some(project.path().to_path_buf()),
+                        include_local_mcp: false,
+                    })
+                    .await;
+                assert!(Arc::ptr_eq(&global, &projected));
+            },
+        )
+        .await;
+    }
+
+    /// Editing a project's `.mcp.json` rebuilds that project's registry.
+    #[tokio::test]
+    async fn local_mcp_json_edit_rebuilds() {
+        let config = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        std::fs::write(project.path().join(".mcp.json"), r#"{"mcpServers":{}}"#).unwrap();
+        temp_env::async_with_vars(
+            [("CODE_ASSISTANT_CONFIG_DIR", Some(config.path()))],
+            async {
+                let provider = ConfigToolRegistry::new();
+                let before = provider.current_for(project_request(project.path())).await;
+                std::fs::write(project.path().join(".mcp.json"), r#"{ "mcpServers": {} }"#)
+                    .unwrap();
+                let after = provider.current_for(project_request(project.path())).await;
+                assert!(!Arc::ptr_eq(&before, &after), "changed .mcp.json rebuilds");
+            },
+        )
+        .await;
+    }
+
+    /// The cache holds only weak references: once nothing uses a registry any
+    /// more, it is gone (with its MCP connections) and a later request builds
+    /// afresh instead of resurrecting stale state.
+    #[tokio::test]
+    async fn cache_does_not_keep_registries_alive() {
+        let config = tempfile::tempdir().unwrap();
+        temp_env::async_with_vars(
+            [("CODE_ASSISTANT_CONFIG_DIR", Some(config.path()))],
+            async {
+                let provider = ConfigToolRegistry::new();
+                let registry = provider.current().await;
+                let weak = Arc::downgrade(&registry);
+                drop(registry);
+                assert!(
+                    weak.upgrade().is_none(),
+                    "the cache must not hold a strong reference"
+                );
+                // A later request simply rebuilds.
+                let _rebuilt = provider.current().await;
+            },
+        )
+        .await;
     }
 }

--- a/crates/mcp_client/src/config.rs
+++ b/crates/mcp_client/src/config.rs
@@ -24,26 +24,49 @@ impl McpServersConfig {
         self.servers.iter().filter(|(_, server)| server.enabled)
     }
 
-    /// Substitute `${VAR}` patterns in every server's secret-carrying values,
-    /// so config files can reference secrets instead of baking them in. That
-    /// means stdio env values and HTTP header values. `lookup` resolves a
-    /// variable name (typically `|name| std::env::var(name).ok()`); an
-    /// unresolvable variable or an unclosed `${` is an error naming the
-    /// offending server.
-    pub fn substitute_env_values(&mut self, lookup: impl Fn(&str) -> Option<String>) -> Result<()> {
-        for (name, server) in self.servers.iter_mut() {
-            match &mut server.transport {
-                McpTransport::Stdio { env, .. } => {
-                    for value in env.values_mut() {
-                        *value = substitute_variables(value, &lookup)
-                            .with_context(|| format!("in env of MCP server '{name}'"))?;
-                    }
+    /// Substitute `${VAR}` patterns in every server's secret-carrying values
+    /// — stdio env values and HTTP header values — so config files can
+    /// reference secrets instead of baking them in. `lookup` resolves a
+    /// variable name (typically `|name| std::env::var(name).ok()`). A server
+    /// with an unresolvable variable (or an unclosed `${`) is **dropped**
+    /// rather than failing the whole configuration: missing its secret it
+    /// could not connect anyway, but it must not take the other servers down
+    /// with it. The dropped servers are returned as `(name, error)` for the
+    /// caller to log.
+    pub fn substitute_env_values(
+        &mut self,
+        lookup: impl Fn(&str) -> Option<String>,
+    ) -> Vec<(String, anyhow::Error)> {
+        let mut dropped = Vec::new();
+        self.servers
+            .retain(|name, server| match server.substitute_env_values(&lookup) {
+                Ok(()) => true,
+                Err(error) => {
+                    dropped.push((name.clone(), error));
+                    false
                 }
-                McpTransport::Http { headers, .. } => {
-                    for value in headers.values_mut() {
-                        *value = substitute_variables(value, &lookup)
-                            .with_context(|| format!("in headers of MCP server '{name}'"))?;
-                    }
+            });
+        dropped
+    }
+}
+
+impl McpServerConfig {
+    /// Substitute `${VAR}` in this server's stdio `env` / HTTP `headers`
+    /// values (both carry secrets), erroring on the first unresolvable
+    /// variable.
+    pub fn substitute_env_values(
+        &mut self,
+        lookup: &impl Fn(&str) -> Option<String>,
+    ) -> Result<()> {
+        match &mut self.transport {
+            McpTransport::Stdio { env, .. } => {
+                for value in env.values_mut() {
+                    *value = substitute_variables(value, lookup).context("in env")?;
+                }
+            }
+            McpTransport::Http { headers, .. } => {
+                for value in headers.values_mut() {
+                    *value = substitute_variables(value, lookup).context("in headers")?;
                 }
             }
         }
@@ -328,9 +351,9 @@ mod tests {
             } } }"#,
         )
         .unwrap();
-        config
-            .substitute_env_values(|name| (name == "JIRA_TOKEN").then(|| "s3cret".to_string()))
-            .unwrap();
+        let dropped = config
+            .substitute_env_values(|name| (name == "JIRA_TOKEN").then(|| "s3cret".to_string()));
+        assert!(dropped.is_empty());
         let McpTransport::Stdio { env, .. } = &config.servers["jira"].transport else {
             panic!("expected stdio transport");
         };
@@ -347,9 +370,9 @@ mod tests {
             } } }"#,
         )
         .unwrap();
-        config
-            .substitute_env_values(|name| (name == "API_TOKEN").then(|| "s3cret".to_string()))
-            .unwrap();
+        let dropped = config
+            .substitute_env_values(|name| (name == "API_TOKEN").then(|| "s3cret".to_string()));
+        assert!(dropped.is_empty());
         let McpTransport::Http { url, headers } = &config.servers["remote"].transport else {
             panic!("expected http transport");
         };
@@ -380,27 +403,41 @@ mod tests {
     }
 
     #[test]
-    fn unresolvable_variable_errors_with_server_name() {
+    fn unresolvable_variable_drops_only_that_server() {
+        // A server missing its secret cannot connect anyway; it must not
+        // take the other servers down with it.
         let mut config: McpServersConfig = serde_json::from_str(
-            r#"{ "servers": { "jira": { "command": "npx", "env": { "T": "${MISSING}" } } } }"#,
+            r#"{ "servers": {
+                "jira": { "command": "npx", "env": { "T": "${MISSING}" } },
+                "docs": { "command": "npx", "env": { "T": "${SET}" } }
+            } }"#,
         )
         .unwrap();
-        let error = format!("{:#}", config.substitute_env_values(|_| None).unwrap_err());
+        let dropped =
+            config.substitute_env_values(|name| (name == "SET").then(|| "ok".to_string()));
+
+        assert_eq!(dropped.len(), 1);
+        let (name, error) = &dropped[0];
+        assert_eq!(name, "jira");
+        let error = format!("{error:#}");
         assert!(error.contains("MISSING"), "names the variable: {error}");
-        assert!(error.contains("jira"), "names the server: {error}");
+
+        assert!(!config.servers.contains_key("jira"), "failing server gone");
+        let McpTransport::Stdio { env, .. } = &config.servers["docs"].transport else {
+            panic!("expected stdio transport");
+        };
+        assert_eq!(env["T"], "ok", "the other server is kept and substituted");
     }
 
     #[test]
-    fn unclosed_substitution_errors() {
+    fn unclosed_substitution_drops_the_server() {
         let mut config: McpServersConfig = serde_json::from_str(
             r#"{ "servers": { "jira": { "command": "npx", "env": { "T": "${OOPS" } } } }"#,
         )
         .unwrap();
-        assert!(
-            config
-                .substitute_env_values(|_| Some("x".to_string()))
-                .is_err()
-        );
+        let dropped = config.substitute_env_values(|_| Some("x".to_string()));
+        assert_eq!(dropped.len(), 1);
+        assert!(config.servers.is_empty());
     }
 
     #[test]
@@ -412,7 +449,7 @@ mod tests {
             r#"{ "servers": { "jira": { "command": "${CMD}", "args": ["${ARG}"] } } }"#,
         )
         .unwrap();
-        config.substitute_env_values(|_| None).unwrap();
+        assert!(config.substitute_env_values(|_| None).is_empty());
         assert_eq!(
             config.servers["jira"].transport,
             McpTransport::Stdio {

--- a/crates/mcp_client/src/lib.rs
+++ b/crates/mcp_client/src/lib.rs
@@ -20,6 +20,8 @@ pub use client::McpServerConnection;
 pub use config::{
     McpServerConfig, McpServersConfig, McpTransport, parse_local_mcp_json, substitute_variables,
 };
+pub use naming::is_mcp_tool_name;
+pub use output::deserialize_mcp_output;
 pub use registry::{
     ConnectionProvider, DiscoveredTool, MCP_CAPABILITY, McpServerStatus, discover_tools,
     register_connection_tools, register_mcp_tools, register_mcp_tools_pooled,

--- a/crates/mcp_client/src/naming.rs
+++ b/crates/mcp_client/src/naming.rs
@@ -12,6 +12,13 @@ pub const MAX_TOOL_NAME_LENGTH: usize = 64;
 /// Prefix marking registry tools that proxy an MCP server tool.
 pub const MCP_TOOL_PREFIX: &str = "mcp__";
 
+/// Whether `name` was minted by [`registry_tool_name`] — i.e. it records the
+/// execution of an MCP server tool. The prefix is reserved: no native tool
+/// may claim it.
+pub fn is_mcp_tool_name(name: &str) -> bool {
+    name.starts_with(MCP_TOOL_PREFIX)
+}
+
 /// The registry name for a tool offered by a server.
 pub fn registry_tool_name(server: &str, tool: &str) -> String {
     let name = format!("{MCP_TOOL_PREFIX}{}__{}", sanitize(server), sanitize(tool));
@@ -77,6 +84,13 @@ mod tests {
         assert_eq!(name_b.len(), MAX_TOOL_NAME_LENGTH);
         assert_ne!(name_a, name_b, "truncated names must stay distinct");
         assert!(name_a.starts_with("mcp__server__"));
+    }
+
+    #[test]
+    fn mcp_tool_names_are_recognized() {
+        assert!(is_mcp_tool_name(&registry_tool_name("jira", "search")));
+        assert!(!is_mcp_tool_name("execute_command"));
+        assert!(!is_mcp_tool_name("parse_error"));
     }
 
     #[test]

--- a/crates/mcp_client/src/output.rs
+++ b/crates/mcp_client/src/output.rs
@@ -69,6 +69,22 @@ impl McpToolOutput {
     }
 }
 
+/// Deserialize a persisted MCP tool output without a live server or registry
+/// entry. `McpToolOutput` is self-describing, so a recorded MCP execution
+/// renders identically in any instance — including one that never connected
+/// (or never trusted) the server that produced it.
+/// [`McpTool::deserialize_output`] delegates here so there is one code path.
+///
+/// [`McpTool::deserialize_output`]: crate::tool::McpTool
+pub fn deserialize_mcp_output(
+    json: serde_json::Value,
+) -> anyhow::Result<Box<dyn tools_core::dyn_tool::AnyOutput>> {
+    let mut output: McpToolOutput = serde_json::from_value(json)?;
+    // Re-check dimensions on load for sessions persisted before capping.
+    output.cap_images(tools_core::MAX_IMAGE_EDGE);
+    Ok(Box::new(output))
+}
+
 impl ToolResult for McpToolOutput {
     fn is_success(&self) -> bool {
         !self.is_error
@@ -119,5 +135,26 @@ impl Render for McpToolOutput {
                 image.base64_data = base64_data;
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_mcp_output_needs_no_live_tool() {
+        let json = serde_json::json!({ "text": "42 issues found", "is_error": false });
+        let output = deserialize_mcp_output(json).unwrap();
+        assert!(output.is_success());
+        assert_eq!(output.as_render().status(), "42 issues found");
+    }
+
+    #[test]
+    fn deserialize_mcp_output_preserves_error_flag() {
+        let json = serde_json::json!({ "text": "boom", "is_error": true });
+        let output = deserialize_mcp_output(json).unwrap();
+        assert!(!output.is_success());
+        assert_eq!(output.as_render().status(), "Failed: boom");
     }
 }

--- a/crates/mcp_client/src/tool.rs
+++ b/crates/mcp_client/src/tool.rs
@@ -101,9 +101,6 @@ impl DynTool for McpTool {
     }
 
     fn deserialize_output(&self, json: Value) -> Result<Box<dyn AnyOutput>> {
-        let mut output: McpToolOutput = serde_json::from_value(json)?;
-        // Re-check dimensions on load for sessions persisted before capping.
-        tools_core::render::Render::cap_images(&mut output, tools_core::MAX_IMAGE_EDGE);
-        Ok(Box::new(output))
+        crate::output::deserialize_mcp_output(json)
     }
 }

--- a/docs/mcp-client-mode.md
+++ b/docs/mcp-client-mode.md
@@ -152,10 +152,12 @@ shows and preserves.
   `<config_dir>/mcp-servers.json` with `${ENV_VAR}` substitution in `env`
   values; `tools::default_registry_with_mcp()` builds the registry. The
   wiring layers install `tools::ConfigToolRegistry` as the session
-  manager's `ToolRegistryProvider`, which rebuilds the registry (behind a
-  fingerprint cache) at the start of every agent run — so config changes
-  apply on the next run, not only on restart. A running agent keeps the
-  registry it started with.
+  manager's `ToolRegistryProvider`, which rebuilds registries (cached per
+  project behind a fingerprint) at the start of every agent run — so config
+  changes apply on the next run, not only on restart. A running agent keeps
+  the registry it started with. Projects can additionally ship servers in a
+  `.mcp.json` at the project root, gated by a trust prompt — see
+  [project-scoped-mcp-servers.md](project-scoped-mcp-servers.md).
 - **gpui settings page** ("MCP Servers"): expandable card per server with
   enable switch, add/edit/delete (including a transport selector for
   stdio command/args/env vs HTTP url/headers), live tool discovery and

--- a/docs/project-scoped-mcp-servers.md
+++ b/docs/project-scoped-mcp-servers.md
@@ -33,9 +33,12 @@ committed file serves both tools.
   implies HTTP and a `command` implies stdio. An explicit `"type": "stdio"`
   with a stray `url` is an error (missing `command`), not silently HTTP.
 - `${VAR}` references in `env` and `headers` values are substituted from the
-  environment at load time, so the committed file never carries secrets.
-  Note: substitution is currently all-or-nothing — one unresolvable variable
-  drops the whole file (with a log warning), not just the affected server.
+  environment at load time, so the committed file never carries secrets. A
+  server whose variables cannot be resolved is skipped with a log warning
+  (it could not connect anyway); the other servers still load. Note that
+  config fingerprints read the files raw, so exporting a previously missing
+  variable takes effect on the next rebuild (a config edit or restart), not
+  by itself.
 - Project entries carry no `enabled`/`enabled_tools`/`disabled_tools`
   metadata; every listed server is on (per-session toggles below).
 
@@ -117,9 +120,6 @@ native tools still require a registry entry to render.
 ## Known limitations
 
 - No UI to revoke a persisted trust (edit `mcp-trust.json` by hand).
-- `${VAR}` substitution failure drops the whole `.mcp.json`, not just the
-  affected server; the per-session toggle menu (which reads the file raw)
-  still lists the servers.
 - Per-session deactivation hides a server's tools but does not prevent its
   process from launching.
 - The settings page edits the global config only; project files are edited

--- a/docs/project-scoped-mcp-servers.md
+++ b/docs/project-scoped-mcp-servers.md
@@ -1,0 +1,126 @@
+# Project-scoped MCP servers
+
+In addition to the globally configured MCP servers
+(`<config_dir>/mcp-servers.json`, see [mcp-client-mode.md](mcp-client-mode.md)),
+a project can ship its own servers in a **`.mcp.json` at the project root**.
+The file format follows the convention Claude Code established, so one
+committed file serves both tools.
+
+## The `.mcp.json` format
+
+```jsonc
+{
+  "mcpServers": {
+    "filesystem": {                         // stdio: "type" may be omitted
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "."],
+      "env": { "NODE_ENV": "production" }
+    },
+    "internal-api": {
+      "type": "http",                       // "sse" / "streamable-http" alias http
+      "url": "https://api.example.com/mcp",
+      "headers": { "Authorization": "Bearer ${API_TOKEN}" }
+    }
+  }
+}
+```
+
+- Top-level key is **`mcpServers`** (Claude Code's key; the global
+  `mcp-servers.json` keeps its own `servers` key — the two formats are parsed
+  by separate code, `mcp_client::parse_local_mcp_json` for this one).
+- Transport is chosen by the explicit `type` field; without one, a `url`
+  implies HTTP and a `command` implies stdio. An explicit `"type": "stdio"`
+  with a stray `url` is an error (missing `command`), not silently HTTP.
+- `${VAR}` references in `env` and `headers` values are substituted from the
+  environment at load time, so the committed file never carries secrets.
+  Note: substitution is currently all-or-nothing — one unresolvable variable
+  drops the whole file (with a log warning), not just the affected server.
+- Project entries carry no `enabled`/`enabled_tools`/`disabled_tools`
+  metadata; every listed server is on (per-session toggles below).
+
+## Merge semantics
+
+The effective server set for a session is the global config overlaid by the
+project's `.mcp.json`, **merged at the server level by name — project wins**.
+A colliding name takes the project file's entire server definition; the
+global definition of that name contributes nothing, so there is never a
+tool-level collision (tool names `mcp__<server>__<tool>` derive from the
+surviving server only).
+
+## Trust
+
+A `.mcp.json` arrives with a cloned repository, and loading it launches the
+processes it names — so an untrusted project file is never loaded silently.
+At the first agent run in a project with an untrusted (or edited)
+`.mcp.json`, the user is prompted with the server names and three choices:
+
+- **Load once** — this run only; ask again next time.
+- **Always (this project)** — persists in `<config_dir>/mcp-trust.json`,
+  keyed by canonicalized project path to an md5 fingerprint of the file's
+  contents. Any later edit to the file changes the fingerprint and
+  re-prompts.
+- **Deny** — the run proceeds with global servers only.
+
+The prompt travels the normal permission-mediator path, so it works in the
+GPUI, terminal, and ACP frontends alike (the option list is defined once, in
+`session::permissions::permission_options_for`). A frontend that cannot ask
+skips the project's servers with a log warning. Revoking a persisted trust
+currently means editing `mcp-trust.json` by hand — an untrust UI is an open
+follow-up.
+
+## Per-session server toggles
+
+Each session can deactivate individual servers (global or project-local) via
+the MCP selector in the input bar; the set persists in the session config
+(`disabled_mcp_servers`). Deactivation filters the **tool set** offered to
+and callable by that session's agent (via the per-server
+`scope:mcp-<server>` capability tag) — it does not prevent the server
+process from starting, since registries and their connections are shared
+across sessions.
+
+## Registries and connection lifecycle
+
+Because a project file makes the tool registry project-dependent, registries
+are built **per project** and cached by `tools::ConfigToolRegistry`:
+
+- The cache is keyed by the directory whose `.mcp.json` is included (`None`
+  for the global-only registry; sessions without a trusted project file all
+  share that one). Sessions running in different projects at the same time
+  each keep their own registry — starting a run in one project does not
+  invalidate, or relaunch the servers of, another.
+- A cache entry is validated by a fingerprint of `tools.json`,
+  `mcp-servers.json`, and the project's `.mcp.json` (all read raw, so a
+  changed environment alone does not rebuild). The provider is consulted at
+  the start of every agent run; an unchanged configuration returns the same
+  `Arc`. A running agent keeps the registry it started with.
+- **Lifetimes are ownership-driven.** The cache and the MCP connection pool
+  hold only `Weak` references. A registry stays alive as long as a session
+  instance or in-flight run holds it; each registry holds its connections
+  via `Arc` inside its tools. Connections are pooled by server identity
+  (name + transport config), so servers shared between registries —
+  typically the global set — run once, and a server's child process
+  terminates when the last registry using it is dropped. In practice: a
+  project's servers run while a session that uses them is open, and nothing
+  is ever shut down under a live run.
+
+## Rendering is registry-independent
+
+Recorded MCP tool executions (`mcp__…` names) deserialize from their
+self-describing persisted JSON (`mcp_client::deserialize_mcp_output`), never
+through a registry lookup (`tools::mcp::deserialize_tool_execution`). A
+session therefore renders identically wherever it is viewed — under another
+project's registry, or in a second code-assistant instance that never
+launched (or never trusted) the servers that produced the output. Only
+native tools still require a registry entry to render.
+
+## Known limitations
+
+- No UI to revoke a persisted trust (edit `mcp-trust.json` by hand).
+- `${VAR}` substitution failure drops the whole `.mcp.json`, not just the
+  affected server; the per-session toggle menu (which reads the file raw)
+  still lists the servers.
+- Per-session deactivation hides a server's tools but does not prevent its
+  process from launching.
+- The settings page edits the global config only; project files are edited
+  in the repository.


### PR DESCRIPTION
Follow-up to #189. With sessions running in parallel across projects, the single-slot registry cache and the registry broadcast caused real misbehavior; this PR makes registries per-project and makes session rendering independent of connection state.

## Problems

1. **Rendering depended on random connection state.** Recorded MCP tool executions were resolved through whichever registry an instance happened to hold. Starting a run in project A rewired *every* session's rendering to A's registry (broadcast in `refresh_tool_registry`), so a session viewed while another project's agent was running silently dropped its MCP tool calls. The same failure hit a session viewed in a second code-assistant instance that never launched (or never trusted) the producing servers.
2. **Single cache slot thrashed across projects.** Every run start in a different project rebuilt the registry and the eviction pass killed the other project's local MCP servers — with two agents active in two projects, local servers bounced on every alternation.
3. **`${VAR}` substitution was all-or-nothing.** One unset variable failed the whole `mcp-servers.json` (nothing registered) or dropped the whole `.mcp.json`.

## Changes

- **Registry-independent MCP rendering.** `McpToolOutput` is self-describing; recorded `mcp__*` executions now always deserialize via `mcp_client::deserialize_mcp_output` (`tools::mcp::deserialize_tool_execution`), never through a registry lookup. A session renders identically wherever it is viewed. Only native tools still require a registry entry.
- **Per-project registry cache, lifetimes via ownership.** `ConfigToolRegistry` keys registries by the included local-MCP directory (`None` = global-only). Cache and connection pool hold `Weak` references: a registry lives while a session instance or in-flight run holds it; connections live while some registry references them (dropping the last `Arc` terminates the server child). This removes the `building_keys`/`evict_unreferenced` machinery and answers the eviction question deterministically: a project's servers run while a session that uses them is open. Parallel sessions in different projects no longer invalidate each other or relaunch each other's servers.
- **No more broadcast.** `refresh_tool_registry` assigns the fresh registry to the requesting session's instance only (and catches an instance up when the provider returns an already-cached `Arc` for a second session in the same project).
- **Per-server `${VAR}` degradation.** `McpServersConfig::substitute_env_values` drops only the servers whose variables cannot be resolved and returns them for the loaders to log; the other servers keep working. Applies to both `mcp-servers.json` and `.mcp.json`.
- **Docs.** `docs/project-scoped-mcp-servers.md` reworked from a design note into feature documentation (format, merge, trust, toggles, lifecycle, rendering guarantee, known limitations); cross-referenced from `mcp-client-mode.md` and `AGENTS.md`.

## Notes

- Frontends and `SessionService` needed no changes — provider signature and `RegistryRequest` are unchanged.
- A viewed-only session keeps the default registry; the project registry is resolved at its first agent run (viewing must not launch servers or prompt for trust). Rendering no longer depends on it.
- Known follow-ups (documented): no UI to revoke persisted trust; per-session server toggles hide tools but don't prevent the server process from launching.
- `session_mode_returns_session_id_while_running` (PTY execute_command) is flaky under full-suite load on `main` as well — unrelated to this branch.