### PR TITLE
fix(llm): keep model output out of parse-failure logs and errors

### DIFF
--- a/crates/llm/src/anthropic.rs
+++ b/crates/llm/src/anthropic.rs
@@ -1163,7 +1163,16 @@ impl AnthropicClient {
                         _ => {}
                     }
                 } else {
-                    return Err(anyhow::anyhow!("Failed to parse stream event:\n{line}"));
+                    // The raw line is model output; the error message travels
+                    // into user-facing toasts and logs, so keep it out.
+                    let error = serde_json::from_str::<StreamEvent>(data)
+                        .err()
+                        .map(|e| e.to_string())
+                        .unwrap_or_default();
+                    return Err(anyhow::anyhow!(
+                        "Failed to parse stream event ({} bytes): {error}",
+                        data.len()
+                    ));
                 }
             }
             Ok(())

--- a/crates/llm/src/ollama.rs
+++ b/crates/llm/src/ollama.rs
@@ -204,7 +204,10 @@ impl OllamaClient {
                     // Ignore redacted thinking blocks
                 }
                 _ => {
-                    warn!("Unexpected content block type in user message: {:?}", block);
+                    warn!(
+                        "Unexpected content block type in user message: {}",
+                        block.kind()
+                    );
                 }
             }
         }

--- a/crates/llm/src/openai.rs
+++ b/crates/llm/src/openai.rs
@@ -500,8 +500,8 @@ impl OpenAIClient {
                 }
                 _ => {
                     warn!(
-                        "Unexpected content block type in assistant message: {:?}",
-                        block
+                        "Unexpected content block type in assistant message: {}",
+                        block.kind()
                     );
                 }
             }
@@ -590,7 +590,10 @@ impl OpenAIClient {
                     // Ignore redacted thinking blocks
                 }
                 _ => {
-                    warn!("Unexpected content block type in user message: {:?}", block);
+                    warn!(
+                        "Unexpected content block type in user message: {}",
+                        block.kind()
+                    );
                 }
             }
         }
@@ -1095,7 +1098,16 @@ impl OpenAIClient {
                         *usage = Some(chunk_usage);
                     }
                 } else {
-                    warn!("Failed to parse stream event: '{}'", data);
+                    // The payload is model output — log the failure, not the data.
+                    let error = serde_json::from_str::<OpenAIStreamResponse>(data)
+                        .err()
+                        .map(|e| e.to_string())
+                        .unwrap_or_default();
+                    warn!(
+                        "Failed to parse stream event ({} bytes): {}",
+                        data.len(),
+                        error
+                    );
                 }
             }
             Ok(())

--- a/crates/llm/src/openai_responses.rs
+++ b/crates/llm/src/openai_responses.rs
@@ -1281,9 +1281,11 @@ impl<'a> StreamProcessor<'a> {
                 return Ok(());
             }
 
+            // The raw event is model output; it must not end up in logs or in
+            // the error message (which reaches user-facing toasts and logs).
             let event: StreamEvent = serde_json::from_str(data).map_err(|e| {
-                warn!("Failed to parse SSE event (raw data: {data:?}): {e}");
-                anyhow::anyhow!("Failed to parse SSE event: {e} (raw data: {data:?})")
+                warn!("Failed to parse SSE event ({} bytes): {e}", data.len());
+                anyhow::anyhow!("Failed to parse SSE event ({} bytes): {e}", data.len())
             })?;
 
             match event.event_type.as_str() {

--- a/crates/llm/src/types.rs
+++ b/crates/llm/src/types.rs
@@ -570,6 +570,19 @@ impl Message {
 }
 
 impl ContentBlock {
+    /// Variant name only — for log lines that must not carry the block's
+    /// content (message text, images, tool arguments).
+    pub fn kind(&self) -> &'static str {
+        match self {
+            ContentBlock::Thinking { .. } => "thinking",
+            ContentBlock::RedactedThinking { .. } => "redacted_thinking",
+            ContentBlock::Text { .. } => "text",
+            ContentBlock::Image { .. } => "image",
+            ContentBlock::ToolUse { .. } => "tool_use",
+            ContentBlock::ToolResult { .. } => "tool_result",
+        }
+    }
+
     /// Create a thinking content block from a String
     pub fn new_thinking(text: impl Into<String>, signature: impl Into<String>) -> Self {
         ContentBlock::Thinking {

--- a/crates/llm/src/vertex.rs
+++ b/crates/llm/src/vertex.rs
@@ -1278,10 +1278,22 @@ impl VertexClient {
                         }
                     }
                 } else {
-                    warn!("Failed to parse Vertex response from data: {}", data);
+                    // The payload is model output — log the failure, not the data.
+                    let error = serde_json::from_str::<VertexResponse>(data)
+                        .err()
+                        .map(|e| e.to_string())
+                        .unwrap_or_default();
+                    warn!(
+                        "Failed to parse Vertex response ({} bytes): {}",
+                        data.len(),
+                        error
+                    );
                 }
             } else if line.len() > 1 {
-                warn!("Received line without 'data' prefix: {}", line);
+                warn!(
+                    "Received SSE line without 'data' prefix ({} bytes)",
+                    line.len()
+                );
             }
             Ok(())
         };


### PR DESCRIPTION
## Summary
Streaming parse failures logged the raw payload — which is model output, and in a downstream app like Onoki potentially a child's conversation:
- `vertex.rs`: `Failed to parse Vertex response from data: {data}` and the non-`data` line
- `openai.rs`: `Failed to parse stream event: '{data}'`, plus `{:?}` of whole content blocks (assistant and user messages); same block dump in `ollama.rs`
- `openai_responses.rs`: `raw data: {data:?}` in **both** the warning and the returned `anyhow` error
- `anthropic.rs`: the raw line in the returned error

Error messages travel further than logs (toasts, frontend error logs), so both paths now carry only the payload length and the serde error. Content blocks log their variant name via a new `ContentBlock::kind()`.

`cargo check -p llm`, `cargo fmt --check`, `cargo test -p llm` pass.